### PR TITLE
Update all jobs to 0.3.1 ie bazel 0.5.4

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -88,7 +88,7 @@ presubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -147,7 +147,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -201,7 +201,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -262,7 +262,7 @@ presubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -313,7 +313,7 @@ presubmits:
       - master
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -363,7 +363,7 @@ presubmits:
       - master
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -413,7 +413,7 @@ presubmits:
       - master
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -463,7 +463,7 @@ presubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -516,7 +516,7 @@ presubmits:
       - release-0.1
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -566,7 +566,7 @@ presubmits:
       trigger: "(?m)^/test mixer-e2e-smoketest?,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -621,7 +621,7 @@ presubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -671,7 +671,7 @@ presubmits:
       trigger: "(?m)^/test pilot-e2e-smoketest?,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -719,7 +719,7 @@ presubmits:
       skip_report: true
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.2.1
+        - image: gcr.io/istio-testing/prowbazel:0.3.1
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -778,7 +778,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -868,7 +868,7 @@ postsubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -921,7 +921,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -975,7 +975,7 @@ postsubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -1024,7 +1024,7 @@ postsubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.2.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -1245,11 +1245,13 @@ periodics:
   name: test-infra-update-deps
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.1.7
+    - image: gcr.io/istio-testing/prowbazel:0.3.1
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
       - "--timeout=20"
+      securityContext:
+        privileged: true
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -1277,11 +1279,13 @@ periodics:
   name: test-infra-update-deps
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.1.7
+    - image: gcr.io/istio-testing/prowbazel:0.3.1
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
       - "--timeout=20"
+      securityContext:
+        privileged: true
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
People have been testing with bazel 0.5.4 for quite sometime so this is safe.
Updating to 0.6.0 will likely fail and we need to move one repo at a time.

```release-note
none
```
