### PR TITLE
Update-submodules fail when no file have changed.

### DIFF
--- a/resources/update-submodules
+++ b/resources/update-submodules
@@ -62,14 +62,14 @@ function commit_file() {
       && git commit -m "Updates ${key} in ${file}" \
       || error_exit "Could not create commit for ${key} update in ${file}."
   else
-    echo 'Nothing to commit.'
+    error_exit 'Nothing to commit. Something should have changed'
   fi
 }
 
 while getopts :s: arg; do
   case ${arg} in
     s) SUBMODULES="${OPTARG}";;
-    *) echo "Invalid option: -${OPTARG}";;
+    *) error_exit "Invalid option: -${OPTARG}";;
   esac
 done
 


### PR DESCRIPTION
Because the file to be changed for submodules updates is set in Jenkins there is currently no way to figure that a file has been changed or remove. By adding this check,we'll know and we ll be able to update jenkins job configuration.