### PR TITLE
Skips release-note check for Release PR.

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -173,9 +173,12 @@ func cloneIstioMakePR(newBranch, prTitle, prBody string, edit func() error) erro
 		newBranch, newBranch); err != nil {
 		return err
 	}
-	_, err = githubClnt.CreatePullRequest(
+	pr, err := githubClnt.CreatePullRequest(
 		prTitle, prBody, newBranch, *baseBranch, istioRepo)
-	return err
+	if err != nil {
+		return err
+	}
+	return githubClnt.AddlabelsToPR(istioRepo, pr, "release-note-none")
 }
 
 // UpdateIstioVersionAfterReleaseTagsMadeOnDeps runs updateVersion.sh to update


### PR DESCRIPTION
We had to manually to this, so making it easier for next release engineer

```release-note
none
```
