### PR TITLE
Using preset in prow config.yaml to remove duplicate code

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -46,6 +46,15 @@ presets:
   - name: service
     secret:
       secretName: service-account
+- labels:
+    preset-bazel: true
+  volumeMounts:
+  - name: cache-ssd
+    mountPath: /home/bootstrap/.cache
+  volumes:
+  - name: cache-ssd
+    hostPath:
+      path: /mnt/disks/ssd0
 
 presubmits:
   # PR job triggering definitions.
@@ -75,6 +84,7 @@ presubmits:
     - master
     labels:
       preset-service-account: true
+      preset-bazel: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -85,9 +95,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /home/bootstrap/.cache
         ports:
         - containerPort: 9999
           hostPort: 9998
@@ -100,10 +107,6 @@ presubmits:
             cpu: "5000m"
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   - name: proxy-presubmit-asan
     agent: kubernetes
@@ -115,6 +118,7 @@ presubmits:
     - master
     labels:
       preset-service-account: true
+      preset-bazel: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -125,9 +129,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /home/bootstrap/.cache
         ports:
         - containerPort: 9999
           hostPort: 9998
@@ -140,10 +141,6 @@ presubmits:
             cpu: "5000m"
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   - name: proxy-presubmit-tsan
     agent: kubernetes
@@ -155,6 +152,7 @@ presubmits:
     - master
     labels:
       preset-service-account: true
+      preset-bazel: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -165,9 +163,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /home/bootstrap/.cache
         ports:
         - containerPort: 9999
           hostPort: 9998
@@ -180,10 +175,6 @@ presubmits:
             cpu: "5000m"
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   istio/api:
 
@@ -540,6 +531,7 @@ presubmits:
     - master
     labels:
       preset-service-account: true
+      preset-bazel: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -550,9 +542,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /home/bootstrap/.cache
         ports:
         - containerPort: 9999
           hostPort: 9998
@@ -565,10 +554,6 @@ presubmits:
             cpu: "5000m"
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
   istio-releases/daily-release:
 
@@ -1123,6 +1108,7 @@ postsubmits:
     - master
     labels:
       preset-service-account: true
+      preset-bazel: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1133,9 +1119,6 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: cache-ssd
-          mountPath: /home/bootstrap/.cache
         ports:
         - containerPort: 9999
           hostPort: 9998
@@ -1148,10 +1131,6 @@ postsubmits:
             cpu: "5000m"
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
-      volumes:
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
 
 periodics:
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1178,9 +1178,6 @@ periodics:
       - name: netrc
         mountPath: /etc/netrc
         readOnly: true
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
     volumes:
     - name: netrc
       secret:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -32,6 +32,20 @@ tide:
     istio/test-infra: squash
   target_url: https://prow.istio.io/tide.html
 
+presets:
+- labels:
+    preset-service-account: true
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/service-account/service-account.json
+  volumeMounts:
+  - name: service
+    mountPath: /etc/service-account
+    readOnly: true
+  volumes:
+  - name: service
+    secret:
+      secretName: service-account
 
 presubmits:
   # PR job triggering definitions.
@@ -59,6 +73,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|proxy-presubmit))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -69,13 +85,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /home/bootstrap/.cache
         ports:
@@ -91,9 +101,6 @@ presubmits:
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -106,6 +113,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|proxy-presubmit-asan))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -116,13 +125,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /home/bootstrap/.cache
         ports:
@@ -138,9 +141,6 @@ presubmits:
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -153,6 +153,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|proxy-presubmit-tsan))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -163,13 +165,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /home/bootstrap/.cache
         ports:
@@ -185,9 +181,6 @@ presubmits:
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -202,6 +195,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|api-presubmit))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -212,17 +207,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
 
   istio/istio:
@@ -233,6 +217,8 @@ presubmits:
     always_run: true
     rerun_command: "/test istio-unit-tests"
     trigger: "(?m)^/(retest|test (all|istio-unit-tests))?,?(\\s+|$)"
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -243,20 +229,11 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         # Pilot, security unit tests require kubeconfig
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: istio-e2e-rbac-kubeconfig
@@ -273,6 +250,8 @@ presubmits:
     - release-0.8
     - release-0.9
     - release-1.0
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -283,19 +262,10 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: istio-e2e-rbac-kubeconfig
@@ -311,6 +281,8 @@ presubmits:
       - release-0.8
       - release-0.9
       - release-1.0
+      labels:
+        preset-service-account: true
       max_concurrency: 8
       spec:
         containers:
@@ -322,17 +294,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: istio-pilot-e2e
       agent: kubernetes
       context: prow/istio-pilot-e2e.sh
