### PR TITLE
prow: add pilot postsubmit to configuration.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -164,8 +164,6 @@ postsubmits:
       - image: gcr.io/istio-testing/prowbazel:0.1.5
         args:
         - "--branch=$(PULL_REFS)"
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -153,3 +153,52 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+
+postsubmits:
+  istio/pilot:
+  - name: pilot-postsubmit
+    max_concurrency: 1
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.1.5
+        args:
+        - "--branch=$(PULL_REFS)"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--git-cache=/root/.cache/git"
+        - "--clean"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: e2e-testing-kubeconfig
+          mountPath: /etc/e2e-testing-kubeconfig
+          readOnly: true
+        - name: pilot-codecov-token
+          mountPath: /etc/codecov
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /home/bootstrap/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9998
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: e2e-testing-kubeconfig
+        secret:
+          secretName: e2e-testing-kubeconfig
+      - name: pilot-codecov-token
+        secret:
+          secretName: pilot-codecov-token
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -157,7 +157,6 @@ presubmits:
 postsubmits:
   istio/pilot:
   - name: pilot-postsubmit
-    max_concurrency: 1
     branches:
     - master
     spec:


### PR DESCRIPTION
This introduces a `pilot-postsubmit` job.

**Release note**:
```release-note
NONE
```