### PR TITLE
Increase build timeout limit after mono repo reorg

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -384,7 +384,7 @@ presubmits:
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
-        - "--timeout=15"
+        - "--timeout=60"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -576,7 +576,7 @@ presubmits:
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
-        - "--timeout=15"
+        - "--timeout=60"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true


### PR DESCRIPTION
Previous timeout limit was set before mono repo structure, which is no longer enough and causes builds to abort prematurely as seen in https://github.com/istio/istio/pull/1405

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
