### PR TITLE
increase timeout for green build

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2001,7 +2001,7 @@ periodics:
       - --repo-manifest=https://github.com/istio/manifest,master
       - --repo=green-build
       - --clean
-      - --timeout=60
+      - --timeout=120
       image: gcr.io/istio-testing/prow-builder:0.4.5
       ports:
       - containerPort: 9999


### PR DESCRIPTION
green build not finishing in 1 hour  with new build changes, because of lack of cache