### PR TITLE
Upgrade Golang version. New changes in Mixer needs latest Golang

### DIFF
--- a/scripts/tools/linux-install-golang
+++ b/scripts/tools/linux-install-golang
@@ -8,7 +8,7 @@ fi
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
 
-GO_VERSION='1.8'
+GO_VERSION='1.9'
 GO_BASE_URL="https://storage.googleapis.com/golang"
 GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"


### PR DESCRIPTION
Currently it works because we are using bazel build and that installs 1.9 version of go,
However, for other steps (doing go build and go test outside bazel) we need latest version of go installed on the test machine.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
