### PR TITLE
Add plugin for pilot

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -25,6 +25,10 @@ istio/mixer:
 
 istio/pilot:
 - trigger
+- release-note
+- close
+- reopen
+- lgtm
 
 istio/test-infra:
 - trigger


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
