### PR TITLE
Introduce tide into test-infra

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10,6 +10,10 @@ sinker:
 prowjob_namespace: default
 pod_namespace: test-pods
 
+tide:
+  queries:
+  - "type:pr state:open repo:istio/test-infra label:lgtm label:approved -label:needs-ok-to-test -label:do-not-merge -label:do-not-merge/release-note-label-needed -label:do-not-merge/hold label:\"cla: yes\""
+
 presubmits:
   # PR job triggering definitions.
   # Keys: Full repo name: "org/repo".

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -72,6 +72,7 @@ plugins:
   - hold
 
   istio/test-infra:
+  - approve
   - assign
   - trigger
   - config-updater


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
