### PR TITLE
More process logging when making release

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -88,6 +88,7 @@ func getReleaseTag() (string, error) {
 // TagIstioDepsForRelease creates release tag on each dependent repo of istio
 func TagIstioDepsForRelease() error {
 	assertNotEmpty("base_branch", baseBranch)
+	log.Printf("Fetching and processing istio.VERSION\n")
 	istioVersion, err := githubClnt.GetFileContent(istioRepo, *baseBranch, istioVersionFile)
 	if err != nil {
 		return err
@@ -101,6 +102,7 @@ func TagIstioDepsForRelease() error {
 	if err != nil {
 		return err
 	}
+	log.Printf("Fetching release tag\n")
 	releaseTag, err := getReleaseTag()
 	if err != nil {
 		return err
@@ -109,6 +111,7 @@ func TagIstioDepsForRelease() error {
 	for _, dep := range deps {
 		// use sha directly read from istio.VERSION in case updateVersion.sh was run
 		// manually without also updating istio.deps
+		log.Printf("Creating annotated tag [%s] on %s\n", releaseTag, dep.RepoName)
 		ref, exists := kv[dep.Name]
 		if !exists {
 			return fmt.Errorf("ill-defined %s: unable to find %s", istioVersionFile, dep.Name)
@@ -129,6 +132,7 @@ func TagIstioDepsForRelease() error {
 
 func cloneIstioMakePR(newBranch, prTitle, prBody string, edit func() error) error {
 	assertNotEmpty("base_branch", baseBranch)
+	log.Printf("Cloning istio to local and checkout %s\n", *baseBranch)
 	repoDir, err := u.CloneRepoCheckoutBranch(githubClnt, istioRepo, *baseBranch, newBranch)
 	if err != nil {
 		return err
@@ -141,6 +145,7 @@ func cloneIstioMakePR(newBranch, prTitle, prBody string, edit func() error) erro
 	if err := edit(); err != nil {
 		return err
 	}
+	log.Printf("Staging commit and creating pull request\n")
 	if err := u.CreateCommitPushToRemote(
 		newBranch, newBranch); err != nil {
 		return err

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -46,7 +46,7 @@ const (
 	releaseBaseDir       = "tmp/release"
 	releasePRTtilePrefix = "[Auto Release] "
 	releasePRBody        = "Update istio.VERSION and downloadIstio.sh"
-	releaseBucketFmtStr  = "https://storage.googleapis.com/istio-artifacts/pilot/%s/artifacts/istioctl"
+	releaseBucketFmtStr  = "https://storage.googleapis.com/istio-release/releases/%s/istioctl"
 )
 
 // Panic if value not specified

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -285,6 +285,7 @@ func (g GithubClient) CreateAnnotatedTag(repo, tag, sha, msg string) error {
 func (g GithubClient) CreateReleaseUploadArchives(repo, releaseTag, archiveDir string) error {
 	// create release
 	release := github.RepositoryRelease{TagName: &releaseTag}
+	log.Printf("Creating on github new %s release [%s]\n", repo, releaseTag)
 	res, _, err := g.client.Repositories.CreateRelease(
 		context.Background(), g.owner, repo, &release)
 	if err != nil {
@@ -298,6 +299,7 @@ func (g GithubClient) CreateReleaseUploadArchives(repo, releaseTag, archiveDir s
 		return err
 	}
 	for _, f := range files {
+		log.Printf("Uploading asset %s\n", f.Name())
 		filePath := fmt.Sprintf("%s/%s", archiveDir, f.Name())
 		fd, err := os.Open(filePath)
 		if err != nil {


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
