### PR TITLE
url points to deck, then gubernator

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,6 +1,6 @@
 ---
 plank:
-  job_url_template: 'https://k8s-gubernator.appspot.com/build/istio-prow/{{if eq .Spec.Type "presubmit"}}pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else}}.{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  job_url_template: '{{if eq .Status.State "pending"}}https://prow.istio.io/?repo={{.Spec.Refs.Repo | urlquery}}&pull={{(index .Spec.Refs.Pulls 0).Number | urlquery}}{{else}}https://k8s-gubernator.appspot.com/build/istio-prow/{{if eq .Spec.Type "presubmit"}}pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}.{{end}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/{{end}}'
 
 sinker:
   resync_period: 1h


### PR DESCRIPTION
This obviously won't get in before I leave, but once kubernetes merges the PR that re-executes the URL template when the ProwJob's status changes, we can deploy this I believe to have it first point to deck and then to gubernator.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
