### PR TITLE
Skip report on auto-merge_master

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -428,8 +428,7 @@ presubmits:
       always_run: true
       rerun_command: "/test auto-merge_master"
       trigger: "(?m)^/(retest|test (all|auto-merge_master))?,?(\\s+|$)"
-      branches:
-      - master
+      skip_report: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.3.1


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
