### PR TITLE
Remove release-0.1 and create jobs for release-0.2

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -27,6 +27,7 @@ presubmits:
   #                  Otherwise, run a Jenkins job.
 
   istio/api:
+
   - name: api-presubmit
     agent: kubernetes
     context: prow/api-presubmit.sh
@@ -75,7 +76,9 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+
   istio/auth:
+
   - name: auth-presubmit
     agent: kubernetes
     context: prow/auth-presubmit.sh
@@ -84,8 +87,6 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|auth-presubmit))?,?(\\s+|$)"
     branches:
     - master
-    - release-0.1
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.1
@@ -136,7 +137,67 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+  - name: auth-presubmit
+    agent: kubernetes
+    context: prow/auth-presubmit.sh
+    always_run: true
+    rerun_command: "/test auth-presubmit"
+    trigger: "(?m)^/(retest|test (all|auth-presubmit))?,?(\\s+|$)"
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=20"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: auth-e2e-rbac-kubeconfig
+          mountPath: /home/bootstrap/.kube
+        - name: auth-codecov-token
+          mountPath: /etc/codecov
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /home/bootstrap/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9998
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: auth-e2e-rbac-kubeconfig
+        secret:
+          secretName: auth-e2e-rbac-kubeconfig
+      - name: auth-codecov-token
+        secret:
+          secretName: auth-codecov-token
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
+
   istio/broker:
+
   - name: broker-presubmit
     agent: kubernetes
     context: prow/broker-presubmit.sh
@@ -249,7 +310,9 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+
   istio/istio:
+
   - name: istio-presubmit
     agent: kubernetes
     context: prow/istio-presubmit.sh
@@ -258,8 +321,6 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|istio-presubmit))?,?(\\s+|$)"
     branches:
     - master
-    - release-0.1
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.1
@@ -309,8 +370,6 @@ presubmits:
       context: prow/e2e-suite-rbac-no_auth.sh
       rerun_command: "/test e2e-suite-rbac-no_auth"
       trigger: "(?m)^/test (e2e-suite|e2e-suite-rbac-no_auth)?,?(\\s+|$)"
-      branches:
-      - master
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.3.1
@@ -359,8 +418,6 @@ presubmits:
       context: prow/e2e-suite-rbac-auth.sh
       rerun_command: "/test e2e-suite-rbac-auth"
       trigger: "(?m)^/test (e2e-suite|e2e-suite-rbac-auth)?,?(\\s+|$)"
-      branches:
-      - master
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.3.1
@@ -409,8 +466,6 @@ presubmits:
       context: prow/e2e-cluster_wide-auth.sh
       rerun_command: "/test e2e-cluster_wide-auth"
       trigger: "(?m)^/test (e2e-suite|e2e-cluster_wide-auth)?,?(\\s+|$)"
-      branches:
-      - master
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.3.1
@@ -450,7 +505,201 @@ presubmits:
           hostPath:
             path: /mnt/disks/ssd0
 
+  - name: istio-presubmit
+    agent: kubernetes
+    context: prow/istio-presubmit.sh
+    always_run: true
+    rerun_command: "/test istio-presubmit"
+    trigger: "(?m)^/(retest|test (all|istio-presubmit))?,?(\\s+|$)"
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=15"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: istio-e2e-rbac-kubeconfig
+          mountPath: /home/bootstrap/.kube
+        - name: cache-ssd
+          mountPath: /home/bootstrap/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9998
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: istio-e2e-rbac-kubeconfig
+        secret:
+          secretName: istio-e2e-rbac-kubeconfig
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: e2e-suite-rbac-no_auth
+      agent: kubernetes
+      context: prow/e2e-suite-rbac-no_auth.sh
+      rerun_command: "/test e2e-suite-rbac-no_auth"
+      trigger: "(?m)^/test (e2e-suite|e2e-suite-rbac-no_auth)?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: istio-e2e-rbac-kubeconfig
+            mountPath: /home/bootstrap/.kube
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: istio-e2e-rbac-kubeconfig
+          secret:
+            secretName: istio-e2e-rbac-kubeconfig
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+    - name: e2e-suite-rbac-auth
+      agent: kubernetes
+      context: prow/e2e-suite-rbac-auth.sh
+      rerun_command: "/test e2e-suite-rbac-auth"
+      trigger: "(?m)^/test (e2e-suite|e2e-suite-rbac-auth)?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: istio-e2e-rbac-kubeconfig
+            mountPath: /home/bootstrap/.kube
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: istio-e2e-rbac-kubeconfig
+          secret:
+            secretName: istio-e2e-rbac-kubeconfig
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+    - name: e2e-cluster_wide-auth
+      agent: kubernetes
+      context: prow/e2e-cluster_wide-auth.sh
+      rerun_command: "/test e2e-cluster_wide-auth"
+      trigger: "(?m)^/test (e2e-suite|e2e-cluster_wide-auth)?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: new-cluster-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+
+
   istio/mixer:
