### PR TITLE
Test /hold

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -58,4 +58,5 @@ plugins:
   - close
   - reopen
   - lgtm
+  - hold
   - yuks


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

They implemented /hold which is awesome! Let's give it try first.

https://github.com/kubernetes/test-infra/tree/master/prow/plugins/hold
https://github.com/kubernetes/test-infra/blob/master/commands.md
