### PR TITLE
Binary to fast forward stable branch

### DIFF
--- a/toolbox/githubctl/BUILD
+++ b/toolbox/githubctl/BUILD
@@ -4,15 +4,13 @@ go_library(
     name = "go_default_library",
     srcs = [
     	"main.go",
-    	"dependency.go",
     ],
     deps = [
         "//toolbox/util:go_default_library",
-        "@com_github_google_go_github//github:go_default_library",
     ],
 )
 
 go_binary(
-    name = "update_deps",
+    name = "githubctl",
     library = ":go_default_library",
 )

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	"istio.io/test-infra/toolbox/util"
+)
+
+var (
+	owner      = flag.String("owner", "istio", "Github owner or org")
+	tokenFile  = flag.String("token_file", "", "File containing Github API Access Token")
+	op         = flag.String("op", "", "Operation to be performed")
+	repo       = flag.String("repo", "", "Repository to which op is applied")
+	baseBranch = flag.String("base_branch", "", "Branch to which op is applied")
+	refBranch  = flag.String("ref_branch", "", "Reference Branch used to update base branch")
+	githubClnt *util.GithubClient
+)
+
+// Panic if value not specified
+func assertNotEmpty(name string, value *string) {
+	if value == nil || *value == "" {
+		log.Panicf("%s must be specified\n", name)
+	}
+}
+
+func fastForward(repo, baseBranch, refBranch *string) error {
+	assertNotEmpty("repo", repo)
+	assertNotEmpty("baseBranch", baseBranch)
+	assertNotEmpty("refBranch", refBranch)
+	sha, err := githubClnt.GetHeadCommitSHA(*repo, *refBranch)
+	if err != nil {
+		return err
+	}
+	return githubClnt.FastForward(*repo, *baseBranch, sha)
+}
+
+func initialize() {
+	flag.Parse()
+	assertNotEmpty("token_file", tokenFile)
+	token, err := util.GetAPITokenFromFile(*tokenFile)
+	if err != nil {
+		log.Panicf("Error accessing user supplied token_file: %v\n", err)
+	}
+	githubClnt, err = util.NewGithubClient(*owner, token)
+	if err != nil {
+		log.Panicf("Error when initializing github client: %v\n", err)
+	}
+}
+
+func main() {
+	initialize()
+	switch *op {
+	case "fastForward":
+		if err := fastForward(repo, baseBranch, refBranch); err != nil {
+			log.Printf("Error during fastForward: %v\n", err)
+		}
+	default:
+		log.Printf("Unsupported operation: %s\n", *op)
+	}
+}

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -27,7 +27,7 @@ var (
 	op         = flag.String("op", "", "Operation to be performed")
 	repo       = flag.String("repo", "", "Repository to which op is applied")
 	baseBranch = flag.String("base_branch", "", "Branch to which op is applied")
-	refBranch  = flag.String("ref_branch", "", "Reference Branch used to update base branch")
+	refSHA     = flag.String("ref_sha", "", "Reference commit SHA used to update base branch")
 	githubClnt *util.GithubClient
 )
 
@@ -38,18 +38,14 @@ func assertNotEmpty(name string, value *string) {
 	}
 }
 
-func fastForward(repo, baseBranch, refBranch *string) error {
+func fastForward(repo, baseBranch, refSHA *string) error {
 	assertNotEmpty("repo", repo)
-	assertNotEmpty("baseBranch", baseBranch)
-	assertNotEmpty("refBranch", refBranch)
-	sha, err := githubClnt.GetHeadCommitSHA(*repo, *refBranch)
-	if err != nil {
-		return err
-	}
-	return githubClnt.FastForward(*repo, *baseBranch, sha)
+	assertNotEmpty("base_branch", baseBranch)
+	assertNotEmpty("ref_sha", refSHA)
+	return githubClnt.FastForward(*repo, *baseBranch, *refSHA)
 }
 
-func initialize() {
+func init() {
 	flag.Parse()
 	assertNotEmpty("token_file", tokenFile)
 	token, err := util.GetAPITokenFromFile(*tokenFile)
@@ -63,10 +59,9 @@ func initialize() {
 }
 
 func main() {
-	initialize()
 	switch *op {
 	case "fastForward":
-		if err := fastForward(repo, baseBranch, refBranch); err != nil {
+		if err := fastForward(repo, baseBranch, refSHA); err != nil {
 			log.Printf("Error during fastForward: %v\n", err)
 		}
 	default:

--- a/toolbox/util/BUILD
+++ b/toolbox/util/BUILD
@@ -5,9 +5,12 @@ go_library(
     srcs = [
         "commonUtils.go",
         "githubUtils.go",
+        "githubClient.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_google_go_github//github:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
     ],
 )


### PR DESCRIPTION
Given that there is no longer any PR from master to stable, this binary is required to fast forward stable branch. It is structured in a flexible way that is extensible for additional features in the near future.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
