### PR TITLE
disable istio repo bot in test-infra-update-deps.sh

### DIFF
--- a/prow/test-infra-update-deps.sh
+++ b/prow/test-infra-update-deps.sh
@@ -42,6 +42,8 @@ case ${GIT_BRANCH} in
     hour=`date "+%I"` #( 1..12)
     day_of_week=`date "+%u"` #( 1..7)
     repos=( proxy )
+    hour=25 #disable bot for istio repo, its broken now
+    # TODO need to update the bot for istio after fixing it
     case ${hour} in
       02|04|06|08|10|12)
 	./bazel-bin/toolbox/deps_update/deps_update \


### PR DESCRIPTION
Three has been a change in the istio repo. It is using submodules and therefore the dependency bot needs new code to follow the new workflow.
Among many things it needs to run 
 make -n depend.update DEPARGS="--update istio.io/api"


