### PR TITLE
Fix the missing piece on binary name update

### DIFF
--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -27,7 +27,7 @@ set -u
 set -x
 
 echo "=== Building Binary that Updates Istio Dependency ==="
-bazel build //toolbox/deps_update:update_deps
+bazel build //toolbox/deps_update:deps_update
 
 git config --global user.email "istio.testing@gmail.com"
 git config --global user.name "istio-bot"


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
