### PR TITLE
Fix updateVersion commandline args in release tool

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -167,7 +167,7 @@ func UpdateIstioVersionAfterReleaseTagsMadeOnDeps() error {
 		// Pilot
 		cmd += fmt.Sprintf(" -p %s -i %s -P %s", hubCommaTag, istioctlURL, debianURL)
 		// Proxy
-		cmd += fmt.Sprintf(" -r %s -E %s", hubCommaTag, debianURL)
+		cmd += fmt.Sprintf(" -r %s -E %s", releaseTag, debianURL)
 		_, err := u.Shell(cmd)
 		return err
 	}


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