@@ -344,6 +305,8 @@ presubmits:
       - release-0.8
       - release-0.9
       - release-1.0
+      labels:
+        preset-service-account: true
       max_concurrency: 8
       spec:
         containers:
@@ -355,17 +318,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: e2e-bookInfoTests
       agent: kubernetes
       context: prow/e2e-bookInfoTests.sh
@@ -377,6 +329,8 @@ presubmits:
       - release-0.8
       - release-0.9
       - release-1.0
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -387,17 +341,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: e2e-simpleTests
       agent: kubernetes
       context: prow/e2e-simpleTests.sh
@@ -409,6 +352,8 @@ presubmits:
       - release-0.8
       - release-0.9
       - release-1.0
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -419,17 +364,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
 
   - name: istio-presubmit
     agent: kubernetes
@@ -440,6 +374,8 @@ presubmits:
     branches:
     - release-0.5
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -450,19 +386,10 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: istio-e2e-rbac-kubeconfig
@@ -475,6 +402,8 @@ presubmits:
       branches:
       - release-0.5
       - release-0.6
+      labels:
+        preset-service-account: true
       max_concurrency: 8
       spec:
         containers:
@@ -486,17 +415,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: e2e-bookInfoTests
       agent: kubernetes
       context: prow/e2e-bookInfoTests.sh
@@ -505,6 +423,8 @@ presubmits:
       branches:
       - release-0.5
       - release-0.6
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -515,19 +435,10 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: kubeconfig
             mountPath: /home/bootstrap/.kube
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: kubeconfig
           secret:
             secretName: istio-e2e-rbac-kubeconfig
@@ -539,6 +450,8 @@ presubmits:
       branches:
       - release-0.5
       - release-0.6
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -549,19 +462,10 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: kubeconfig
             mountPath: /home/bootstrap/.kube
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: kubeconfig
           secret:
             secretName: istio-e2e-rbac-kubeconfig
@@ -572,6 +476,8 @@ presubmits:
     rerun_command: "/test e2e-suite-rbac-no_auth"
     trigger: "(?m)^/(test e2e-suite-rbac-no_auth)?,?(\\s+|$)"
     agent: kubernetes
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -582,17 +488,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
@@ -600,6 +495,8 @@ presubmits:
     rerun_command: "/test e2e-suite-rbac-auth"
     trigger: "(?m)^/(test e2e-suite-rbac-auth)?,?(\\s+|$)"
     agent: kubernetes
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -610,17 +507,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
@@ -628,6 +514,8 @@ presubmits:
     rerun_command: "/test e2e-cluster_wide-auth"
     trigger: "(?m)^/(test e2e-cluster_wide-auth)?,?(\\s+|$)"
     agent: kubernetes
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -638,17 +526,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
 
   istio/test-infra:
@@ -661,6 +538,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|test-infra-presubmit))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -671,13 +550,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /home/bootstrap/.cache
         ports:
@@ -693,9 +566,6 @@ presubmits:
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -710,6 +580,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-no_auth))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -720,17 +592,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
     run_after_success:
     - name: daily-e2e-rbac-no_auth-skew
       agent: kubernetes
@@ -740,6 +601,8 @@ presubmits:
       trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-no_auth-skew))?,?(\\s+|$)"
       branches:
       - master
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -750,17 +613,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
 
   - name: daily-e2e-rbac-no_auth-default
     agent: kubernetes
@@ -770,6 +622,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-no_auth-default))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -780,17 +634,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
   - name: daily-e2e-rbac-auth
     agent: kubernetes
@@ -800,6 +643,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-auth))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -810,17 +655,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
     run_after_success:
     - name: daily-e2e-rbac-auth-skew
       agent: kubernetes
@@ -830,6 +664,8 @@ presubmits:
       trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-auth-skew))?,?(\\s+|$)"
       branches:
       - master
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -840,17 +676,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
 
   - name: daily-e2e-rbac-auth-default
     agent: kubernetes
@@ -860,6 +685,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-auth-default))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -870,17 +697,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
   - name: daily-e2e-rbac-no_auth
     agent: kubernetes
@@ -890,6 +706,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-no_auth))?,?(\\s+|$)"
     branches:
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -900,19 +718,10 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: daily-release-e2e-rbac-kubeconfig
@@ -925,6 +734,8 @@ presubmits:
       trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-no_auth-skew))?,?(\\s+|$)"
       branches:
       - release-0.6
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -935,19 +746,10 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: kubeconfig
             mountPath: /home/bootstrap/.kube
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: kubeconfig
           secret:
             secretName: daily-release-e2e-rbac-kubeconfig
