### PR TITLE
Fix failing prow jobs by mounting service acct secret

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -685,7 +685,7 @@ periodics:
       secret:
         secretName: e2e-testing-kubeconfig
 
-- interval: 10m
+- interval: 12h
   agent: kubernetes
   name: test-infra-update-deps
   spec:
@@ -702,6 +702,9 @@ periodics:
         mountPath: /etc/github
         readOnly: true
     volumes:
+    - name: service
+      secret:
+        secretName: service-account
     - name: oauth
       secret:
         secretName: oauth-token


### PR DESCRIPTION
Also have the dependency update job to run every 12 hours
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
