### PR TITLE
Disabling github approval as it is confusing

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -35,7 +35,6 @@ tide:
     - do-not-merge/work-in-progress
     - needs-ok-to-test
     - needs-rebase
-    reviewApprovedRequired: true
   merge_method:
     istio/test-infra: squash
   target_url: https://prow.istio.io/tide.html


### PR DESCRIPTION
note for that last we need both github approval and /approve. After this is merged then we won't need to.