### PR TITLE
Put back rbac_auth

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -309,6 +309,56 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+    - name: e2e-suite-rbac-auth
+      agent: kubernetes
+      context: prow/e2e-suite-rbac-auth.sh
+      rerun_command: "/test e2e-suite-rbac-auth"
+      trigger: "(?m)^/test (e2e-suite|e2e-suite-rbac-auth)?,?(\\s+|$)"
+      branches:
+      - master
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: e2e-testing-rbac-kubeconfig
+            mountPath: /home/bootstrap/.kube
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: e2e-testing-rbac-kubeconfig
+          secret:
+            secretName: e2e-testing-rbac-kubeconfig
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
     - name: new-e2e-rbac_no_auth
       agent: kubernetes
       context: prow/new-e2e-rbac_no_auth.sh


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
