### PR TITLE
Release tool: new skip_edit_download_script flag and better approach to add new line before eof

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -208,7 +208,7 @@ func CreateIstioReleaseUploadArtifacts() error {
 		if err := u.WriteFile(releaseTagFile, *nextRelease); err != nil {
 			return err
 		}
-		if skipEditDownloadScript {
+		if *skipEditDownloadScript {
 			return nil
 		}
 		return u.UpdateKeyValueInFile(

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -31,7 +31,7 @@ var (
 	baseBranch           = flag.String("base_branch", "", "Branch to which op is applied")
 	refSHA               = flag.String("ref_sha", "", "Reference commit SHA used to update base branch")
 	nextRelease          = flag.String("next_release", "", "Tag of the next release")
-	udpateDownloadScript = flag.Bool("update_download_script", false, "Have download script point to latest version")
+	updateDownloadScript = flag.Bool("update_download_script", false, "Have download script point to latest version")
 	githubClnt           *u.GithubClient
 )
 
@@ -206,10 +206,10 @@ func CreateIstioReleaseUploadArtifacts() error {
 			istioRepo, releaseTag, archiveDir); err != nil {
 			return err
 		}
-		if err := u.WriteFile(releaseTagFile, *nextRelease); err != nil {
+		if err := u.WriteTextFile(releaseTagFile, *nextRelease); err != nil {
 			return err
 		}
-		if *udpateDownloadScript {
+		if *updateDownloadScript {
 			log.Printf("Updating download script with latest release")
 			return u.UpdateKeyValueInFile(
 				downloadScript, "ISTIO_VERSION", releaseTag)

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -204,7 +204,7 @@ func CreateIstioReleaseUploadArtifacts() error {
 			istioRepo, releaseTag, archiveDir); err != nil {
 			return err
 		}
-		if err := u.WriteFile(releaseTagFile, *nextRelease+"\n"); err != nil {
+		if err := u.WriteFile(releaseTagFile, *nextRelease); err != nil {
 			return err
 		}
 		return u.UpdateKeyValueInFile(

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -24,14 +24,15 @@ import (
 )
 
 var (
-	owner       = flag.String("owner", "istio", "Github owner or org")
-	tokenFile   = flag.String("token_file", "", "File containing Github API Access Token")
-	op          = flag.String("op", "", "Operation to be performed")
-	repo        = flag.String("repo", "", "Repository to which op is applied")
-	baseBranch  = flag.String("base_branch", "", "Branch to which op is applied")
-	refSHA      = flag.String("ref_sha", "", "Reference commit SHA used to update base branch")
-	nextRelease = flag.String("next_release", "", "Tag of the next release")
-	githubClnt  *u.GithubClient
+	owner                  = flag.String("owner", "istio", "Github owner or org")
+	tokenFile              = flag.String("token_file", "", "File containing Github API Access Token")
+	op                     = flag.String("op", "", "Operation to be performed")
+	repo                   = flag.String("repo", "", "Repository to which op is applied")
+	baseBranch             = flag.String("base_branch", "", "Branch to which op is applied")
+	refSHA                 = flag.String("ref_sha", "", "Reference commit SHA used to update base branch")
+	nextRelease            = flag.String("next_release", "", "Tag of the next release")
+	skipEditDownloadScript = flag.Bool("skip_edit_download_script", false, "Have download script point to old version")
+	githubClnt             *u.GithubClient
 )
 
 const (
@@ -207,11 +208,14 @@ func CreateIstioReleaseUploadArtifacts() error {
 		if err := u.WriteFile(releaseTagFile, *nextRelease); err != nil {
 			return err
 		}
+		if skipEditDownloadScript {
+			return nil
+		}
 		return u.UpdateKeyValueInFile(
 			downloadScript, "ISTIO_VERSION", releaseTag)
 	}
 	body := fmt.Sprintf(
-		"Create release %s on istio, update next release tag and download scrpit", releaseTag)
+		"Create release %s on istio, update next release tag and download script", releaseTag)
 	prTitle := releasePRTtilePrefix + body
 	return cloneIstioMakePR(releaseBranch, prTitle, body, edit)
 }

--- a/toolbox/util/commonUtils.go
+++ b/toolbox/util/commonUtils.go
@@ -36,6 +36,9 @@ func ReadFile(filePath string) (string, error) {
 
 // WriteFile overwrites the file on the given path with content
 func WriteFile(filePath, content string) error {
+	if len(content) == 0 || content[len(content)-1] != '\n' {
+		content += "\n"
+	}
 	return ioutil.WriteFile(filePath, []byte(content), 0600)
 }
 

--- a/toolbox/util/commonUtils.go
+++ b/toolbox/util/commonUtils.go
@@ -36,7 +36,7 @@ func ReadFile(filePath string) (string, error) {
 
 // WriteFile overwrites the file on the given path with content
 func WriteFile(filePath, content string) error {
-	if len(content) == 0 || content[len(content)-1] != '\n' {
+	if len(content) > 0 && content[len(content)-1] != '\n' {
 		content += "\n"
 	}
 	return ioutil.WriteFile(filePath, []byte(content), 0600)

--- a/toolbox/util/commonUtils.go
+++ b/toolbox/util/commonUtils.go
@@ -34,8 +34,8 @@ func ReadFile(filePath string) (string, error) {
 	return string(b), nil
 }
 
-// WriteFile overwrites the file on the given path with content
-func WriteFile(filePath, content string) error {
+// WriteTextFile overwrites the file on the given path with content
+func WriteTextFile(filePath, content string) error {
 	if len(content) > 0 && content[len(content)-1] != '\n' {
 		content += "\n"
 	}
@@ -76,7 +76,7 @@ func UpdateKeyValueInFile(file, key, value string) error {
 		return fmt.Errorf("no occurrence of %s found in %s", key, file)
 	}
 	output := strings.Join(lines, "\n")
-	return WriteFile(file, output)
+	return WriteTextFile(file, output)
 }
 
 // GetMD5Hash generates an MD5 digest of the given string


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
