### PR TITLE
allow /test all for triggering jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -30,7 +30,7 @@ presubmits:
     context: prow/istio-presubmit.sh
     always_run: true
     rerun_command: "@istio-testing bazel test this"
-    trigger: "@istio-testing (bazel )?test this"
+    trigger: "((?m)^@istio-testing (bazel )?test this,?(\\s+|$)|(?m)^/test( all| bazel),?(\\s+|$))"
     branches:
     - master
     spec:
@@ -73,7 +73,7 @@ presubmits:
     context: prow/pilot-presubmit.sh
     always_run: true
     rerun_command: "@istio-testing bazel test this"
-    trigger: "@istio-testing (bazel )?test this"
+    trigger: "((?m)^@istio-testing (bazel )?test this,?(\\s+|$)|(?m)^/test( all| bazel),?(\\s+|$))"
     branches:
     - master
     spec:
@@ -122,7 +122,7 @@ presubmits:
     context: prow/test-infra-presubmit.sh
     always_run: true
     rerun_command: "@istio-testing bazel test this"
-    trigger: "@istio-testing (bazel )?test this"
+    trigger: "((?m)^@istio-testing (bazel )?test this,?(\\s+|$)|(?m)^/test( all| bazel),?(\\s+|$))"
     branches:
     - master
     spec:


### PR DESCRIPTION
This specifically targets the functionality of submit queue, whereby it comments `/test all` to re-run all tests.

This change makes our re-run commands match those in k8s/test-infra.

@chxchx I'm adding you as reviewer so that you can start to familiarize with Prow config changes !

**Release note**:
```release-note
NONE
```