### PR TITLE
Stop proxy from update-deps until it's stable

### DIFF
--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -38,7 +38,7 @@ TOKEN_PATH="/etc/github/oauth"
 case ${GIT_BRANCH} in
   master)
     #repos=( istio mixerclient proxy ) TODO put this back and enable istio
-    repos=(        mixerclient proxy )
+    repos=( mixerclient )
     ;;
   release-0.2)
     repos=( old_mixer_repo mixerclient old_pilot_repo proxy )


### PR DESCRIPTION
It seems proxy-presubmit is constantly failing. Since it's holiday season, should we just disable auto-PR for now. I think it created too many useless PRs in proxy repo. WDYT, @rkpagadala 