### PR TITLE
Pushing docker images to gcr.io

### DIFF
--- a/resources/release-docker
+++ b/resources/release-docker
@@ -2,7 +2,7 @@
 
 # Example usage:
 #
-# docker/release-docker -h docker.io/istio,gcr.io/istio-testing \
+# docker/release-docker -h docker.io/istio \
 #  -c release \
 #  -t $(git rev-parse --short HEAD),$(date +%Y%m%d%H%M%S),latest" \
 #  -i "init,init_debug,app,app_debug,runtime,runtime_debug"
@@ -10,7 +10,7 @@
 function usage() {
   echo "$0 \
     -c <bazel config to use> \
-    -h <comma separated list of docker image repository> \
+    -h <docker image repository> \
     -t <comma separated list of docker image tags> \
     -i <comma separated list of docker images>"
   exit 1
@@ -20,32 +20,29 @@ function usage() {
 while getopts :c:h:i:t:: arg; do
   case ${arg} in
     c) BAZEL_ARGS="--config=${OPTARG}";;
-    h) HUBS="${OPTARG}";;
+    h) HUB="${OPTARG}";;
     i) IMAGES="${OPTARG}";;
     t) TAGS="${OPTARG}";;
   esac
 done
 
-[[ -z "${HUBS}" ]] && usage
+[[ -z "${HUB}" ]] && usage
 [[ -z "${TAGS}" ]] && usage
 [[ -z "${IMAGES}" ]] && usage
+
+IFS=',' read -ra TAGS <<< "${TAGS}"
+IFS=',' read -ra IMAGES <<< "${IMAGES}"
 
 if [[ "${HUB}" =~ ^gcr\.io ]]; then
   gcloud docker --authorize-only
 fi
-
-IFS=',' read -ra TAGS <<< "${TAGS}"
-IFS=',' read -ra IMAGES <<< "${IMAGES}"
-IFS=',' read -ra HUBS <<< "${IMAGES}"
 
 set -ex
 
 for IMAGE in "${IMAGES[@]}"; do
   bazel ${BAZEL_STARTUP_ARGS} run ${BAZEL_ARGS} "//docker:${IMAGE}" istio/docker:"${IMAGE}"
   for TAG in "${TAGS[@]}"; do
-    for HUB in "${HUBS[@]}"; do
-      docker tag istio/docker:"${IMAGE}" "${HUB}/${IMAGE}:${TAG}"
-      docker push "${HUB}/${IMAGE}:${TAG}"
-    done
+    docker tag istio/docker:"${IMAGE}" "${HUB}/${IMAGE}:${TAG}"
+    docker push "${HUB}/${IMAGE}:${TAG}"
   done
 done

--- a/src/org/istio/testutils/Utilities.groovy
+++ b/src/org/istio/testutils/Utilities.groovy
@@ -112,16 +112,21 @@ def sendNotification(notify_list) {
 }
 
 // Push images to hub
-def publishDockerImages(images, tags, config = '', hub = 'docker.io/istio') {
+def publishDockerImages(images, tags, config = '') {
+  def dockerRegistry = 'docker.io/istio'
+  def googleRegistry = 'gcr.io/istio-testing'
   def res = libraryResource('release-docker')
   def releaseDocker = '/tmp/release-docker'
   def credentialId = env.ISTIO_TESTING_DOCKERHUB
   writeFile(file: releaseDocker, text: res)
   sh("chmod +x ${releaseDocker}")
   withDockerRegistry([credentialsId: credentialId]) {
-    sh("${releaseDocker} -h ${hub} -t ${tags} -i ${images} " +
+    sh("${releaseDocker} -h ${dockerRegistry} -t ${tags} -i ${images} " +
         "${config == '' ? '' : "-c ${config}"}")
   }
+  sh("${releaseDocker} -h ${googleRegistry} -t ${tags} -i ${images} " +
+      "${config == '' ? '' : "-c ${config}"}")
+
 }
 
 // Publish Code Coverage


### PR DESCRIPTION
the withDockerRegistry pipeline step does prevent docker push to gcr.io. I tried to find the source code to understand why, but I could not find it. This is the reason we need to run the command twice. 