### PR TITLE
Add Go to the build environment

### DIFF
--- a/docker/istio-builder/Dockerfile.istio-builder
+++ b/docker/istio-builder/Dockerfile.istio-builder
@@ -29,3 +29,8 @@ RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs)
 # Install Repo tool
 RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
     chmod a+x /usr/local/bin/repo
+
+# Install Go
+RUN wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz
+ENV PATH="${PATH}:/usr/local/go/bin"


### PR DESCRIPTION
Pilot is looking for Go in the path instead of finding the binary used
by Bazel.  Temporary fix until the Pilot build can be corrected.

```release-note
Add Go to the build environment
```
