### PR TITLE
Add /opt/go/bin to PATH in Prow Base Image

### DIFF
--- a/docker/prowbazel/Dockerfile
+++ b/docker/prowbazel/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod +x /tmp/istio_tmp/scripts/linux-install-software
 RUN /tmp/istio_tmp/scripts/linux-install-software \
     && rm -rf /tmp/istio_tmp
 
-ENV PATH /usr/local/go/bin:/usr/lib/google-cloud-sdk/bin:${PATH}
+ENV PATH /usr/local/go/bin:/usr/lib/google-cloud-sdk/bin:/opt/go/bin:${PATH}
 
 # Create bootstrap user
 ENV HOME /home/bootstrap

--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.4.1
+VERSION = 0.4.2
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -32,3 +32,4 @@ Our dependency on this script is because it appropariately writes test job resul
 * 0.3.6: add fpm and its ruby dependencies
 * 0.4.0: update bazel to 0.10.0
 * 0.4.1: add go-junit-report
+* 0.4.2: add /opt/go/bin to PATH

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -91,7 +91,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -122,7 +122,7 @@ presubmits:
     trigger: "(?m)^/test (istio-unit-tests)?,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -164,7 +164,7 @@ presubmits:
     - release-1.0
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -197,7 +197,7 @@ presubmits:
       max_concurrency: 8
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.4.1
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -254,7 +254,7 @@ presubmits:
       trigger: "(?m)^/test (e2e-simple)?,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.4.1
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -287,7 +287,7 @@ presubmits:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -319,7 +319,7 @@ presubmits:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -351,7 +351,7 @@ presubmits:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -384,7 +384,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -433,7 +433,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -502,7 +502,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -537,7 +537,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -606,7 +606,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -641,7 +641,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -700,7 +700,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/istio-releases/daily-release=$(PULL_REFS)"
         - "--clean"
@@ -731,7 +731,7 @@ postsubmits:
     - release-0.2
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -771,7 +771,7 @@ postsubmits:
     - release-1.0
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.1
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--clean"
@@ -800,7 +800,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.4.1
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -828,7 +828,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.4.1
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -856,7 +856,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/istio-testing/prowbazel:0.4.1
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
           args:
           - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -933,7 +933,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.1
+    - image: gcr.io/istio-testing/prowbazel:0.4.2
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -963,7 +963,7 @@ periodics:
   name: test-infra-cleanup-cluster
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.1
+    - image: gcr.io/istio-testing/prowbazel:0.4.2
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -993,7 +993,7 @@ periodics:
   name: test-infra-cleanup-GKE
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.1
+    - image: gcr.io/istio-testing/prowbazel:0.4.2
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"
@@ -1018,7 +1018,7 @@ periodics:
   name: test-infra-update-deps
   spec:
     containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.1
+    - image: gcr.io/istio-testing/prowbazel:0.4.2
       args:
       - "--repo=github.com/istio/test-infra=master"
       - "--clean"


### PR DESCRIPTION
Required to make go-junit-report binary accessible in prow base image. Helps unblock https://github.com/istio/istio/pull/3542