### PR TITLE
Update release tool to check next_release

### DIFF
--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -10,7 +10,7 @@ ROOTDIR=$SCRIPTPATH/..
 cd $ROOTDIR
 
 PKGS="tools/ toolbox/"
-GO_FILES=$(find ${PKGS} -type f -name '*.go')
+GO_FILES=$(git ls-files | grep -e '.*\.go'  | grep -v vendor)
 UX=$(uname)
 
 #remove blank lines so gofmt / goimports can do their job
@@ -23,6 +23,4 @@ fi
 done
 gofmt -s -w ${GO_FILES}
 goimports -w -local istio.io ${GO_FILES}
-buildifier -showlog -mode=fix $(find . -type f \( -name 'BUILD' -or \
-  -name 'WORKSPACE' -or \
-  -wholename '.*\.bazel' -or -wholename '.*bzl' \) -print )
+buildifier -showlog -mode=fix $(git ls-files| grep -e BUILD -e WORKSPACE | grep -v vendor)

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -211,8 +211,8 @@ func UpdateIstioVersionAfterReleaseTagsMadeOnDeps() error {
 	return cloneIstioMakePR(releaseBranch, prTitle, body, edit)
 }
 
-// CreateIstioReleaseUploadArtifacts creates a release on istio from the sha provided and uploads dependent artifacts
-func CreateIstioReleaseUploadArtifacts(refSHA string) error {
+// CreateIstioReleaseUploadArtifacts creates a release on istio from the refSHA provided and uploads dependent artifacts
+func CreateIstioReleaseUploadArtifacts() error {
 	assertNotEmpty("ref_sha", refSHA)
 	assertNotEmpty("base_branch", baseBranch)
 	assertNotEmpty("next_release", nextRelease)
@@ -232,7 +232,7 @@ func CreateIstioReleaseUploadArtifacts(refSHA string) error {
 		}
 		archiveDir := releaseBaseDir + "/archives"
 		if err := githubClnt.CreateReleaseUploadArchives(
-			istioRepo, releaseTag, refSHA, archiveDir); err != nil {
+			istioRepo, releaseTag, *refSHA, archiveDir); err != nil {
 			return err
 		}
 		if err := u.WriteTextFile(releaseTagFile, *nextRelease); err != nil {
@@ -271,7 +271,7 @@ func main() {
 			log.Printf("Error during UpdateIstioVersionAfterReleaseTagsMadeOnDeps: %v\n", err)
 		}
 	case "uploadArtifacts":
-		if err := CreateIstioReleaseUploadArtifacts(*refSHA); err != nil {
+		if err := CreateIstioReleaseUploadArtifacts(); err != nil {
 			log.Printf("Error during CreateIstioReleaseUploadArtifacts: %v\n", err)
 		}
 	default:

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -211,13 +211,14 @@ func UpdateIstioVersionAfterReleaseTagsMadeOnDeps() error {
 	return cloneIstioMakePR(releaseBranch, prTitle, body, edit)
 }
 
-// CreateIstioReleaseUploadArtifacts creates a release on istio and uploads dependent artifacts
+// CreateIstioReleaseUploadArtifacts creates a release on istio from the sha provided and uploads dependent artifacts
 func CreateIstioReleaseUploadArtifacts(refSHA string) error {
+	assertNotEmpty("ref_sha", refSHA)
 	assertNotEmpty("base_branch", baseBranch)
 	assertNotEmpty("next_release", nextRelease)
 	releaseTag, err := getReleaseTag()
 	if releaseTag == *nextRelease {
-		return fmt.Errorf("Next Release tag needs to be greater than the current release.")
+		return fmt.Errorf("next_release should be greater than the current release")
 	}
 	if err != nil {
 		return err
@@ -270,7 +271,6 @@ func main() {
 			log.Printf("Error during UpdateIstioVersionAfterReleaseTagsMadeOnDeps: %v\n", err)
 		}
 	case "uploadArtifacts":
-		assertNotEmpty("ref_sha", refSHA)
 		if err := CreateIstioReleaseUploadArtifacts(*refSHA); err != nil {
 			log.Printf("Error during CreateIstioReleaseUploadArtifacts: %v\n", err)
 		}

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -336,9 +336,12 @@ func (g GithubClient) CreateAnnotatedTag(repo, tag, sha, msg string) error {
 
 // CreateReleaseUploadArchives creates a release given release tag and
 // upload all files in archiveDir as assets of this release
-func (g GithubClient) CreateReleaseUploadArchives(repo, releaseTag, archiveDir string) error {
+func (g GithubClient) CreateReleaseUploadArchives(repo, releaseTag, sha, archiveDir string) error {
 	// create release
-	release := github.RepositoryRelease{TagName: &releaseTag}
+	release := github.RepositoryRelease{
+		TagName: &releaseTag,
+		TargetCommitish: &sha,
+	}
 	// Setting release to pre release and draft such that it does not send an announcement.
 	newBool := func(b bool) *bool {
 		bb := b

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -339,7 +339,7 @@ func (g GithubClient) CreateAnnotatedTag(repo, tag, sha, msg string) error {
 func (g GithubClient) CreateReleaseUploadArchives(repo, releaseTag, sha, archiveDir string) error {
 	// create release
 	release := github.RepositoryRelease{
-		TagName: &releaseTag,
+		TagName:         &releaseTag,
 		TargetCommitish: &sha,
 	}
 	// Setting release to pre release and draft such that it does not send an announcement.


### PR DESCRIPTION
Also adds a requirement to specify the sha to create the release from.
Now a release can be tagged on istio with:
```
githubctl --token_file=<github token file> \
    --op=uploadArtifacts --base_branch=<release branch or master> \
    --next_release=0.2.2 --ref_sha=<sha>
```
```release-note
none
```
