### PR TITLE
Use gcsweb for artifacts link

### DIFF
--- a/src/org/istio/testutils/GitUtilities.groovy
+++ b/src/org/istio/testutils/GitUtilities.groovy
@@ -151,7 +151,7 @@ def fastUnstash(name) {
 // Sets an artifacts links to the Build.
 def setArtifactsLink() {
   def ref = getRef()
-  def url = "https://console.cloud.google.com/storage/browser/${env.BUCKET}/${ref}"
+  def url = "http://gcsweb.istio.io/gcs/${env.BUCKET}/${ref}"
   def html = """
 <!DOCTYPE HTML>
 Find <a href='${url}'>artifacts</a> here


### PR DESCRIPTION
This enable users that do not use GCP to access the link