### PR TITLE
update presubmits to pick up required go 1.9

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,7 +43,7 @@ presubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -867,7 +867,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -969,7 +969,7 @@ postsubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.1
+      - image: gcr.io/istio-testing/prowbazel:0.3.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"


### PR DESCRIPTION
Pick up the latest docker image with 1.9 go version

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
