### PR TITLE
add privileged mode for bazel

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -184,6 +184,9 @@ presubmits:
           args:
           - "--pull=$(PULL_REFS)"
           - "--clean"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/service-account/service-account.json


### PR DESCRIPTION
We need privileged mode for bazel to sandbox builds in the e2e smoke test.