### PR TITLE
Change pilot kubeconfig

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -543,7 +543,7 @@ presubmits:
           - name: service
             mountPath: /etc/service-account
             readOnly: true
-          - name: e2e-testing-kubeconfig
+          - name: pilot-e2e-rbac-kubeconfig
             mountPath: /home/bootstrap/.kube
           - name: cache-ssd
             mountPath: /home/bootstrap/.cache
@@ -563,9 +563,9 @@ presubmits:
         - name: service
           secret:
             secretName: service-account
-        - name: e2e-testing-kubeconfig
+        - name: pilot-e2e-rbac-kubeconfig
           secret:
-            secretName: e2e-testing-kubeconfig
+            secretName: pilot-e2e-rbac-kubeconfig
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
Pilot e2e uses its dedicated cluster.