### PR TITLE
Add periodic job to cleanup GKE clusters from cluster-wide test.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1006,6 +1006,30 @@ periodics:
       secret:
         secretName: e2e-testing-rbac-kubeconfig
 
+- interval: 3h
+  agent: kubernetes
+  name: test-infra-cleanup-GKE
+  spec:
+    containers:
+    - image: gcr.io/istio-testing/prowbazel:0.1.7
+      args:
+      - "--repo=github.com/istio/test-infra=master"
+      - "--clean"
+      - "--timeout=30"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+    nodeSelector:
+      cloud.google.com/gke-nodepool: build-pool
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+
 - interval: 2h
   agent: kubernetes
   name: test-infra-update-deps

--- a/prow/test-infra-cleanup-GKE.sh
+++ b/prow/test-infra-cleanup-GKE.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2017 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+#############################################
+# Crontab cleanup script triggered by Prow. #
+#############################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+echo "=== Cleaning up GKE clusters ==="
+./scripts/cleanup-GKE

--- a/scripts/cleanup-GKE
+++ b/scripts/cleanup-GKE
@@ -35,7 +35,10 @@ export -f delete_cluster
 echo "Currect Time:"
 date -u '+%Y-%m-%dT%H:%M:%S UTC'
 
-gcloud container clusters list --project istio-testing --format="table(name,createTime,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-*"
+# Print out the list of clusters should be clean
+# Filter out clusters match name pattern, with alpha enabled and live longer than expected.
+gcloud container clusters list --project istio-testing --format="table(name,createTime,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-* AND createTime<-p${HOURS_OLD}h"
 
+# Get the same list and call delete_cluster
 gcloud container clusters list --project istio-testing --format="table(name,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-* AND createTime<-p${HOURS_OLD}h" \
   | xargs -L2 -I {} bash -c 'delete_cluster "${@}"' _ {},"istio-testing"

--- a/scripts/cleanup-GKE
+++ b/scripts/cleanup-GKE
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Print commands
+set -x
+
+PROJECT_ID='istio-testing'
+HOURS_OLD=3
+
+while getopts :h:p arg; do
+  case ${arg} in
+    h) HOURS_OLD=${OPTARG};;
+    p) PROJECT_ID="${OPTARG}";;
+    *) error_exit "Unrecognized argument -${OPTARG}";;
+  esac
+done
+
+function delete_cluster() {
+  IFS=',| '
+  ary=(${1})
+  CLUSTER_NAME=${ary[0]}
+  ZONE=${ary[1]}
+  PROJECT_ID=${ary[2]}
+  # Exit if that's the table title line.
+  if [[ ${CLUSTER_NAME} == "NAME" ]]; then
+    exit
+  fi
+  echo "Project: ${PROJECT_ID}"
+  echo "Cluster Name: ${CLUSTER_NAME}"
+  echo "ZONE: ${ZONE}"
+  gcloud container clusters delete ${CLUSTER_NAME} --zone ${ZONE} --project ${PROJECT_ID} --quiet \
+    || echo "Failed to delete cluster ${CLUSTER_NAME}"
+}
+export -f delete_cluster
+
+echo "Currect Time:"
+date -u '+%Y-%m-%dT%H:%M:%S UTC'
+
+gcloud container clusters list --project istio-testing --format="table(name,createTime,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-*"
+
+gcloud container clusters list --project istio-testing --format="table(name,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-* AND createTime<-p${HOURS_OLD}h" \
+  | xargs -L2 -I {} bash -c 'delete_cluster "${@}"' _ {},"istio-testing"


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
