### PR TITLE
remove ISTIOCTL_URL from greenBuild.VERSION

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -264,8 +264,8 @@ func DailyReleaseQualification() error {
 		if err := u.UpdateKeyValueInFile(greenBuildVersionFile, "TIME", timestamp); err != nil {
 			return err
 		}
-		if err := u.UpdateKeyValueInFile(greenBuildVersionFile, "ISTIOCTL_URL",
-			fmt.Sprintf("https://storage.googleapis.com/%s/istioctl", *gcsPath)); err != nil {
+		if err := u.UpdateKeyValueInFile(greenBuildVersionFile, "ISTIO_REL_URL",
+			fmt.Sprintf("https://storage.googleapis.com/%s", *gcsPath)); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
remove istioctl_url, since it has multiple meanings and is not relevant