### PR TITLE
prow: new trigger commands for test-infra

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -303,8 +303,8 @@ presubmits:
     agent: kubernetes
     context: prow/test-infra-presubmit.sh
     always_run: true
-    rerun_command: "@istio-testing bazel test this"
-    trigger: "((?m)^@istio-testing (bazel )?test this,?(\\s+|$)|(?m)^/test( all| bazel),?(\\s+|$))"
+    rerun_command: "/test test-infra-presubmit"
+    trigger: "(?m)^/(retest|test all)?,?(\\s+|$)"
     branches:
     - master
     spec:


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
