### PR TITLE
Upgrade prowbazel to 0.3.3

### DIFF
--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.3.2
+VERSION = 0.3.3
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -24,6 +24,6 @@ Long term, if we use `bootstrap.py`, it would be prudent to push these changes u
 
 Our dependency on this script is because it appropariately writes test job results to a GCS bucket in such a way that gubernator (a basic UI k8s test-infra run to view job results) understands. The specification of this structure is inherent in bootstrap.py and the gubernator front-end.
 
-### Update log
+### Upgrade log
 
 * 0.3.3: golang 1.8 -> 1.9

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -24,3 +24,6 @@ Long term, if we use `bootstrap.py`, it would be prudent to push these changes u
 
 Our dependency on this script is because it appropariately writes test job results to a GCS bucket in such a way that gubernator (a basic UI k8s test-infra run to view job results) understands. The specification of this structure is inherent in bootstrap.py and the gubernator front-end.
 
+### Update log
+
+* 0.3.3: golang 1.8 -> 1.9

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -91,7 +91,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -305,7 +305,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -355,7 +355,7 @@ presubmits:
       max_concurrency: 8
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.3.2
+        - image: gcr.io/istio-testing/prowbazel:0.3.3
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -398,7 +398,7 @@ presubmits:
       trigger: "(?m)^/test (e2e-smoke)?,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.3.2
+        - image: gcr.io/istio-testing/prowbazel:0.3.3
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -960,7 +960,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -1009,7 +1009,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -1060,7 +1060,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -1111,7 +1111,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -1162,7 +1162,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -1213,7 +1213,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -1259,7 +1259,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -1307,7 +1307,7 @@ postsubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -1350,7 +1350,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -1396,7 +1396,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.3.2
+        - image: gcr.io/istio-testing/prowbazel:0.3.3
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1441,7 +1441,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.3.2
+        - image: gcr.io/istio-testing/prowbazel:0.3.3
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1486,7 +1486,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.3.2
+        - image: gcr.io/istio-testing/prowbazel:0.3.3
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1694,7 +1694,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.3.2
+      - image: gcr.io/istio-testing/prowbazel:0.3.3
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -1738,7 +1738,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1770,7 +1770,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1802,7 +1802,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1834,7 +1834,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1866,7 +1866,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1898,7 +1898,7 @@ periodics:
   name: test-infra-cleanup-GKE
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1925,7 +1925,7 @@ periodics:
   name: test-infra-update-deps
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1959,7 +1959,7 @@ periodics:
   name: test-infra-update-deps
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.3.2
+    - image: gcr.io/istio-testing/prowbazel:0.3.3
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

Bump golang 1.8 -> 1.9
