### PR TITLE
Script to update e2e cluster

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,21 @@
+## update-e2e-cluster.sh
+
+This script is used to update test clusters since the alpha-feature-cluster expires and is deleted in 30 days.
+So we need to create new ones, and update secrets of kubeconfig in Prow to point to the new clusters. 
+
+It always tries to create cluster with name `<repo>-e2e-rbac-rotation-1`, if gets error (if that cluster already exists),
+tries to create `<repo>-e2e-rbac-rotation-2`. It always assumes there is only one of them exists, if not, exits with error.
+
+* Flag
+```
+  -r  target repo
+  -n  number of node
+  -z  cluster zone
+```
+
+We need to update cluster for: auth, broker, pilot, mixer, istio
+Example:
+```Bash
+$ ./scripts/update-e2e-cluster.sh -r pilot -n 10
+$ ./scripts/update-e2e-cluster.sh -r auth -n 4
+```

--- a/scripts/update-e2e-cluster.sh
+++ b/scripts/update-e2e-cluster.sh
@@ -83,7 +83,7 @@ do
 done
 
 # Keep new config into temp dir and put original config back
-TEMP_DIR="${HOME}/.kube/${REPO}_TEMP"
+TEMP_DIR="$(mktemp -d)"
 mkdir ${TEMP_DIR}
 mv "${CONFIG_FILE}" "${TEMP_DIR}/config"
 mv "${CONFIG_BACKUP}" "${CONFIG_FILE}"
@@ -96,6 +96,5 @@ gcloud container clusters get-credentials ${PROW_CLUSTER} --zone ${PROW_ZONE} --
 SECRET_NAME="${REPO}-e2e-rbac-kubeconfig"
 kubectl delete secret ${SECRET_NAME} -n ${PROW_TEST_NS}
 sleep 5
-kubectl -n test-pods create secret generic ${SECRET_NAME} --from-file=${TEMP_DIR}
-kubectl get secret -n test-pods
-
+kubectl -n ${PROW_TEST_NS} create secret generic ${SECRET_NAME} --from-file=${TEMP_DIR}
+kubectl get secret -n ${PROW_TEST_NS}

--- a/scripts/update-e2e-cluster.sh
+++ b/scripts/update-e2e-cluster.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Copyright 2017 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#!/bin/bash
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+#
+
+PROJECT_NAME='istio-testing'
+ZONE='us-east4-c'
+MACHINE_TYPE='n1-standard-4'
+NUM_NODES='10'
+
+PROW_CLUSTER='prow'
+PROW_ZONE='us-west1-a'
+PROW_PROJECT='istio-testing'
+PROW_TEST_NS='test-pods'
+CONFIG_BACKUPED=false
+
+cleanup () {
+  if [ "${CONFIG_BACKUPED}" = true ]; then
+    mv "${CONFIG_BACKUP}" "${CONFIG_FILE}"
+  fi
+  if [ ! -z "${TEMP_DIR}" ] && [ -d "${TEMP_DIR}" ]; then
+    rm -r ${TEMP_DIR}
+  fi
+}
+trap cleanup EXIT
+
+while getopts :r:z:n: arg; do
+  case ${arg} in
+    r) REPO=${OPTARG};;
+    z) ZONE=${OPTARG};;
+    n) NUM_NODES=${OPTARG};;
+    *) error_exit "Unrecognized argument -${OPTARG}";;
+  esac
+done
+
+if [ "${REPO}" != 'auth' ] && [ "${REPO}" != 'broker' ] && [ "${REPO}" != 'istio' ] && [ "${REPO}" != 'mixer' ] && [ "${REPO}" != 'pilot' ]; then
+  echo 'Must specific a repo and it must be auth/brokeristio/pilot/mixer'
+  exit 1
+fi
+
+# Generate cluster version and name
+CLUSTER_VERSION=$(gcloud container get-server-config --project="${PROJECT_NAME}" --zone="${ZONE}" --format='value(defaultClusterVersion)')
+echo "Default cluster version: ${CLUSTER_VERSION}"
+
+# Backup original config on your machine
+CONFIG_FILE="${HOME}/.kube/config"
+CONFIG_BACKUP="${HOME}/.kube/config.backup"
+mv ${CONFIG_FILE} ${CONFIG_BACKUP}
+CONFIG_BACKUPED=true
+
+# Try to create a rotation cluster, named $REPO-e2e-rbac-rotation-<suffix>, suffix can be 1 or 2
+gcloud config set container/use_client_certificate True
+for i in {1..2}
+do
+  CLUSTER_NAME="${REPO}-e2e-rbac-rotation-${i}"
+  result=$(gcloud container clusters create ${CLUSTER_NAME} --zone ${ZONE} --project ${PROJECT_NAME} --cluster-version ${CLUSTER_VERSION} \
+  --machine-type ${MACHINE_TYPE} --num-nodes ${NUM_NODES} --no-enable-legacy-authorization --enable-kubernetes-alpha --quiet \
+  ||  echo 'Failed')
+  [[ ${result} == 'Failed' ]] || break
+  if [ ${i} -eq 2 ]; then
+    echo "Cannot create a rotation cluster for ${REPO}"; exit 1
+  fi
+done
+
+# Keep new config into temp dir and put original config back
+TEMP_DIR="${HOME}/.kube/${REPO}_TEMP"
+mkdir ${TEMP_DIR}
+mv "${CONFIG_FILE}" "${TEMP_DIR}/config"
+mv "${CONFIG_BACKUP}" "${CONFIG_FILE}"
+CONFIG_BACKUPED=false
+
+# Switch to prow cluster
+gcloud container clusters get-credentials ${PROW_CLUSTER} --zone ${PROW_ZONE} --project ${PROW_PROJECT}
+
+# Update kubeconfig
+SECRET_NAME="${REPO}-e2e-rbac-kubeconfig"
+kubectl delete secret ${SECRET_NAME} -n ${PROW_TEST_NS}
+sleep 5
+kubectl -n test-pods create secret generic ${SECRET_NAME} --from-file=${TEMP_DIR}
+kubectl get secret -n test-pods
+


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
This is a script to create a new e2e cluster for one repo and update the secret in Prow cluster to point to the new cluster credentials.
