### PR TITLE
Add assign plugin to all repos

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -3,6 +3,7 @@
 # Values: List of plugins to run against the repo.
 ---
 istio/auth:
+- assign
 - trigger
 - close
 - release-note
@@ -10,6 +11,7 @@ istio/auth:
 - lgtm
 
 istio/istio:
+- assign
 - trigger
 - release-note
 - close
@@ -17,6 +19,7 @@ istio/istio:
 - lgtm
 
 istio/mixer:
+- assign
 - trigger
 - release-note
 - close
@@ -24,6 +27,7 @@ istio/mixer:
 - lgtm
 
 istio/pilot:
+- assign
 - trigger
 - release-note
 - close


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
