### PR TITLE
enable bots for mixerclient and proxy

### DIFF
--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -38,9 +38,7 @@ TOKEN_PATH="/etc/github/oauth"
 case ${GIT_BRANCH} in
   master)
     repos=( mixerclient proxy )
-    # disable for now until prow/jenkins for mixerclient and proxy is fixed as per request from wayne
     # TODO need to enable for istio/istio
-    exit 0
     ;;
   release-0.2)
     repos=( old_mixer_repo mixerclient old_pilot_repo proxy )


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
