### PR TITLE
prow: enable /test test-infra-presubmit

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -304,7 +304,7 @@ presubmits:
     context: prow/test-infra-presubmit.sh
     always_run: true
     rerun_command: "/test test-infra-presubmit"
-    trigger: "(?m)^/(retest|test all)?,?(\\s+|$)"
+    trigger: "(?m)^/(retest|test (all|test-infra-presubmit))?,?(\\s+|$)"
     branches:
     - master
     spec:


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
