### PR TITLE
Skip broken builds

### DIFF
--- a/toolbox/metrics/generate.sh
+++ b/toolbox/metrics/generate.sh
@@ -13,3 +13,5 @@ gcloud docker -- push gcr.io/istio-testing/metrics_fetcher:${GIT_HEAD}
 sed 's/image: gcr.io\/istio-testing\/metrics_fetcher:.*/image: gcr.io\/istio-testing\/metrics_fetcher:'"$GIT_HEAD"'/g' toolbox/metrics/metrics_fetcher.yaml > toolbox/metrics/local.metrics_fetcher.yaml
 
 cat toolbox/metrics/local.metrics_fetcher.yaml
+
+echo "To replace: kubectl replace -f toolbox/metrics/local.metrics_fetcher.yaml"

--- a/toolbox/metrics/main.go
+++ b/toolbox/metrics/main.go
@@ -48,7 +48,6 @@ var (
 	gcsBucket       = flag.String("bucket", "istio-code-coverage", "GCS bucket name.")
 	codeCovTrackJob = flag.String("coverage_job", "fast-forward", "In which job we are tracking code coverage.")
 
-
 	metricsSuite *p8sMetricsSuite
 
 	gcsClient  *storage.Client


### PR DESCRIPTION
When hit a build whose message is broken for some reasons, skip it and move on. This happens when we manually delete a build at Jenkins UI.