### PR TITLE
Skip updating dependency file if it is not specified

### DIFF
--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -106,6 +106,9 @@ func generateArtifactURL(repo, ref, suffix string) string {
 // Updates the list of dependencies in repo to the latest stable references
 func updateDeps(repo string, deps *[]u.Dependency, depChangeList *[]u.Dependency) error {
 	for _, dep := range *deps {
+		if dep.File == "" {
+			continue
+		}
 		if err := u.UpdateKeyValueInFile(dep.File, dep.Name, dep.LastStableSHA); err != nil {
 			return err
 		}


### PR DESCRIPTION
this allows us to just update istio.deps with new shas and not have any other dependencies, used for PROXY_TAG in istio repo