### PR TITLE
update README with triggers/ block and execution bit gotchas

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -27,10 +27,15 @@ Both of these types of jobs can be configured using the config configmap [here](
 
 ```yaml
 # in config.yaml
+triggers:
+- repos:
+  - istio/istio
+  - istio/test-infra
+  - istio/<my-repo> # ADD THIS LINE
+# ...
 presubmits:
   # ...
-
-  istio/<my-repo>:
+  istio/<my-repo>: # ADD THIS BLOCK
   - name: my-repo-presubmit
     context: prow/my-repo-presubmit.sh
     always_run: true
@@ -44,7 +49,7 @@ presubmits:
     # ...
 
 # in plugins.yaml
-my-repo:
+my-repo: # ADD THIS BLOCK
 - trigger
 ```
 
@@ -67,6 +72,11 @@ $ tree
 │   └── my-job.sh
 ├── LICENSE
 └── README.md
+```
+
+Remember that when you add a job file, you need to set the execution bit!
+```bash
+$ chmod +x prow/my-repo-presubmit.sh
 ```
 
 ### Test-Infra Prow Jobs

--- a/prow/README.md
+++ b/prow/README.md
@@ -76,7 +76,7 @@ $ tree
 
 Remember that when you add a job file, you need to set the execution bit!
 ```bash
-$ chmod +x prow/my-repo-presubmit.sh
+$ chmod +x prow/my-presubmit.sh
 ```
 
 ### Test-Infra Prow Jobs


### PR DESCRIPTION
Add two gotchas to the README. 

1. The first is that in order for triggers to work, you must also add them to the config block at the top of `config.yaml`.

2. Second, in order for the prowbazel image to execute the job script, the execution bit must be set. Otherwise you will recieve a Permission error, as [here](https://k8s-gubernator.appspot.com/build/istio-prow/pull/istio_istio/464/istio-presubmit/1/). This is a bit of a gotcha, so we call it out in the README.