### PR TITLE
enable prow reporting on test-infra

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -65,7 +65,6 @@ presubmits:
 
   istio/test-infra:
   - name: test-infra-presubmit
-    skip_report: true
     context: prow/test-infra-presubmit.sh
     always_run: true
     rerun_command: "@istio-testing bazel test this"


### PR DESCRIPTION
Now that the `prow/test-infra-presubmit.sh` file is in master, it makes sense to turn on reporting.