### PR TITLE
Adding branch spec for after_success jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -286,6 +286,12 @@ presubmits:
       context: prow/istio-pilot-e2e.sh
       rerun_command: "/test istio-pilot-e2e"
       trigger: "(?m)^/test (istio-pilot-e2e)?,?(\\s+|$)"
+      branches:
+      - master
+      - release-0.7
+      - release-0.8
+      - release-0.9
+      - release-1.0
       max_concurrency: 8
       spec:
         containers:
@@ -313,6 +319,12 @@ presubmits:
       context: prow/e2e-bookInfoTests.sh
       rerun_command: "/test e2e-bookInfo"
       trigger: "(?m)^/test (e2e-bookInfo)?,?(\\s+|$)"
+      branches:
+      - master
+      - release-0.7
+      - release-0.8
+      - release-0.9
+      - release-1.0
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.2
@@ -339,6 +351,12 @@ presubmits:
       context: prow/e2e-simpleTests.sh
       rerun_command: "/test e2e-simple"
       trigger: "(?m)^/test (e2e-simple)?,?(\\s+|$)"
+      branches:
+      - master
+      - release-0.7
+      - release-0.8
+      - release-0.9
+      - release-1.0
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.2
@@ -402,6 +420,9 @@ presubmits:
       context: prow/istio-pilot-e2e.sh
       rerun_command: "/test istio-pilot-e2e"
       trigger: "(?m)^/test (istio-pilot-e2e)?,?(\\s+|$)"
+      branches:
+      - release-0.5
+      - release-0.6
       max_concurrency: 8
       spec:
         containers:
@@ -429,6 +450,9 @@ presubmits:
       context: prow/e2e-bookInfoTests.sh
       rerun_command: "/test e2e-bookInfo"
       trigger: "(?m)^/test (e2e-bookInfo)?,?(\\s+|$)"
+      branches:
+      - release-0.5
+      - release-0.6
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.2
@@ -460,6 +484,9 @@ presubmits:
       context: prow/e2e-simpleTests.sh
       rerun_command: "/test e2e-simple"
       trigger: "(?m)^/test (e2e-simple)?,?(\\s+|$)"
+      branches:
+      - release-0.5
+      - release-0.6
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.2
@@ -514,6 +541,7 @@ presubmits:
       - name: service
         secret:
           secretName: service-account
+
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
     always_run: false
@@ -541,6 +569,7 @@ presubmits:
       - name: service
         secret:
           secretName: service-account
+
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
     always_run: false
@@ -680,6 +709,7 @@ presubmits:
         - name: service
           secret:
             secretName: service-account
+
   - name: daily-e2e-rbac-no_auth-default
     agent: kubernetes
     context: prow/daily-e2e-rbac-no_auth-default.sh
@@ -769,6 +799,7 @@ presubmits:
         - name: service
           secret:
             secretName: service-account
+
   - name: daily-e2e-rbac-auth-default
     agent: kubernetes
     context: prow/daily-e2e-rbac-auth-default.sh
@@ -858,6 +889,7 @@ presubmits:
         - name: service
           secret:
             secretName: service-account
+
   - name: daily-e2e-cluster_wide-auth-default
     agent: kubernetes
     context: prow/daily-e2e-cluster_wide-auth-default.sh


### PR DESCRIPTION
According to Ben we need to add branch spec on after_success jobs in case we have duplicate entries. 