### PR TITLE
Experiment working but not compatible with gubernator

### DIFF
--- a/docker/prowbuilder/Makefile
+++ b/docker/prowbuilder/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.1.1
+VERSION = 0.1.9
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -323,7 +323,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbuilder:0.1.1
+      - image: gcr.io/istio-testing/prowbuilder:0.1.9
         args:
         - "--timeout=15"
         # Bazel needs privileged mode in order to sandbox builds.


### PR DESCRIPTION
The experiment is successful with a few caveats:
1. Repo is called before bootstrap and therefore no logs will be provided to user to understand issue
2. Since repo is doing the checkout, bootstrap does not know that where to put the logs. 

The final solution would be to update bootstrap to use repo to checkout the code.

```release-note
none
```
