### PR TITLE
disable master bot to istio

### DIFF
--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -37,7 +37,8 @@ TOKEN_PATH="/etc/github/oauth"
 # excluding istio/istio
 case ${GIT_BRANCH} in
   master)
-    repos=( istio mixerclient proxy )
+    #repos=( istio mixerclient proxy ) TODO put this back and enable istio
+    repos=(        mixerclient proxy )
     ;;
   release-0.2)
     repos=( old_mixer_repo mixerclient old_pilot_repo proxy )


### PR DESCRIPTION
Disable until the build related changes off of bazel are finished.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
