### PR TITLE
Separate code coverage from presubmit for pilot

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -553,9 +553,9 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-    - name: pilot-package-coverage
+    - name: pilot-coverage
       agent: kubernetes
-      context: prow/pilot-package-coverage.sh
+      context: prow/pilot-coverage.sh
       always_run: true
      spec:
         containers:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -480,9 +480,6 @@ presubmits:
           readOnly: true
         - name: e2e-testing-kubeconfig
           mountPath: /home/bootstrap/.kube
-        - name: pilot-codecov-token
-          mountPath: /etc/codecov
-          readOnly: true
         - name: cache-ssd
           mountPath: /home/bootstrap/.cache
         ports:
@@ -504,9 +501,6 @@ presubmits:
       - name: e2e-testing-kubeconfig
         secret:
           secretName: e2e-testing-kubeconfig
-      - name: pilot-codecov-token
-        secret:
-          secretName: pilot-codecov-token
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -579,7 +573,10 @@ presubmits:
           - name: service
             mountPath: /etc/service-account
             readOnly: true
-         - name: cache-ssd
+          - name: pilot-codecov-token
+            mountPath: /etc/codecov
+            readOnly: true
+          - name: cache-ssd
             mountPath: /home/bootstrap/.cache
           ports:
           - containerPort: 9999
@@ -597,7 +594,10 @@ presubmits:
         - name: service
           secret:
             secretName: service-account
-       - name: cache-ssd
+        - name: pilot-codecov-token
+          secret:
+            secretName: pilot-codecov-token
+        - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -557,7 +557,8 @@ presubmits:
       agent: kubernetes
       context: prow/pilot-coverage.sh
       always_run: true
-     spec:
+      skip_report: true
+      spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.2.1
           args:
@@ -600,7 +601,6 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-
 
   istio/test-infra:
   - name: test-infra-presubmit

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -559,6 +559,48 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+    - name: pilot-package-coverage
+      agent: kubernetes
+      context: prow/pilot-package-coverage.sh
+      always_run: true
+     spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+         - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+       - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+
 
   istio/test-infra:
   - name: test-infra-presubmit


### PR DESCRIPTION
Separate coverage processes (codecov.io, package check) with presubmit:
    1) Speed up presubmit
    2) Coverage will not block presubmit, we can easily make it required or not.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
Connect to https://github.com/istio/pilot/pull/1110