### PR TITLE
Add kubeconfig volumn for pilot-coverage

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -631,6 +631,8 @@ presubmits:
           - name: pilot-codecov-token
             mountPath: /etc/codecov
             readOnly: true
+          - name: e2e-testing-kubeconfig
+            mountPath: /home/bootstrap/.kube
           - name: cache-ssd
             mountPath: /home/bootstrap/.cache
           ports:
@@ -652,6 +654,9 @@ presubmits:
         - name: pilot-codecov-token
           secret:
             secretName: pilot-codecov-token
+        - name: e2e-testing-kubeconfig
+          secret:
+            secretName: e2e-testing-kubeconfig
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0


### PR DESCRIPTION
fixes https://k8s-gubernator.appspot.com/build/istio-prow/pull/istio_pilot/1158/pilot-coverage/19/
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
