### PR TITLE
Document pr self-approve

### DIFF
--- a/mungegithub/deployment/README.md
+++ b/mungegithub/deployment/README.md
@@ -26,7 +26,7 @@ Mungegithub waits for 4 labels:
 
   >  Note: Do not comment "/approve" or add "approved" label unless you are 100% sure you want this change, because after you say that, the pr will be merge any minutes.
   
-  >  Note: The PR will be self-approved if the PR creator is in OWNERS file and this PR is associated with at lease one issue.
+  >  Note: The PR will be self-approved if the PR creator is in OWNERS file and this PR is associated with at least one issue.
   
 * **Release-note** Release note enforcement is another feather we are seeking from Mungegithub. With template, when prs are create, people should add release note (can be "None") in the pr description. Depended on the release message left, Mungegithub will add "release-note", "release-note-none". If you leave it empty, "release-note-needed" will be added and is going to block merging.
 

--- a/mungegithub/deployment/README.md
+++ b/mungegithub/deployment/README.md
@@ -26,6 +26,8 @@ Mungegithub waits for 4 labels:
 
   >  Note: Do not comment "/approve" or add "approved" label unless you are 100% sure you want this change, because after you say that, the pr will be merge any minutes.
   
+  >  Note: The PR will be self-approved if the PR creator is in OWNERS file and this PR is associated with at lease one issue.
+  
 * **Release-note** Release note enforcement is another feather we are seeking from Mungegithub. With template, when prs are create, people should add release note (can be "None") in the pr description. Depended on the release message left, Mungegithub will add "release-note", "release-note-none". If you leave it empty, "release-note-needed" will be added and is going to block merging.
 
 * **do-not-merge** Even with all required parts, you can always have more time by add "do-not-merge" label. 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