+
   - name: mixer-presubmit
     agent: kubernetes
     context: prow/mixer-presubmit.sh
@@ -459,8 +708,6 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|mixer-presubmit))?,?(\\s+|$)"
     branches:
     - master
-    - release-0.1
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.2
@@ -511,9 +758,6 @@ presubmits:
       always_run: true
       rerun_command: "/test mixer-coverage"
       trigger: "(?m)^/test mixer-coverage?,?(\\s+|$)"
-      branches:
-      - master
-      - release-0.1
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.3.2
@@ -608,7 +852,161 @@ presubmits:
           hostPath:
             path: /mnt/disks/ssd0
 
+  - name: mixer-presubmit
+    agent: kubernetes
+    context: prow/mixer-presubmit.sh
+    always_run: true
+    rerun_command: "/test mixer-presubmit"
+    trigger: "(?m)^/(retest|test (all|mixer-presubmit))?,?(\\s+|$)"
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=40"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: mixer-e2e-rbac-kubeconfig
+          mountPath: /home/bootstrap/.kube
+        - name: cache-ssd
+          mountPath: /home/bootstrap/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9998
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: mixer-e2e-rbac-kubeconfig
+        secret:
+          secretName: mixer-e2e-rbac-kubeconfig
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: mixer-coverage
+      agent: kubernetes
+      context: prow/mixer-coverage.sh
+      always_run: true
+      rerun_command: "/test mixer-coverage"
+      trigger: "(?m)^/test mixer-coverage?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=40"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: mixer-codecov-token
+            mountPath: /etc/codecov
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: mixer-codecov-token
+          secret:
+            secretName: mixer-codecov-token
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+    - name: mixer-e2e-smoketest
+      agent: kubernetes
+      context: prow/mixer-e2e-smoketest.sh
+      always_run: true
+      rerun_command: "/test mixer-e2e-smoketest"
+      trigger: "(?m)^/test mixer-e2e-smoketest?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: mixer-e2e-rbac-kubeconfig
+            mountPath: /home/bootstrap/.kube
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: mixer-e2e-rbac-kubeconfig
+          secret:
+            secretName: mixer-e2e-rbac-kubeconfig
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+
+
   istio/pilot:
+
   - name: pilot-presubmit
     agent: kubernetes
     context: prow/pilot-presubmit.sh
@@ -617,8 +1015,6 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|pilot-presubmit))?,?(\\s+|$)"
     branches:
     - master
-    - release-0.1
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.2
@@ -767,7 +1163,165 @@ presubmits:
           hostPath:
             path: /mnt/disks/ssd0
 
