### PR TITLE
Release-note collector uses tag creation time as the cut off time

### DIFF
--- a/release-note
+++ b/release-note
@@ -1,0 +1,10 @@
+
+istio/istio: 0.2.7 -- 0.2.9
+
+istio/mixer: 0.2.7 -- 0.2.9
+
+istio/pilot: 0.2.7 -- 0.2.9
+* When a pod uses hostNetwork: true, the pod will be disabled from side car injection on purpose because we don't want the envoy side car to change the network configuration at the host level.  https://github.com/istio/pilot/pull/1453
+
+istio/auth: 0.2.7 -- 0.2.9
+* Standalone node agent path fix (debian)  https://github.com/istio/auth/pull/301

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -50,17 +50,10 @@ const (
 	debianSuffix         = "deb"
 )
 
-// Exit if value not specified
-func assertNotEmpty(name string, value *string) {
-	if value == nil || *value == "" {
-		log.Fatalf("%s must be specified\n", name)
-	}
-}
-
 func fastForward(repo, baseBranch, refSHA *string) error {
-	assertNotEmpty("repo", repo)
-	assertNotEmpty("base_branch", baseBranch)
-	assertNotEmpty("ref_sha", refSHA)
+	u.AssertNotEmpty("repo", repo)
+	u.AssertNotEmpty("base_branch", baseBranch)
+	u.AssertNotEmpty("ref_sha", refSHA)
 	isAncestor, err := githubClnt.SHAIsAncestorOfBranch(*repo, masterBranch, *refSHA)
 	if err != nil {
 		return err
@@ -86,7 +79,7 @@ func processIstioVersion(content *string) map[string]string {
 }
 
 func getReleaseTag() (string, error) {
-	assertNotEmpty("base_branch", baseBranch)
+	u.AssertNotEmpty("base_branch", baseBranch)
 	releaseTag, err := githubClnt.GetFileContent(istioRepo, *baseBranch, releaseTagFile)
 	if err != nil {
 		return "", err
@@ -96,7 +89,7 @@ func getReleaseTag() (string, error) {
 
 // TagIstioDepsForRelease creates release tag on each dependent repo of istio
 func TagIstioDepsForRelease() error {
-	assertNotEmpty("base_branch", baseBranch)
+	u.AssertNotEmpty("base_branch", baseBranch)
 	log.Printf("Fetching and processing istio.VERSION\n")
 	istioVersion, err := githubClnt.GetFileContent(istioRepo, *baseBranch, istioVersionFile)
 	if err != nil {
@@ -153,7 +146,7 @@ func TagIstioDepsForRelease() error {
 }
 
 func cloneIstioMakePR(newBranch, prTitle, prBody string, edit func() error) error {
-	assertNotEmpty("base_branch", baseBranch)
+	u.AssertNotEmpty("base_branch", baseBranch)
 	log.Printf("Cloning istio to local and checkout %s\n", *baseBranch)
 	repoDir, err := u.CloneRepoCheckoutBranch(githubClnt, istioRepo, *baseBranch, newBranch)
 	if err != nil {
@@ -183,7 +176,7 @@ func cloneIstioMakePR(newBranch, prTitle, prBody string, edit func() error) erro
 // UpdateIstioVersionAfterReleaseTagsMadeOnDeps runs updateVersion.sh to update
 // istio.VERSION and then create a PR on istio
 func UpdateIstioVersionAfterReleaseTagsMadeOnDeps() error {
-	assertNotEmpty("base_branch", baseBranch)
+	u.AssertNotEmpty("base_branch", baseBranch)
 	releaseTag, err := getReleaseTag()
 	if err != nil {
 		return err
@@ -212,9 +205,9 @@ func UpdateIstioVersionAfterReleaseTagsMadeOnDeps() error {
 
 // CreateIstioReleaseUploadArtifacts creates a release on istio from the refSHA provided and uploads dependent artifacts
 func CreateIstioReleaseUploadArtifacts() error {
-	assertNotEmpty("ref_sha", refSHA)
-	assertNotEmpty("base_branch", baseBranch)
-	assertNotEmpty("next_release", nextRelease)
+	u.AssertNotEmpty("ref_sha", refSHA)
+	u.AssertNotEmpty("base_branch", baseBranch)
+	u.AssertNotEmpty("next_release", nextRelease)
 	releaseTag, err := getReleaseTag()
 	if releaseTag == *nextRelease {
 		return fmt.Errorf("next_release should be greater than the current release")
@@ -247,7 +240,7 @@ func CreateIstioReleaseUploadArtifacts() error {
 
 func init() {
 	flag.Parse()
-	assertNotEmpty("token_file", tokenFile)
+	u.AssertNotEmpty("token_file", tokenFile)
 	token, err := u.GetAPITokenFromFile(*tokenFile)
 	if err != nil {
 		log.Fatalf("Error accessing user supplied token_file: %v\n", err)

--- a/toolbox/metrics/buildFreshness/buildFreshness.go
+++ b/toolbox/metrics/buildFreshness/buildFreshness.go
@@ -35,19 +35,19 @@ type DepFreshness struct {
 	Age time.Duration
 }
 
-func getBranchHeadTime(githubClnt *u.GithubClient, repo, branch string) (*time.Time, error) {
+func getBranchHeadTime(githubClnt *u.GithubClient, repo, branch string) (time.Time, error) {
 	sha, err := githubClnt.GetHeadCommitSHA(repo, branch)
 	if err != nil {
-		return nil, err
+		return time.Time{}, err
 	}
 	t, err := githubClnt.GetCommitCreationTime(repo, sha)
 	if err != nil {
-		return nil, err
+		return time.Time{}, err
 	}
 	return t, nil
 }
 
-func getCommitCreationTimeByRef(githubClnt *u.GithubClient, repo, ref string) (*time.Time, error) {
+func getCommitCreationTimeByRef(githubClnt *u.GithubClient, repo, ref string) (time.Time, error) {
 	if u.SHARegex.MatchString(ref) {
 		return githubClnt.GetCommitCreationTime(repo, ref)
 	} else if u.ReleaseTagRegex.MatchString(ref) {
@@ -55,7 +55,7 @@ func getCommitCreationTimeByRef(githubClnt *u.GithubClient, repo, ref string) (*
 	}
 	err := fmt.Errorf(
 		"reference must be a SHA or release tag to get creation time, but was instead %s", ref)
-	return nil, err
+	return time.Time{}, err
 }
 
 func getAgeMetric(githubClnt *u.GithubClient, dep *u.Dependency) (*DepFreshness, error) {
@@ -73,7 +73,7 @@ func getAgeMetric(githubClnt *u.GithubClient, dep *u.Dependency) (*DepFreshness,
 			dep.ProdBranch, dep.RepoName, err)
 		return nil, e
 	}
-	lag := latestTime.Sub(*stableTime)
+	lag := latestTime.Sub(stableTime)
 	return &DepFreshness{*dep, lag}, nil
 }
 

--- a/toolbox/release_note_collector/main.go
+++ b/toolbox/release_note_collector/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/github"
 	u "istio.io/test-infra/toolbox/util"
@@ -187,7 +188,7 @@ func addQuery(queries []string, queryParts ...string) []string {
 }
 
 func getReleaseTime(repo, release string) (string, error) {
-	time, err := gh.GetReleaseCreationTime(repo, release)
+	time, err := getReleaseTagCreationTime(repo, release)
 	if err != nil {
 		log.Println("Failed to get created time of this release tag")
 		return "", err
@@ -197,4 +198,18 @@ func getReleaseTime(repo, release string) (string, error) {
 		t.Year(), t.Month(), t.Day(),
 		t.Hour(), t.Minute(), t.Second())
 	return timeString, nil
+}
+
+// getReleaseCreationTime gets the creation time of a release tag (0.1.6, 0.2.7)
+func getReleaseTagCreationTime(repo, tag string) (createTime time.Time, err error) {
+	if repo == "istio" {
+		createTime, err = gh.GetReleaseTagCreationTime(repo, tag)
+	} else {
+		createTime, err = gh.GetannotatedTagCreationTime(repo, tag)
+	}
+	if err != nil {
+		log.Printf("Cannot get the creation time of %s/%s", repo, tag)
+		return time.Time{}, err
+	}
+	return createTime, nil
 }

--- a/toolbox/release_note_collector/main.go
+++ b/toolbox/release_note_collector/main.go
@@ -45,6 +45,7 @@ var (
 	previousRelease = flag.String("previous_release", "", "Previous release")
 	currentRelease  = flag.String("current_release", "", "Current release")
 	prLink          = flag.Bool("pr_link", false, "Weather a link of the PR is added at the end of each release note")
+	branch          = flag.String("branch", "master", "Commit branch, master or release branch")
 	gh              *u.GithubClient
 )
 
@@ -156,6 +157,7 @@ func createQueryString(repo string) ([]string, error) {
 	queries = addQuery(queries, "is", "merged")
 	queries = addQuery(queries, "type", "pr")
 	queries = addQuery(queries, "merged", startTime, "..", endTime)
+	queries = addQuery(queries, "base", *branch)
 
 	return queries, nil
 }

--- a/toolbox/util/commonUtils.go
+++ b/toolbox/util/commonUtils.go
@@ -150,3 +150,10 @@ func FillUpTemplate(t string, i interface{}) (string, error) {
 	}
 	return wr.String(), nil
 }
+
+// AssertNotEmpty check if a value is empty, exit if value not specified
+func AssertNotEmpty(name string, value *string) {
+	if value == nil || *value == "" {
+		log.Fatalf("%s must be specified\n", name)
+	}
+}

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -252,7 +252,7 @@ func (g GithubClient) CloseIdlePullRequests(prTitlePrefix, repo, baseBranch stri
 	return multiErr
 }
 
-// GetReferenceSHAAndType finds the SHA of the commit to which the HEAD of branch points
+// GetHeadCommitSHA finds the SHA of the commit to which the HEAD of branch points
 func (g GithubClient) GetHeadCommitSHA(repo, branch string) (string, error) {
 	sha, _, err := g.GetReferenceSHAAndType(repo, "refs/heads/"+branch)
 	return sha, err
@@ -433,7 +433,7 @@ func (g GithubClient) CreateReleaseUploadArchives(repo, releaseTag, sha, archive
 	return nil
 }
 
-// GetReference returns the sha of a reference
+// GetReferenceSHAAndType returns the sha of a reference
 func (g GithubClient) GetReferenceSHAAndType(repo, ref string) (string, string, error) {
 	githubRefObj, _, err := g.client.Git.GetRef(
 		context.Background(), g.owner, repo, ref)


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

fixes https://github.com/istio/test-infra/issues/563

Instead of commit time, use creation time of release tag(e.g. 0.1.6, 0.2.7) as the cut off time