### PR TITLE
Dependency freshness metrics from a stable build

### DIFF
--- a/toolbox/deps_update/BUILD
+++ b/toolbox/deps_update/BUILD
@@ -4,11 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
     	"main.go",
-    	"dependency.go",
     ],
     deps = [
         "//toolbox/util:go_default_library",
-        "@com_github_google_go_github//github:go_default_library",
     ],
 )
 

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -52,10 +52,7 @@ func init() {
 	if err != nil {
 		log.Panicf("Error accessing user supplied token_file: %v\n", err)
 	}
-	githubClnt, err = util.NewGithubClient(*owner, token)
-	if err != nil {
-		log.Panicf("Error when initializing github client: %v\n", err)
-	}
+	githubClnt = util.NewGithubClient(*owner, token)
 }
 
 func main() {

--- a/toolbox/metrics/BUILD
+++ b/toolbox/metrics/BUILD
@@ -3,9 +3,15 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "buildFreshness.go",
+    ],
     visibility = ["//visibility:private"],
     deps = [
+        "//toolbox/util:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",

--- a/toolbox/metrics/buildFreshness.go
+++ b/toolbox/metrics/buildFreshness.go
@@ -1,0 +1,96 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+	u "istio.io/test-infra/toolbox/util"
+)
+
+const (
+	istioDepsFile = "istio.deps"
+)
+
+// DepFreshness stores how many days behind the dependency SHA used by the last
+// stable build is compared to the HEAD of the production branch of that dependency
+type DepFreshness struct {
+	Dep       u.Dependency
+	Freshness time.Duration
+}
+
+func getBranchHeadTime(gclient *u.GithubClient, repo, branch string) (*time.Time, error) {
+	sha, err := gclient.GetHeadCommitSHA(repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	t, err := gclient.GetSHATime(repo, sha)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func getStableBuildFreshness(owner, repo, branch string) ([]DepFreshness, error) {
+	githubClnt := u.NewGithubClientNoAuth(owner)
+	var stats []DepFreshness
+	pickledDeps, err := githubClnt.GetFileContent(repo, branch, istioDepsFile)
+	if err != nil {
+		return stats, err
+	}
+	deps, err := u.DeserializeDepsFromString(pickledDeps)
+	if err != nil {
+		return stats, err
+	}
+	var wg sync.WaitGroup
+	var mutex = &sync.Mutex{} // used to synchronize access to stats and multiErr
+	var multiErr error
+	for _, dep := range deps {
+		wg.Add(1)
+		go func(dep u.Dependency) {
+			latestTime, err := getBranchHeadTime(githubClnt, dep.RepoName, dep.ProdBranch)
+			if err != nil {
+				// multierror not thread safe
+				mutex.Lock()
+				multiErr = multierror.Append(multiErr, err)
+				mutex.Unlock()
+				return
+			}
+			var stableTime *time.Time
+			if strings.Contains(dep.LastStableSHA, "-") || strings.Contains(dep.LastStableSHA, ".") {
+				// the reference is a tag
+				stableTime, err = githubClnt.GetTagPublishTime(dep.RepoName, dep.LastStableSHA)
+			} else {
+				stableTime, err = githubClnt.GetSHATime(dep.RepoName, dep.LastStableSHA)
+			}
+			if err != nil {
+				mutex.Lock()
+				multiErr = multierror.Append(multiErr, err)
+				mutex.Unlock()
+				return
+			}
+			lag := latestTime.Sub(*stableTime)
+			mutex.Lock()
+			stats = append(stats, DepFreshness{dep, lag})
+			mutex.Unlock()
+			wg.Done()
+		}(dep)
+	}
+	wg.Wait()
+	return stats, multiErr
+}

--- a/toolbox/util/BUILD
+++ b/toolbox/util/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "commonUtils.go",
+        "dependency.go",
         "githubUtils.go",
         "githubClient.go",
     ],

--- a/toolbox/util/dependency.go
+++ b/toolbox/util/dependency.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package util
 
 import (
 	"encoding/json"
@@ -38,7 +38,8 @@ import (
 		)
 */
 
-type dependency struct {
+// Dependency records meta data
+type Dependency struct {
 	Name          string `json:"name"`
 	RepoName      string `json:"repoName"`
 	ProdBranch    string `json:"prodBranch"`    // either master or stable
@@ -46,9 +47,10 @@ type dependency struct {
 	LastStableSHA string `json:"lastStableSHA"` // sha used in the latest stable build of parent
 }
 
-// Get the list of dependencies of a repo by deserializing the file on depsFilePath
-func deserializeDeps(depsFilePath string) ([]dependency, error) {
-	var deps []dependency
+// DeserializeDeps get the list of dependencies of a repo by
+// deserializing the file on depsFilePath
+func DeserializeDeps(depsFilePath string) ([]Dependency, error) {
+	var deps []Dependency
 	raw, err := ioutil.ReadFile(depsFilePath)
 	if err != nil {
 		return deps, err
@@ -57,8 +59,15 @@ func deserializeDeps(depsFilePath string) ([]dependency, error) {
 	return deps, err
 }
 
-// Writes in-memory dependencies to file
-func serializeDeps(depsFilePath string, deps *[]dependency) error {
+// DeserializeDepsFromString inflates the list of dependencies from a string
+func DeserializeDepsFromString(pickled string) ([]Dependency, error) {
+	var deps []Dependency
+	err := json.Unmarshal([]byte(pickled), &deps)
+	return deps, err
+}
+
+// SerializeDeps writes in-memory dependencies to file
+func SerializeDeps(depsFilePath string, deps *[]Dependency) error {
 	pickled, err := json.MarshalIndent(*deps, "", "\t")
 	if err != nil {
 		return err

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -175,8 +175,8 @@ func (g GithubClient) GetHeadCommitSHA(repo, branch string) (string, error) {
 	return g.getReferenceSHA(repo, "refs/heads/"+branch)
 }
 
-// GetSHATime gets the time when sha is made
-func (g GithubClient) GetSHATime(repo, sha string) (*time.Time, error) {
+// GetCommitCreationTime gets the time when the commit identified by sha is created
+func (g GithubClient) GetCommitCreationTime(repo, sha string) (*time.Time, error) {
 	commit, _, err := g.client.Git.GetCommit(
 		context.Background(), g.owner, repo, sha)
 	if err != nil {
@@ -185,8 +185,9 @@ func (g GithubClient) GetSHATime(repo, sha string) (*time.Time, error) {
 	return (*(*commit).Author).Date, nil
 }
 
-// GetTagPublishTime finds the time a tag is published
-func (g GithubClient) GetTagPublishTime(repo, tag string) (*time.Time, error) {
+// GetCommitCreationTimeByTag finds the time when the commit pointed by a tag is created
+// Note that SHA of the tag is different from the commit SHA
+func (g GithubClient) GetCommitCreationTimeByTag(repo, tag string) (*time.Time, error) {
 	sha, err := g.getReferenceSHA(repo, "refs/tags/"+tag)
 	if err != nil {
 		return nil, err
@@ -196,7 +197,8 @@ func (g GithubClient) GetTagPublishTime(repo, tag string) (*time.Time, error) {
 	if err != nil {
 		return nil, err
 	}
-	return (*(*tagObj).Tagger).Date, nil
+	commitSHA := *tagObj.Object.SHA
+	return g.GetCommitCreationTime(repo, commitSHA)
 }
 
 // GetFileContent retrieves the file content from the hosted repo

--- a/toolbox/util/githubUtils.go
+++ b/toolbox/util/githubUtils.go
@@ -28,7 +28,7 @@ var (
 	// SHARegex matches commit SHA's
 	SHARegex = regexp.MustCompile("^[a-z0-9]{40}$")
 	// ReleaseTagRegex matches release tags
-	ReleaseTagRegex = regexp.MustCompile("^[0-9]*.[0-9]*.[0-9]*$")
+	ReleaseTagRegex = regexp.MustCompile("^[0-9]+.[0-9]+.[0-9]+$")
 )
 
 // CIState defines constants representing possible states of

--- a/toolbox/util/githubUtils.go
+++ b/toolbox/util/githubUtils.go
@@ -17,6 +17,7 @@ package util
 import (
 	"io/ioutil"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -24,6 +25,10 @@ import (
 
 var (
 	ci = NewCIState()
+	// SHARegex matches commit SHA's
+	SHARegex = regexp.MustCompile("^[a-z0-9]{40}$")
+	// ReleaseTagRegex matches release tags
+	ReleaseTagRegex = regexp.MustCompile("^[0-9]*.[0-9]*.[0-9]*$")
 )
 
 // CIState defines constants representing possible states of


### PR DESCRIPTION
Generates statistics about how stale the dependency SHAs are compared to their respective latest stable versions.
Also refactored utilities to be more universal applicable.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
