### PR TITLE
Release-note collector - release branch support

### DIFF
--- a/toolbox/release_note_collector/main.go
+++ b/toolbox/release_note_collector/main.go
@@ -45,6 +45,7 @@ var (
 	previousRelease = flag.String("previous_release", "", "Previous release")
 	currentRelease  = flag.String("current_release", "", "Current release")
 	prLink          = flag.Bool("pr_link", false, "Weather a link of the PR is added at the end of each release note")
+	branch          = flag.String("branch", "master", "Commit branch, master or release branch")
 	gh              *u.GithubClient
 )
 
@@ -156,6 +157,7 @@ func createQueryString(repo string) ([]string, error) {
 	queries = addQuery(queries, "is", "merged")
 	queries = addQuery(queries, "type", "pr")
 	queries = addQuery(queries, "merged", startTime, "..", endTime)
+	queries = addQuery(queries, "base", *branch)
 
 	return queries, nil
 }


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