@@ -960,6 +762,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-no_auth-default))?,?(\\s+|$)"
     branches:
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -970,19 +774,10 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: daily-release-e2e-rbac-kubeconfig
@@ -995,6 +790,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-auth))?,?(\\s+|$)"
     branches:
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -1005,19 +802,10 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: daily-release-e2e-rbac-kubeconfig
@@ -1030,6 +818,8 @@ presubmits:
       trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-auth-skew))?,?(\\s+|$)"
       branches:
       - release-0.6
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -1040,19 +830,10 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: kubeconfig
             mountPath: /home/bootstrap/.kube
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: kubeconfig
           secret:
             secretName: daily-release-e2e-rbac-kubeconfig
@@ -1065,6 +846,8 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|daily-e2e-rbac-auth-default))?,?(\\s+|$)"
     branches:
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -1075,19 +858,10 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: daily-release-e2e-rbac-kubeconfig
@@ -1101,6 +875,8 @@ presubmits:
     branches:
     - master
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1111,17 +887,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
     run_after_success:
     - name: daily-e2e-cluster_wide-auth-skew
       agent: kubernetes
@@ -1132,6 +897,8 @@ presubmits:
       branches:
       - master
       - release-0.6
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1142,17 +909,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
 
   - name: daily-e2e-cluster_wide-auth-default
     agent: kubernetes
@@ -1163,6 +919,8 @@ presubmits:
     branches:
     - master
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1173,17 +931,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 
 postsubmits:
 
@@ -1194,6 +941,8 @@ postsubmits:
     branches:
     - master
     - release-0.2
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1204,20 +953,11 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: oauth
           mountPath: /etc/github
           readOnly: true
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: oauth
         secret:
           secretName: oauth-token
@@ -1232,6 +972,8 @@ postsubmits:
     - release-0.8
     - release-0.9
     - release-1.0
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1242,25 +984,18 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: istio-e2e-rbac-kubeconfig
     run_after_success:
     - name: e2e-suite-rbac-no_auth
       agent: kubernetes
+        labels:
+      preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1271,19 +1006,10 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: e2e-suite-rbac-auth
       agent: kubernetes
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1294,19 +1020,10 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: e2e-cluster_wide-auth
       agent: kubernetes
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1317,23 +1034,14 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
 
   - name: istio-postsubmit
     agent: kubernetes
     branches:
     - release-0.5
     - release-0.6
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -1344,25 +1052,18 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: kubeconfig
           mountPath: /home/bootstrap/.kube
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           secretName: istio-e2e-rbac-kubeconfig
     run_after_success:
     - name: e2e-suite-rbac-no_auth
       agent: kubernetes
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1373,19 +1074,10 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
     - name: e2e-suite-rbac-auth
       agent: kubernetes
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1396,24 +1088,17 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
           - name: kubeconfig
             mountPath: /home/bootstrap/.kube
         volumes:
-        - name: service
-          secret:
-            secretName: service-account
         - name: kubeconfig
           secret:
             secretName: istio-e2e-rbac-kubeconfig
     - name: e2e-cluster_wide-auth
       agent: kubernetes
+      labels:
+        preset-service-account: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1424,17 +1109,6 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
 
 
   istio/proxy:
@@ -1447,6 +1121,8 @@ postsubmits:
     trigger: "(?m)^/(retest|test (all|proxy-postsubmit))?,?(\\s+|$)"
     branches:
     - master
+    labels:
+      preset-service-account: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1457,13 +1133,7 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
         - name: cache-ssd
           mountPath: /home/bootstrap/.cache
         ports:
@@ -1479,9 +1149,6 @@ postsubmits:
       nodeSelector:
         cloud.google.com/gke-nodepool: build-pool
       volumes:
-      - name: service
-        secret:
-          secretName: service-account
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -1491,6 +1158,8 @@ periodics:
 - interval: 10m
   agent: kubernetes
   name: test-infra-cleanup-cluster
+  labels:
+    preset-service-account: true
   spec:
     containers:
     - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1501,19 +1170,10 @@ periodics:
       # Docker needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: kubeconfig
         mountPath: /home/bootstrap/.kube
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: kubeconfig
       secret:
         secretName: istio-e2e-rbac-kubeconfig
@@ -1521,6 +1181,8 @@ periodics:
 - interval: 10m
   agent: kubernetes
   name: test-infra-cleanup-cluster
