### PR TITLE
Auto-dep-update: cleanup before check

### DIFF
--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -266,7 +266,7 @@ func (g GithubClient) GetPRTestResults(repo string, pr *github.PullRequest, verb
 // remote branches from which the PRs are made
 func (g GithubClient) CloseIdlePullRequests(prTitlePrefix, repo, baseBranch string) error {
 	log.Printf("If any, close failed auto PRs to update dependencies in repo %s", repo)
-	idleTimeout := time.Hour * 6
+	idleTimeout := time.Hour * 3
 	var multiErr error
 	checkPR := func(prState string) {
 		options := github.PullRequestListOptions{


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

https://github.com/istio/proxy/pull/769

When doing dep-update, when the formal PR is not old enough to be close, the tool doesn't simply return, instead it force commits to that branch again and make Prow removes the "lgtm" label and go to a dead loop.

Thanks @rkpagadala pointing it out!

/cc @chxchx 
