### PR TITLE
remove extra periodic

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -937,7 +937,6 @@ periodics:
       secret:
         secretName: pilot-e2e-rbac-kubeconfig
 
-periodics:
 - interval: 2h
   agent: kubernetes
   name: test-infra-cleanup-cluster


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

It seems prow only find the last "periodic", which means cleanup for pilot cluster never been triggered. Tested this change on prow cluster.