+  labels:
+    preset-service-account: true
   spec:
     containers:
     - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1531,19 +1193,10 @@ periodics:
       # Docker needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
       - name: kubeconfig
         mountPath: /home/bootstrap/.kube
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: kubeconfig
       secret:
         secretName: daily-release-e2e-rbac-kubeconfig
@@ -1551,6 +1204,8 @@ periodics:
 - interval: 10m
   agent: kubernetes
   name: test-infra-cleanup-GKE
+  labels:
+    preset-service-account: true
   spec:
     containers:
     - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1561,21 +1216,12 @@ periodics:
       # Docker needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      volumeMounts:
-      - name: service
-        mountPath: /etc/service-account
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
 
 - interval: 1h
   agent: kubernetes
   name: test-infra-update-deps
+  labels:
+    preset-service-account: true
   spec:
     containers:
     - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1586,28 +1232,22 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       - name: GIT_BRANCH
         value: master
       volumeMounts:
       - name: oauth
         mountPath: /etc/github
         readOnly: true
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
     volumes:
     - name: oauth
       secret:
         secretName: oauth-token
-    - name: service
-      secret:
-        secretName: service-account
 
 - interval: 1h
   agent: kubernetes
   name: green-build
+  labels:
+    preset-service-account: true
   spec:
     containers:
     - args:
@@ -1637,9 +1277,6 @@ periodics:
       - mountPath: /home/bootstrap/.kube
         name: kubeconfig
     volumes:
-    - name: service
-      secret:
-        secretName: service-account
     - name: kubeconfig
       secret:
         secretName: istio-e2e-rbac-kubeconfig

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -55,6 +55,24 @@ presets:
   - name: cache-ssd
     hostPath:
       path: /mnt/disks/ssd0
+- labels:
+    preset-istio-kubeconfig: true
+  volumeMounts:
+  - name: kubeconfig
+    mountPath: /home/bootstrap/.kube
+  volumes:
+  - name: kubeconfig
+    secret:
+      secretName: istio-e2e-rbac-kubeconfig
+- labels:
+    preset-daily-kubeconfig: true
+  volumeMounts:
+  - name: kubeconfig
+    mountPath: /home/bootstrap/.kube
+  volumes:
+  - name: kubeconfig
+    secret:
+      secretName: daily-release-e2e-rbac-kubeconfig
 
 presubmits:
   # PR job triggering definitions.
@@ -210,6 +228,7 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|istio-unit-tests))?,?(\\s+|$)"
     labels:
       preset-service-account: true
+      preset-istio-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -220,14 +239,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        # Pilot, security unit tests require kubeconfig
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
 
   - name: istio-presubmit
     agent: kubernetes
@@ -243,6 +254,7 @@ presubmits:
     - release-1.0
     labels:
       preset-service-account: true
+      preset-istio-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -253,13 +265,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
     run_after_success:
     - name: istio-pilot-e2e-v1alpha3
       agent: kubernetes
@@ -367,6 +372,7 @@ presubmits:
     - release-0.6
     labels:
       preset-service-account: true
+      preset-istio-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -377,13 +383,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
     run_after_success:
     - name: istio-pilot-e2e
       agent: kubernetes
@@ -416,6 +415,7 @@ presubmits:
       - release-0.6
       labels:
         preset-service-account: true
+        preset-istio-kubeconfig: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -426,13 +426,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          volumeMounts:
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
-        volumes:
-        - name: kubeconfig
-          secret:
-            secretName: istio-e2e-rbac-kubeconfig
     - name: e2e-simpleTests
       agent: kubernetes
       context: prow/e2e-simpleTests.sh
@@ -443,6 +436,7 @@ presubmits:
       - release-0.6
       labels:
         preset-service-account: true
+        preset-istio-kubeconfig: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -453,13 +447,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          volumeMounts:
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
-        volumes:
-        - name: kubeconfig
-          secret:
-            secretName: istio-e2e-rbac-kubeconfig
 
   - name: e2e-suite-rbac-no_auth
     context: prow/e2e-suite-rbac-no_auth.sh
@@ -693,6 +680,7 @@ presubmits:
     - release-0.6
     labels:
       preset-service-account: true
+      preset-daily-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -703,13 +691,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
     run_after_success:
     - name: daily-e2e-rbac-no_auth-skew
       agent: kubernetes
@@ -721,6 +702,7 @@ presubmits:
       - release-0.6
       labels:
         preset-service-account: true
+        preset-daily-kubeconfig: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -731,13 +713,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          volumeMounts:
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
-        volumes:
-        - name: kubeconfig
-          secret:
-            secretName: daily-release-e2e-rbac-kubeconfig
 
   - name: daily-e2e-rbac-no_auth-default
     agent: kubernetes
