### PR TITLE
Enable broker in prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13,6 +13,7 @@ pod_namespace: test-pods
 triggers:
 - repos:
   - istio/auth
+  - istio/broker
   - istio/istio
   - istio/mixer
   - istio/pilot

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -10,6 +10,11 @@ istio/auth:
 - reopen
 - lgtm
 
+istio/broker:
+- assign
+- trigger
+- close
+
 istio/istio:
 - assign
 - trigger


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
issue istio/broker#17