### PR TITLE
Prowbazel image migration to bazel 0.6.1

### DIFF
--- a/docker/istio-builder/Makefile
+++ b/docker/istio-builder/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-io
-VERSION = 0.1
+VERSION = 0.3.0
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.2.1
+VERSION = 0.3.0
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/scripts/tools/linux-install-bazel
+++ b/scripts/tools/linux-install-bazel
@@ -8,7 +8,7 @@ fi
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
 
-BAZEL_VERSION='0.5.2'
+BAZEL_VERSION='0.6.1'
 BAZEL_BASE_URL='https://github.com/bazelbuild/bazel/releases/download'
 BAZEL_SH="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
 BAZEL_URL="${BAZEL_BASE_URL}/${BAZEL_VERSION}/${BAZEL_SH}"


### PR DESCRIPTION
I have run `make` in both `docker/istio-builder` and `docker/prowbazel`.

When support for bazel 0.6.1 is done on each repo, I will update the prow/config.yaml to separate jobs for release branch and master such that master will use the prawbazel image with bazel 0.6.1. 

Please help double check to ensure I don't miss anything. Thanks!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
