### PR TITLE
Skip updating doeanload script in other branches if flag not given

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -216,13 +216,14 @@ func CreateIstioReleaseUploadArtifacts() error {
 	if err != nil {
 		return err
 	}
-
-	extraBranches := strings.Split(*extraBranchesUpdateDownloadVersion, ",")
-	for _, branch := range extraBranches {
-		localBranch := fmt.Sprintf("%s-local", branch)
-		if err := githubClnt.CreatePRUpdateRepo(localBranch, branch, istioRepo, prTitle, prBody, updateVersion); err != nil {
-			// Only log out errors if failing update extra branches
-			log.Printf("Warning! Failed to update downloadIstioCandidate.sh in branch %s", branch)
+	if *extraBranchesUpdateDownloadVersion != "" {
+		extraBranches := strings.Split(*extraBranchesUpdateDownloadVersion, ",")
+		for _, branch := range extraBranches {
+			localBranch := fmt.Sprintf("%s-local", branch)
+			if err := githubClnt.CreatePRUpdateRepo(localBranch, branch, istioRepo, prTitle, prBody, updateVersion); err != nil {
+				// Only log out errors if failing update extra branches
+				log.Printf("Warning! Failed to update downloadIstioCandidate.sh in branch %s", branch)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Minor error when making latest release. Fixed in this PR.

```
[finalizeRelease-0.2.11 418491fe] finalizeRelease-0.2.11
2 files changed, 2 insertions(+), 2 deletions(-)
2017/11/06 11:49:03 Running command git push -f --set-upstream origin finalizeRelease-0.2.11
2017/11/06 11:49:06 Command output: 
To https://github.com/istio/istio.git
* [new branch]        finalizeRelease-0.2.11 -> finalizeRelease-0.2.11
Branch 'finalizeRelease-0.2.11' set up to track remote branch 'finalizeRelease-0.2.11' from 'origin'.
2017/11/06 11:49:06 Creating a PR with Title: "[Auto Release] Finalize release 0.2.11 on istio" for repo istio
2017/11/06 11:49:06 Created new PR at https://github.com/istio/istio/pull/1553
2017/11/06 11:49:06 Cloning istio to local and checkout 
2017/11/06 11:49:11 Command output: 
Cloning into 'istio'...
2017/11/06 11:49:11 Running command git checkout 
2017/11/06 11:49:11 Command output: 
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
2017/11/06 11:49:11 Warning! Failed to update downloadIstioCandidate.sh in branch
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