@@ -749,6 +724,7 @@ presubmits:
     - release-0.6
     labels:
       preset-service-account: true
+      preset-daily-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -759,13 +735,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
 
   - name: daily-e2e-rbac-auth
     agent: kubernetes
@@ -777,6 +746,7 @@ presubmits:
     - release-0.6
     labels:
       preset-service-account: true
+      preset-daily-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -787,13 +757,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
     run_after_success:
     - name: daily-e2e-rbac-auth-skew
       agent: kubernetes
@@ -805,6 +768,7 @@ presubmits:
       - release-0.6
       labels:
         preset-service-account: true
+        preset-daily-kubeconfig: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -815,13 +779,6 @@ presubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          volumeMounts:
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
-        volumes:
-        - name: kubeconfig
-          secret:
-            secretName: daily-release-e2e-rbac-kubeconfig
 
   - name: daily-e2e-rbac-auth-default
     agent: kubernetes
@@ -833,6 +790,7 @@ presubmits:
     - release-0.6
     labels:
       preset-service-account: true
+      preset-daily-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -843,13 +801,6 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: daily-release-e2e-rbac-kubeconfig
 
   - name: daily-e2e-cluster_wide-auth
     agent: kubernetes
@@ -959,6 +910,7 @@ postsubmits:
     - release-1.0
     labels:
       preset-service-account: true
+      preset-istio-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -969,13 +921,6 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
     run_after_success:
     - name: e2e-suite-rbac-no_auth
       agent: kubernetes
@@ -1027,6 +972,7 @@ postsubmits:
     - release-0.6
     labels:
       preset-service-account: true
+      preset-istio-kubeconfig: true
     spec:
       containers:
       - image: gcr.io/istio-testing/prowbazel:0.4.3
@@ -1037,13 +983,6 @@ postsubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /home/bootstrap/.kube
-      volumes:
-      - name: kubeconfig
-        secret:
-          secretName: istio-e2e-rbac-kubeconfig
     run_after_success:
     - name: e2e-suite-rbac-no_auth
       agent: kubernetes
@@ -1063,6 +1002,7 @@ postsubmits:
       agent: kubernetes
       labels:
         preset-service-account: true
+        preset-istio-kubeconfig: true
       spec:
         containers:
         - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1073,13 +1013,6 @@ postsubmits:
           # Bazel needs privileged mode in order to sandbox builds.
           securityContext:
             privileged: true
-          volumeMounts:
-          - name: kubeconfig
-            mountPath: /home/bootstrap/.kube
-        volumes:
-        - name: kubeconfig
-          secret:
-            secretName: istio-e2e-rbac-kubeconfig
     - name: e2e-cluster_wide-auth
       agent: kubernetes
       labels:
@@ -1139,6 +1072,7 @@ periodics:
   name: test-infra-cleanup-cluster
   labels:
     preset-service-account: true
+    preset-istio-kubeconfig: true
   spec:
     containers:
     - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1149,13 +1083,6 @@ periodics:
       # Docker needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      volumeMounts:
-      - name: kubeconfig
-        mountPath: /home/bootstrap/.kube
-    volumes:
-    - name: kubeconfig
-      secret:
-        secretName: istio-e2e-rbac-kubeconfig
 
 - interval: 10m
   agent: kubernetes
@@ -1227,6 +1154,7 @@ periodics:
   name: green-build
   labels:
     preset-service-account: true
+    preset-istio-kubeconfig: true
   spec:
     containers:
     - args:
@@ -1253,12 +1181,7 @@ periodics:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
-      - mountPath: /home/bootstrap/.kube
-        name: kubeconfig
     volumes:
-    - name: kubeconfig
-      secret:
-        secretName: istio-e2e-rbac-kubeconfig
     - name: netrc
       secret:
         secretName: istio-testing-netrc

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1089,6 +1089,7 @@ periodics:
   name: test-infra-cleanup-cluster
   labels:
     preset-service-account: true
+    preset-daily-kubeconfig: true
   spec:
     containers:
     - image: gcr.io/istio-testing/prowbazel:0.4.6
@@ -1099,13 +1100,6 @@ periodics:
       # Docker needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      volumeMounts:
-      - name: kubeconfig
-        mountPath: /home/bootstrap/.kube
-    volumes:
-    - name: kubeconfig
-      secret:
-        secretName: daily-release-e2e-rbac-kubeconfig
 
 - interval: 10m
   agent: kubernetes


### PR DESCRIPTION
presets can be used for env, volumes and volumes mounts. Get rid of 500 lines of code, which is not few.