### PR TITLE
Enabling mason for master and next releases

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -250,12 +250,126 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|istio-presubmit))?,?(\\s+|$)"
     branches:
     - master
-    - release-0.5
-    - release-0.6
     - release-0.7
     - release-0.8
     - release-0.9
     - release-1.0
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=60"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /home/bootstrap/.kube
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: kubeconfig
+        secret:
+          secretName: istio-e2e-rbac-kubeconfig
+    run_after_success:
+    - name: istio-pilot-e2e
+      agent: kubernetes
+      context: prow/istio-pilot-e2e.sh
+      rerun_command: "/test istio-pilot-e2e"
+      trigger: "(?m)^/test (istio-pilot-e2e)?,?(\\s+|$)"
+      max_concurrency: 8
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+    - name: e2e-bookInfoTests
+      agent: kubernetes
+      context: prow/e2e-bookInfoTests.sh
+      rerun_command: "/test e2e-bookInfo"
+      trigger: "(?m)^/test (e2e-bookInfo)?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+    - name: e2e-simpleTests
+      agent: kubernetes
+      context: prow/e2e-simpleTests.sh
+      rerun_command: "/test e2e-simple"
+      trigger: "(?m)^/test (e2e-simple)?,?(\\s+|$)"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+
+  - name: istio-presubmit
+    agent: kubernetes
+    context: prow/istio-presubmit.sh
+    always_run: true
+    rerun_command: "/test istio-presubmit"
+    trigger: "(?m)^/(retest|test (all|istio-presubmit))?,?(\\s+|$)"
+    branches:
+    - release-0.5
+    - release-0.6
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.2
@@ -396,15 +510,10 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
     always_run: false
@@ -428,15 +537,10 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
     always_run: false
@@ -542,15 +646,10 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
     run_after_success:
     - name: daily-e2e-rbac-no_auth-skew
       agent: kubernetes
@@ -577,15 +676,10 @@ presubmits:
           - name: service
             mountPath: /etc/service-account
             readOnly: true
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
         volumes:
         - name: service
           secret:
             secretName: service-account
-        - name: kubeconfig
-          secret:
-            secretName: daily-release-e2e-rbac-kubeconfig
   - name: daily-e2e-rbac-no_auth-default
     agent: kubernetes
     context: prow/daily-e2e-rbac-no_auth-default.sh
@@ -611,15 +705,10 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
 
   - name: daily-e2e-rbac-auth
     agent: kubernetes
@@ -646,15 +735,10 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
     run_after_success:
     - name: daily-e2e-rbac-auth-skew
       agent: kubernetes
@@ -681,15 +765,10 @@ presubmits:
           - name: service
             mountPath: /etc/service-account
             readOnly: true
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
         volumes:
         - name: service
           secret:
             secretName: service-account
-        - name: kubeconfig
-          secret:
-            secretName: daily-release-e2e-rbac-kubeconfig
   - name: daily-e2e-rbac-auth-default
     agent: kubernetes
     context: prow/daily-e2e-rbac-auth-default.sh
@@ -715,15 +794,10 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
       volumes:
       - name: service
         secret:
           secretName: service-account
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
 
   - name: daily-e2e-cluster_wide-auth
     agent: kubernetes
@@ -857,12 +931,112 @@ postsubmits:
     agent: kubernetes
     branches:
     - master
-    - release-0.5
-    - release-0.6
     - release-0.7
     - release-0.8
     - release-0.9
     - release-1.0
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/prowbazel:0.4.2
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--timeout=60"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /home/bootstrap/.kube
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: kubeconfig
+        secret:
+          secretName: istio-e2e-rbac-kubeconfig
+    run_after_success:
+    - name: e2e-suite-rbac-no_auth
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+    - name: e2e-suite-rbac-auth
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+    - name: e2e-cluster_wide-auth
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.2
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+
+  - name: istio-postsubmit
+    agent: kubernetes
+    branches:
+    - release-0.5
+    - release-0.6
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.2


### PR DESCRIPTION
This PR duplicates istio presubmit and postsubmit entries such that master and future releases do not need to mount a kubeconfig and older release like 0.5 and 0.6 still use the kubeconfig.

It is also enables mason on dailies