### PR TITLE
Change cluster default name and add more configurable

### DIFF
--- a/prow/test-infra-cleanup-GKE.sh
+++ b/prow/test-infra-cleanup-GKE.sh
@@ -27,4 +27,4 @@ set -u
 set -x
 
 echo "=== Cleaning up GKE clusters ==="
-./scripts/cleanup-GKE "${@}"
+./scripts/cleanup-GKE "$@"

--- a/prow/test-infra-cleanup-GKE.sh
+++ b/prow/test-infra-cleanup-GKE.sh
@@ -27,4 +27,4 @@ set -u
 set -x
 
 echo "=== Cleaning up GKE clusters ==="
-./scripts/cleanup-GKE
+./scripts/cleanup-GKE "${@}"

--- a/scripts/cleanup-GKE
+++ b/scripts/cleanup-GKE
@@ -5,11 +5,15 @@ set -x
 
 PROJECT_ID='istio-testing'
 HOURS_OLD=3
+CLUSTER_PREFIX='cluster-wide-auth'
+ALPHA_ENABLED='true'
 
-while getopts :h:p arg; do
+while getopts :h:p:n:a: arg; do
   case ${arg} in
     h) HOURS_OLD=${OPTARG};;
     p) PROJECT_ID="${OPTARG}";;
+    c) CLUSTER_PREFIX="${OPTARG}";;
+    a) ALPHA_ENABLED="${OPTARG}";;
     *) error_exit "Unrecognized argument -${OPTARG}";;
   esac
 done
@@ -37,8 +41,8 @@ date -u '+%Y-%m-%dT%H:%M:%S UTC'
 
 # Print out the list of clusters should be clean
 # Filter out clusters match name pattern, with alpha enabled and live longer than expected.
-gcloud container clusters list --project istio-testing --format="table(name,createTime,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-* AND createTime<-p${HOURS_OLD}h"
+gcloud container clusters list --project ${PROJECT_ID} --format="table(name,createTime,locations[0])" --filter="enableKubernetesAlpha=${ALPHA_ENABLED} AND name:${CLUSTER_PREFIX}-* AND createTime<-p${HOURS_OLD}h"
 
 # Get the same list and call delete_cluster
-gcloud container clusters list --project istio-testing --format="table(name,locations[0])" --filter="enableKubernetesAlpha=true AND name:rbac-n-auth-* AND createTime<-p${HOURS_OLD}h" \
+gcloud container clusters list --project ${PROJECT_ID} --format="table(name,locations[0])" --filter="enableKubernetesAlpha=${ALPHA_ENABLED} AND name:${CLUSTER_PREFIX}-* AND createTime<-p${HOURS_OLD}h" \
   | xargs -L2 -I {} bash -c 'delete_cluster "${@}"' _ {},"istio-testing"


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
Cluster name changed by https://github.com/istio/istio/pull/902/files#diff-4d4b343aca91a15218a827b3b0385f10R36