### PR TITLE
Continue rather than abort if branch deletion failed

### DIFF
--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -151,7 +151,7 @@ func updateDependenciesOf(repo string) error {
 	// if branch exists, stop here and do not create another PR of identical delta
 	if err = githubClnt.CloseIdlePullRequests(
 		prTitlePrefix, repo, *baseBranch); exists || err != nil {
-		return err
+		log.Printf("error while closing idle PRs: %v\n", err)
 	}
 	if _, err = u.Shell("git checkout -b " + branch); err != nil {
 		return err


### PR DESCRIPTION
Auto dependency update on pilot has been failing in the past 2 days. One example run can be found at https://k8s-gubernator.appspot.com/build/istio-prow/test-infra-update-deps/1099/

```
W1102 01:21:06.472] 2017/11/02 01:21:06 Deleting branch autoUpdateDeps_e55af73d48d09bc7fefcdf8bf753b8b9
W1102 01:21:06.574] 2017/11/02 01:21:06 Failed to delete branch autoUpdateDeps_e55af73d48d09bc7fefcdf8bf753b8b9 in repo old_pilot_repo
...
...
W1102 01:21:16.052] 2017/11/02 01:21:16 Failed to udpate dependency: 2 errors occurred:
W1102 01:21:16.052] 
W1102 01:21:16.052] * DELETE https://api.github.com/repos/istio/old_pilot_repo/git/refs/heads/autoUpdateDeps_2a40be6f9552294f0abe7d8258c50d52: 404 Not Found []
W1102 01:21:16.052] * DELETE https://api.github.com/repos/istio/old_pilot_repo/git/refs/heads/autoUpdateDeps_e55af73d48d09bc7fefcdf8bf753b8b9: 404 Not Found []
```

The issue is likely authorization/privilege related. The go github client lib returns unhelpful 404 when the caller is not authorized to do what it tries to. It really isn't a 404 because
* branch `autoUpdateDeps_2a40be6f9552294f0abe7d8258c50d52` and `autoUpdateDeps_e55af73d48d09bc7fefcdf8bf753b8b9` still exists in pilot https://github.com/istio/old_pilot_repo/branches/active.
* The endpoint does exist as the script has successfully deleted branches in istio/istio as shown from log
```
W1102 01:20:50.661] 2017/11/02 01:20:50 Closing PR istio/istio#1303
W1102 01:20:51.240] 2017/11/02 01:20:51 Deleting branch autoUpdateDeps_8cf249f1a8b542fc3a6e810360b984a6
W1102 01:20:52.439] 2017/11/02 01:20:52 Closing PR istio/istio#1303
W1102 01:20:52.884] 2017/11/02 01:20:52 Closing PR istio/istio#1301
W1102 01:20:53.229] 2017/11/02 01:20:53 Closing PR istio/istio#1299
...
```

This PR is a temp workaround so that pilot may still update its dependencies even when branch deletion fails (which is not a fatal error anyway). Perhaps it has something to do with the repo reorg going on right now. @sebastienvas you may also go ahead and delete those two branches and I will continue monitoring issues like this. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
