### PR TITLE
remove release-note check from istio

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -27,7 +27,6 @@ plugins:
   - assign
   - trigger
   - close
-  - release-note
   - reopen
   - lgtm
   - hold
@@ -50,7 +49,6 @@ plugins:
   istio/istio:
   - assign
   - trigger
-  - release-note
   - close
   - reopen
   - lgtm
@@ -59,7 +57,6 @@ plugins:
   istio/mixerclient:
   - assign
   - trigger
-  - release-note
   - close
   - reopen
   - lgtm
@@ -68,7 +65,6 @@ plugins:
   istio/proxy:
   - assign
   - trigger
-  - release-note
   - close
   - reopen
   - lgtm
@@ -77,7 +73,6 @@ plugins:
   istio/old_mixer_repo:
   - assign
   - trigger
-  - release-note
   - close
   - reopen
   - lgtm
@@ -86,7 +81,6 @@ plugins:
   istio/old_pilot_repo:
   - assign
   - trigger
-  - release-note
   - close
   - reopen
   - lgtm
@@ -96,7 +90,6 @@ plugins:
   - assign
   - trigger
   - config-updater
-  - release-note
   - close
   - reopen
   - lgtm


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
Fixes https://github.com/istio/istio/issues/2201
