### PR TITLE
Add dependency-update label to auto pr

### DIFF
--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -32,9 +32,10 @@ var (
 )
 
 const (
-	istioDepsFile = "istio.deps"
-	prTitlePrefix = "[DO NOT MERGE] Auto PR to update dependencies of "
-	prBody        = "This PR will be merged automatically once checks are successful."
+	istioDepsFile         = "istio.deps"
+	prTitlePrefix         = "[DO NOT MERGE] Auto PR to update dependencies of "
+	prBody                = "This PR will be merged automatically once checks are successful."
+	dependencyUpdateLabel = "dependency-update"
 )
 
 // Updates dependency objects in :deps to the latest stable version.
@@ -150,7 +151,10 @@ func updateDependenciesOf(repo string) error {
 	if err != nil {
 		return err
 	}
-	return githubClnt.AddAutoMergeLabelsToPR(repo, pr)
+	if err := githubClnt.AddAutoMergeLabelsToPR(repo, pr); err != nil {
+		return err
+	}
+	return githubClnt.AddlabelsToPR(repo, pr, dependencyUpdateLabel)
 }
 
 func init() {

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -105,11 +105,12 @@ func (g GithubClient) CreatePullRequest(
 // AddAutoMergeLabelsToPR adds /lgtm and /approve labels to a PR,
 // essentially automatically merges the PR without review, if PR passes presubmit
 func (g GithubClient) AddAutoMergeLabelsToPR(repo string, pr *github.PullRequest) error {
-	labels := []string{
-		"lgtm",
-		"approved",
-		"release-note-none",
-	}
+	return g.AddlabelsToPR(repo, pr, "lgtm", "approved", "release-note-none")
+}
+
+// AddlabelsToPR adds labels to the pull request
+func (g GithubClient) AddlabelsToPR(
+	repo string, pr *github.PullRequest, labels ...string) error {
 	_, _, err := g.client.Issues.AddLabelsToIssue(
 		context.Background(), g.owner, repo, pr.GetNumber(), labels)
 	return err


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
