### PR TITLE
increase timeout for mixer presubmit test. 

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -422,7 +422,7 @@ presubmits:
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
-        - "--timeout=20"
+        - "--timeout=40"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true


### PR DESCRIPTION
 Mixer linters are running slow and combined with other slow downloads and code coverage steps, mixer presubmit is timeout out.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
