### PR TITLE
Update plugins.yaml

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -73,7 +73,6 @@ plugins:
   - hold
 
   istio/test-infra:
-  - approve
   - assign
   - trigger
   - config-updater


### PR DESCRIPTION
@yutongz hook complains that the approve plugin does not exist. @chxchx this might be the reason that PR are not working on istio-release.
```release-note
none
```
