### PR TITLE
Add cleanup template back

### DIFF
--- a/scripts/cleanup-cache
+++ b/scripts/cleanup-cache
@@ -8,7 +8,7 @@ DIR="${ROOT}/scripts"
 ARGS=()
 
 CLUSTER_NAME='jenkins-cluster'
-JOB_TEMPLATE="${ROOT}/k8s/jenkins/cleanup/cleanup.yaml.template"
+JOB_TEMPLATE="${ROOT}/scripts/cleanup.yaml.template"
 PROJECT_ID='istio-testing'
 SELECTOR='role=build'
 TMP_DIR="$(mktemp -d /tmp/bazel-cleanup.XXXXX)"

--- a/scripts/cleanup.yaml.template
+++ b/scripts/cleanup.yaml.template
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cache-cleanup-{UUID}
+spec:
+  template:
+    metadata:
+      name: cache-cleanup-{UUID}
+    spec:
+      containers:
+      - name: cache-cleanup
+        image: ubuntu:xenial
+        command: ["bash", "-c", "rm -rf /root/.cache/*"]
+        volumeMounts:
+        - name: cache-ssd
+          mountPath: /root/.cache
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: {CLUSTER_NODE}
+      volumes:
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

This cleanup cache in CI machine template was deleted in https://github.com/istio/test-infra/pull/618. But we still need this for https://github.com/istio/test-infra/blob/master/scripts/cleanup-cache#L11

