### PR TITLE
Add assign plugin for test-infra

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -31,6 +31,7 @@ istio/pilot:
 - lgtm
 
 istio/test-infra:
+- assign
 - trigger
 - config-updater
 - release-note


### PR DESCRIPTION
We never enable "assign" plugin, so "/assign @somebody" is not working, let's try this on test-infra first and then push to others.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
