### PR TITLE
Enable daily-release cluster rotation creation

### DIFF
--- a/scripts/update-e2e-cluster.sh
+++ b/scripts/update-e2e-cluster.sh
@@ -55,7 +55,7 @@ done
 
 if [ "${REPO}" != 'auth' ] && [ "${REPO}" != 'broker' ] && [ "${REPO}" != 'istio' ] \
   && [ "${REPO}" != 'mixer' ] && [ "${REPO}" != 'pilot' ] && [ "${REPO}" != 'daily-release' ]; then
-  echo 'Must specific a repo and it must be auth/brokeristio/pilot/mixer/daily-release'
+  echo 'Must specific a repo and it must be auth/broker/istio/pilot/mixer/daily-release'
   exit 1
 fi
 

--- a/scripts/update-e2e-cluster.sh
+++ b/scripts/update-e2e-cluster.sh
@@ -53,8 +53,9 @@ while getopts :r:z:n: arg; do
   esac
 done
 
-if [ "${REPO}" != 'auth' ] && [ "${REPO}" != 'broker' ] && [ "${REPO}" != 'istio' ] && [ "${REPO}" != 'mixer' ] && [ "${REPO}" != 'pilot' ]; then
-  echo 'Must specific a repo and it must be auth/brokeristio/pilot/mixer'
+if [ "${REPO}" != 'auth' ] && [ "${REPO}" != 'broker' ] && [ "${REPO}" != 'istio' ] \
+  && [ "${REPO}" != 'mixer' ] && [ "${REPO}" != 'pilot' ] && [ "${REPO}" != 'daily-release' ]; then
+  echo 'Must specific a repo and it must be auth/brokeristio/pilot/mixer/daily-release'
   exit 1
 fi
 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
