### PR TITLE
Update repos names in auto-dep-update tool due to restructuring

### DIFF
--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -35,7 +35,7 @@ git config --global user.name "istio-bot"
 TOKEN_PATH="/etc/github/oauth"
 # List of repo where auto dependency update has been enabled
 # excluding istio/istio
-repos=( mixer mixerclient pilot proxy )
+repos=( old_mixer_repo mixerclient old_pilot_repo proxy )
 
 echo "=== Updating Dependency of Istio ==="
 ./bazel-bin/toolbox/deps_update/deps_update \


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
