### PR TITLE
[Prow] Add manual trigger job step in README

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -180,7 +180,3 @@ Prow should respone:
 ```
 prowjob "e810668f-9435-11e7-9a4d-784f43915c4d" created
 ```
-
-
-
-##

--- a/prow/README.md
+++ b/prow/README.md
@@ -155,3 +155,32 @@ $ chmod +x prow/my-presubmit.sh
 This repository (istio/test-infra) also provides Prow jobs.
 
 - `test-infra-presubmit` - run the linting and testing
+
+### Manually Trigger a Prow Job
+
+
+> **Never do this unless necessary AND you are authorized by istio EngProd team (istio-engprod@google.com)**
+
+
+Connect to Prow cluster and then:
+```bash
+$ git clone https://github.com/kubernetes/test-infra
+$ bazel build //prow/cmd/mkpj   
+$ bazel-bin/prow/cmd/mkpj/mkpj --config-path ~/istio/test-infra/prow/config.yaml --job test-infra-presubmit | kubectl create -f -
+```
+And give the required information:
+```
+Base ref (e.g. master): master
+Base SHA (e.g. 72bcb5d80): 6419408170738a60cf04f963e4ae139028bf0b5b
+PR Number: 465                                     
+PR author: yutongz
+PR SHA (e.g. 72bcb5d80): d7e1ef38cf294de11062a6760d073827585af219
+```
+Prow should respone:
+```
+prowjob "e810668f-9435-11e7-9a4d-784f43915c4d" created
+```
+
+
+
+##

--- a/prow/README.md
+++ b/prow/README.md
@@ -159,7 +159,7 @@ This repository (istio/test-infra) also provides Prow jobs.
 ### Manually Trigger a Prow Job
 
 
-> **Never do this unless necessary AND you are authorized by istio EngProd team (istio-engprod@google.com)**
+> **Never do this unless necessary AND you are authorized by istio EngProd team (istio.slack.com test-infra channel)**
 
 
 Connect to Prow cluster and then:

--- a/prow/README.md
+++ b/prow/README.md
@@ -165,9 +165,13 @@ This repository (istio/test-infra) also provides Prow jobs.
 Connect to Prow cluster and then:
 ```bash
 $ git clone https://github.com/kubernetes/test-infra
-$ bazel build //prow/cmd/mkpj   
+$ bazel build //prow/cmd/mkpj
+```
+And then specify the script and the job you want to trigger:
+``` bash
 $ bazel-bin/prow/cmd/mkpj/mkpj --config-path ~/istio/test-infra/prow/config.yaml --job test-infra-presubmit | kubectl create -f -
 ```
+
 And give the required information:
 ```
 Base ref (e.g. master): master


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