+  - name: pilot-presubmit
+    agent: kubernetes
+    context: prow/pilot-presubmit.sh
+    always_run: true
+    rerun_command: "/test pilot-presubmit"
+    trigger: "(?m)^/(retest|test (all|pilot-presubmit))?,?(\\s+|$)"
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=20"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: pilot-e2e-rbac-kubeconfig
+          mountPath: /home/bootstrap/.kube
+        - name: cache-ssd
+          mountPath: /home/bootstrap/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9998
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: pilot-e2e-rbac-kubeconfig
+        secret:
+          secretName: pilot-e2e-rbac-kubeconfig
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: pilot-e2e-smoketest
+      agent: kubernetes
+      context: prow/pilot-e2e-smoketest.sh
+      always_run: true
+      rerun_command: "/test pilot-e2e-smoketest"
+      trigger: "(?m)^/test pilot-e2e-smoketest?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: pilot-e2e-rbac-kubeconfig
+            mountPath: /home/bootstrap/.kube
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: pilot-e2e-rbac-kubeconfig
+          secret:
+            secretName: pilot-e2e-rbac-kubeconfig
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+    - name: pilot-coverage
+      agent: kubernetes
+      context: prow/pilot-coverage.sh
+      always_run: true
+      skip_report: true
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.2.1
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=20"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: pilot-e2e-rbac-kubeconfig
+            mountPath: /home/bootstrap/.kube
+          - name: pilot-codecov-token
+            mountPath: /etc/codecov
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /home/bootstrap/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9998
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "20Gi"
+              cpu: "5000m"
+        nodeSelector:
+          cloud.google.com/gke-nodepool: build-pool
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: pilot-e2e-rbac-kubeconfig
+          secret:
+            secretName: pilot-e2e-rbac-kubeconfig
+        - name: pilot-codecov-token
+          secret:
+            secretName: pilot-codecov-token
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+
+
   istio/test-infra:
+
   - name: test-infra-presubmit
     agent: kubernetes
     context: prow/test-infra-presubmit.sh
@@ -815,6 +1369,7 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+
 postsubmits:
 
   istio/api:
@@ -860,12 +1415,13 @@ postsubmits:
         secret:
           secretName: oauth-token
 
+
   istio/auth:
+
   - name: auth-postsubmit
     agent: kubernetes
     branches:
     - master
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.1
@@ -914,7 +1470,61 @@ postsubmits:
         secret:
           secretName: oauth-token
 
+  - name: auth-postsubmit
+    agent: kubernetes
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=20"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: auth-e2e-rbac-kubeconfig
+          mountPath: /home/bootstrap/.kube
+        - name: auth-codecov-token
+          mountPath: /etc/codecov
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: auth-e2e-rbac-kubeconfig
+        secret:
+          secretName: auth-e2e-rbac-kubeconfig
+      - name: auth-codecov-token
+        secret:
+          secretName: auth-codecov-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+
+
   istio/broker:
+
   - name: broker-postsubmit
     agent: kubernetes
     branches:
@@ -967,12 +1577,13 @@ postsubmits:
         secret:
           secretName: oauth-token
 
+
   istio/mixer:
+
   - name: mixer-postsubmit
     agent: kubernetes
     branches:
     - master
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.2
@@ -1016,12 +1627,60 @@ postsubmits:
         secret:
           secretName: oauth-token
 
+  - name: mixer-postsubmit
+    agent: kubernetes
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=30"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: mixer-codecov-token
+          mountPath: /etc/codecov
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: mixer-codecov-token
+        secret:
+          secretName: mixer-codecov-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+
+
   istio/pilot:
+
   - name: pilot-postsubmit
     agent: kubernetes
     branches:
     - master
-    - release-0.2
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.3.2
@@ -1070,7 +1729,60 @@ postsubmits:
         secret:
           secretName: oauth-token
 
+  - name: pilot-postsubmit
+    agent: kubernetes
+    branches:
+    - release-0.2
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.2.1
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=60"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: pilot-e2e-rbac-kubeconfig
+          mountPath: /home/bootstrap/.kube
+        - name: pilot-codecov-token
+          mountPath: /etc/codecov
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "20Gi"
+            cpu: "5000m"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: build-pool
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: pilot-e2e-rbac-kubeconfig
+        secret:
+          secretName: pilot-e2e-rbac-kubeconfig
+      - name: pilot-codecov-token
+        secret:
+          secretName: pilot-codecov-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+
 periodics:
+
 - interval: 2h
   agent: kubernetes
   name: test-infra-cleanup-cluster


### PR DESCRIPTION
Removing support for 0.1 as we won't be created patch release for it.

Created specific jobs for 0.2 as we updated bazel in master which is incompatible with 0.2

```release-note
none
```
