### PR TITLE
Approve open PRs with review-not-required label

### DIFF
--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -30,7 +30,7 @@ var (
 	hub        = flag.String("hub", "", "Where the testing images are hosted")
 	githubClnt *u.GithubClient
 	//Repos require review for admin (robots)
-	adminReviewRequired = map[string]bool {
+	adminReviewRequired = map[string]bool{
 		"istio": true,
 	}
 )

--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -29,10 +29,6 @@ var (
 	baseBranch = flag.String("base_branch", "master", "Branch from which the deps update commit is based")
 	hub        = flag.String("hub", "", "Where the testing images are hosted")
 	githubClnt *u.GithubClient
-	//Repos require review for admin (robots)
-	adminReviewRequired = map[string]bool{
-		"istio": true,
-	}
 )
 
 const (
@@ -133,8 +129,7 @@ func updateDependenciesOf(repo string) error {
 		log.Printf("Branch already exists")
 	}
 	// if branch exists, stop here and do not create another PR of identical delta
-	if err = githubClnt.CloseIdlePullRequests(
-		prTitlePrefix, repo, *baseBranch); exists || err != nil {
+	if err = githubClnt.CloseIdlePullRequests(prTitlePrefix, repo); exists || err != nil {
 		return err
 	}
 	if _, err = u.Shell("git checkout -b " + branch); err != nil {
@@ -156,12 +151,6 @@ func updateDependenciesOf(repo string) error {
 	}
 	if err := githubClnt.AddAutoMergeLabelsToPR(repo, pr); err != nil {
 		log.Printf("Failed to add auto-merge labels for pr %s %d", repo, pr.GetNumber())
-	}
-
-	if adminReviewRequired[repo] {
-		if err := githubClnt.ApproveAutoPR(repo, pr); err != nil {
-			log.Printf("Failed to github approve pr %s #%d", repo, pr.GetNumber())
-		}
 	}
 	return nil
 }

--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -29,6 +29,10 @@ var (
 	baseBranch = flag.String("base_branch", "master", "Branch from which the deps update commit is based")
 	hub        = flag.String("hub", "", "Where the testing images are hosted")
 	githubClnt *u.GithubClient
+	//Repos require review for admin (robots)
+	adminReviewRequired = map[string]bool {
+		"istio": true,
+	}
 )
 
 const (
@@ -150,7 +154,16 @@ func updateDependenciesOf(repo string) error {
 	if err != nil {
 		return err
 	}
-	return githubClnt.AddAutoMergeLabelsToPR(repo, pr)
+	if err := githubClnt.AddAutoMergeLabelsToPR(repo, pr); err != nil {
+		log.Printf("Failed to add auto-merge labels for pr %s %d", repo, pr.GetNumber())
+	}
+
+	if adminReviewRequired[repo] {
+		if err := githubClnt.ApproveAutoPR(repo, pr); err != nil {
+			log.Printf("Failed to github approve pr %s #%d", repo, pr.GetNumber())
+		}
+	}
+	return nil
 }
 
 func init() {

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -56,6 +56,11 @@ func assertNotEmpty(name string, value *string) {
 	}
 }
 
+func approvePRsRequiringNoReview() error {
+	assertNotEmpty("repo", repo)
+	return githubClnt.ApprovePRsRequiringNoReview(*repo)
+}
+
 func fastForward(repo, baseBranch, refSHA *string) error {
 	assertNotEmpty("repo", repo)
 	assertNotEmpty("base_branch", baseBranch)
@@ -215,23 +220,27 @@ func init() {
 
 func main() {
 	switch *op {
+	case "approvePRs":
+		if err := approvePRsRequiringNoReview(); err != nil {
+			log.Fatalf("Error during approvePRsRequiringNoReview: %v\n", err)
+		}
 	case "fastForward":
 		if err := fastForward(repo, baseBranch, refSHA); err != nil {
-			log.Printf("Error during fastForward: %v\n", err)
+			log.Fatalf("Error during fastForward: %v\n", err)
 		}
 	case "tagIstioDepsForRelease":
 		if err := TagIstioDepsForRelease(); err != nil {
-			log.Printf("Error during TagIstioDepsForRelease: %v\n", err)
+			log.Fatalf("Error during TagIstioDepsForRelease: %v\n", err)
 		}
 	case "updateIstioVersion":
 		if err := UpdateIstioVersionAfterReleaseTagsMadeOnDeps(); err != nil {
-			log.Printf("Error during UpdateIstioVersionAfterReleaseTagsMadeOnDeps: %v\n", err)
+			log.Fatalf("Error during UpdateIstioVersionAfterReleaseTagsMadeOnDeps: %v\n", err)
 		}
 	case "uploadArtifacts":
 		if err := CreateIstioReleaseUploadArtifacts(); err != nil {
-			log.Printf("Error during CreateIstioReleaseUploadArtifacts: %v\n", err)
+			log.Fatalf("Error during CreateIstioReleaseUploadArtifacts: %v\n", err)
 		}
 	default:
-		log.Printf("Unsupported operation: %s\n", *op)
+		log.Fatalf("Unsupported operation: %s\n", *op)
 	}
 }

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -28,11 +28,14 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	reviewNotRequired = "review-not-required"
+)
+
 var (
 	commitType      = "commit"
 	autoMergeLabels = []string{
-		"lgtm",
-		"approved",
+		reviewNotRequired,
 		"release-note-none",
 	}
 )
@@ -107,35 +110,90 @@ func (g GithubClient) CreatePullRequest(
 	return pr, nil
 }
 
-// AddAutoMergeLabelsToPR adds /lgtm and /approve labels to a PR,
-// essentially automatically merges the PR without review, if PR passes presubmit
+// AddAutoMergeLabelsToPR adds appropriate labels to a PR,
+// indicating this PR can be merged without review, provided PR passes presubmit
 func (g GithubClient) AddAutoMergeLabelsToPR(repo string, pr *github.PullRequest) error {
 	_, _, err := g.client.Issues.AddLabelsToIssue(
 		context.Background(), g.owner, repo, pr.GetNumber(), autoMergeLabels)
 	return err
 }
 
-func (g GithubClient) ApproveAutoPR(repo string, pr *github.PullRequest) error {
-	review, _, err := g.client.PullRequests.CreateReview(context.Background(), g.owner, repo, pr.GetNumber(),
-		&github.PullRequestReviewRequest{})
+func (g GithubClient) forEachOpenPR(repo string, fn func(pr *github.PullRequest) error) error {
+	options := github.PullRequestListOptions{
+		State: "open",
+	}
+	prs, _, err := g.client.PullRequests.List(
+		context.Background(), g.owner, repo, &options)
 	if err != nil {
-		log.Printf("Failed to create a pr review for %s #%d: %s", repo, pr.GetNumber(), err)
 		return err
 	}
-
-	e := "APPROVE"
-	b := "Self-approve for auto PR"
-	reviewRequest := &github.PullRequestReviewRequest{
-		Body:  &b,
-		Event: &e,
+	var multiErr error
+	for _, pr := range prs {
+		if err := fn(pr); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
 	}
+	return multiErr
+}
 
-	_, _, err = g.client.PullRequests.SubmitReview(context.Background(), g.owner, repo, pr.GetNumber(),
-		review.GetID(), reviewRequest)
-	if err != nil {
-		log.Printf("Failed to submit approve review for pr %s #%d: %s", repo, pr.GetNumber(), err)
+// ApprovePRsRequiringNoReview approves all open pull requests that do not require reviews to be merged
+func (g GithubClient) ApprovePRsRequiringNoReview(repo string) error {
+	approvePR := func(pr *github.PullRequest) error {
+		prName := fmt.Sprintf("%s/%s#%d", g.owner, repo, pr.GetNumber())
+		labelsOnPR, _, err := g.client.Issues.ListLabelsByIssue(
+			context.Background(), g.owner, repo, pr.GetNumber(), nil)
+		if err != nil {
+			log.Printf("Failed to read labels on pull request %s", prName)
+			return err
+		}
+		safeToApprove := false
+		for _, label := range labelsOnPR {
+			if label.GetName() == reviewNotRequired {
+				safeToApprove = true
+				break
+			}
+		}
+		if !safeToApprove {
+			return nil
+		}
+		log.Printf("Approving pull request %s", prName)
+		e := "APPROVE"
+		b := "Self-approve PR without review"
+		reviewRequest := &github.PullRequestReviewRequest{
+			Body:  &b,
+			Event: &e,
+		}
+		review, _, err := g.client.PullRequests.CreateReview(
+			context.Background(), g.owner, repo, pr.GetNumber(), reviewRequest)
+		if err != nil {
+			log.Printf("Failed to create a review on pull request %s", prName)
+			return err
+		}
+		_, _, err = g.client.PullRequests.SubmitReview(
+			context.Background(), g.owner, repo, pr.GetNumber(), review.GetID(), reviewRequest)
+		if err != nil {
+			log.Printf("Approval failed, unable to submit APPROVE review for pull request %s", prName)
+		}
+		return err
 	}
-	return err
+	return g.forEachOpenPR(repo, approvePR)
+}
+
+// CloseIdlePullRequests checks all open PRs auto-created on baseBranch in repo,
+// closes the ones that have stayed open for a long time, and deletes the
+// remote branches from which the PRs are made
+func (g GithubClient) CloseIdlePullRequests(prTitlePrefix, repo string) error {
+	log.Printf("If any, close failed auto PRs to update dependencies in repo %s", repo)
+	idleTimeout := time.Hour * 24
+	closeIdlePRofPrefix := func(pr *github.PullRequest) error {
+		if strings.HasPrefix(*pr.Title, prTitlePrefix) {
+			if time.Since(*pr.CreatedAt).Nanoseconds() > idleTimeout.Nanoseconds() {
+				return g.ClosePRDeleteBranch(repo, pr)
+			}
+		}
+		return nil
+	}
+	return g.forEachOpenPR(repo, closeIdlePRofPrefix)
 }
 
 // ClosePRDeleteBranch closes a PR and deletes the branch from which the PR is made
@@ -184,35 +242,6 @@ func (g GithubClient) ExistBranch(repo, branch string) (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-// CloseIdlePullRequests checks all open PRs auto-created on baseBranch in repo,
-// closes the ones that have stayed open for a long time, and deletes the
-// remote branches from which the PRs are made
-func (g GithubClient) CloseIdlePullRequests(prTitlePrefix, repo, baseBranch string) error {
-	log.Printf("If any, close failed auto PRs to update dependencies in repo %s", repo)
-	idleTimeout := time.Hour * 24
-	options := github.PullRequestListOptions{
-		Base:  baseBranch,
-		State: "open",
-	}
-	prs, _, err := g.client.PullRequests.List(
-		context.Background(), g.owner, repo, &options)
-	if err != nil {
-		return err
-	}
-	var multiErr error
-	for _, pr := range prs {
-		if !strings.HasPrefix(*pr.Title, prTitlePrefix) {
-			continue
-		}
-		if time.Since(*pr.CreatedAt).Nanoseconds() > idleTimeout.Nanoseconds() {
-			if err := g.ClosePRDeleteBranch(repo, pr); err != nil {
-				multiErr = multierror.Append(multiErr, err)
-			}
-		}
-	}
-	return multiErr
 }
 
 // GetHeadCommitSHA finds the SHA of the commit to which the HEAD of branch points

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -119,7 +119,8 @@ func (g GithubClient) ApproveAutoPR(repo string, pr *github.PullRequest) error {
 	review, _, err := g.client.PullRequests.CreateReview(context.Background(), g.owner, repo, pr.GetNumber(),
 		&github.PullRequestReviewRequest{})
 	if err != nil {
-		log.Printf("Failed to create a pr review for %s #%d", repo, pr.GetNumber())
+		log.Printf("Failed to create a pr review for %s #%d: %s", repo, pr.GetNumber(), err)
+		return err
 	}
 
 	e := "APPROVE"
@@ -132,7 +133,7 @@ func (g GithubClient) ApproveAutoPR(repo string, pr *github.PullRequest) error {
 	_, _, err = g.client.PullRequests.SubmitReview(context.Background(), g.owner, repo, pr.GetNumber(),
 		review.GetID(), reviewRequest)
 	if err != nil {
-		log.Printf("Failed to submit approve review for pr %s #%d", repo, pr.GetNumber())
+		log.Printf("Failed to submit approve review for pr %s #%d: %s", repo, pr.GetNumber(), err)
 	}
 	return err
 }

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	commitType = "commit"
+	commitType      = "commit"
 	autoMergeLabels = []string{
 		"lgtm",
 		"approved",
@@ -125,7 +125,7 @@ func (g GithubClient) ApproveAutoPR(repo string, pr *github.PullRequest) error {
 	e := "APPROVE"
 	b := "Self-approve for auto PR"
 	reviewRequest := &github.PullRequestReviewRequest{
-		Body: &b,
+		Body:  &b,
 		Event: &e,
 	}
 

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -30,6 +30,11 @@ import (
 
 var (
 	commitType = "commit"
+	autoMergeLabels = []string{
+		"lgtm",
+		"approved",
+		"release-note-none",
+	}
 )
 
 // GithubClient masks RPCs to github as local procedures
@@ -105,13 +110,30 @@ func (g GithubClient) CreatePullRequest(
 // AddAutoMergeLabelsToPR adds /lgtm and /approve labels to a PR,
 // essentially automatically merges the PR without review, if PR passes presubmit
 func (g GithubClient) AddAutoMergeLabelsToPR(repo string, pr *github.PullRequest) error {
-	labels := []string{
-		"lgtm",
-		"approved",
-		"release-note-none",
-	}
 	_, _, err := g.client.Issues.AddLabelsToIssue(
-		context.Background(), g.owner, repo, pr.GetNumber(), labels)
+		context.Background(), g.owner, repo, pr.GetNumber(), autoMergeLabels)
+	return err
+}
+
+func (g GithubClient) ApproveAutoPR(repo string, pr *github.PullRequest) error {
+	review, _, err := g.client.PullRequests.CreateReview(context.Background(), g.owner, repo, pr.GetNumber(),
+		&github.PullRequestReviewRequest{})
+	if err != nil {
+		log.Printf("Failed to create a pr review for %s #%d", repo, pr.GetNumber())
+	}
+
+	e := "APPROVE"
+	b := "Self-approve for auto PR"
+	reviewRequest := &github.PullRequestReviewRequest{
+		Body: &b,
+		Event: &e,
+	}
+
+	_, _, err = g.client.PullRequests.SubmitReview(context.Background(), g.owner, repo, pr.GetNumber(),
+		review.GetID(), reviewRequest)
+	if err != nil {
+		log.Printf("Failed to submit approve review for pr %s #%d", repo, pr.GetNumber())
+	}
 	return err
 }
 
@@ -120,8 +142,7 @@ func (g GithubClient) ClosePRDeleteBranch(repo string, pr *github.PullRequest) e
 	prName := fmt.Sprintf("%s/%s#%d", g.owner, repo, pr.GetNumber())
 	log.Printf("Closing PR %s and deleting branch %s", prName, *pr.Head.Ref)
 	*pr.State = "closed"
-	if _, _, err := g.client.PullRequests.Edit(
-		context.Background(), g.owner, repo, pr.GetNumber(), pr); err != nil {
+	if _, _, err := g.client.PullRequests.Edit(context.Background(), g.owner, repo, pr.GetNumber(), pr); err != nil {
 		log.Printf("Failed to close %s", prName)
 		return err
 	}


### PR DESCRIPTION
Since github prevents one from approving oneself, we need another bot to make the approval and hence auto merging.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
