### PR TITLE
Enable auto dependency udpate on mixer and pilot

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -926,7 +926,7 @@ periodics:
       secret:
         secretName: e2e-testing-rbac-kubeconfig
 
-- interval: 12h
+- interval: 2h
   agent: kubernetes
   name: test-infra-update-deps
   spec:

--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -32,8 +32,21 @@ bazel build //toolbox/deps_update:deps_update
 git config --global user.email "istio.testing@gmail.com"
 git config --global user.name "istio-bot"
 
+TOKEN_PATH="/etc/github/oauth"
+# List of repo where auto dependency update has been enabled
+# excluding istio/istio
+repos=( mixer pilot )
+
 echo "=== Updating Dependency of Istio ==="
 ./bazel-bin/toolbox/deps_update/deps_update \
 --repo=istio \
---token_file=/etc/github/oauth \
+--token_file=${TOKEN_PATH} \
 --hub=gcr.io/istio-testing
+
+for r in "${repos[@]}"
+do
+	echo "=== Updating Dependency of ${r} ==="
+   ./bazel-bin/toolbox/deps_update/deps_update \
+	--repo=${r} \
+	--token_file=${TOKEN_PATH}
+done

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -207,7 +207,7 @@ func (g GithubClient) ExistBranch(repo, branch string) (bool, error) {
 // remote branches from which the PRs are made
 func (g GithubClient) CloseIdlePullRequests(prTitlePrefix, repo, baseBranch string) error {
 	log.Printf("If any, close failed auto PRs to update dependencies in repo %s", repo)
-	idleTimeout := time.Hour * 24
+	idleTimeout := time.Hour * 6
 	options := github.PullRequestListOptions{
 		Base:  baseBranch,
 		State: "open",


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
