### PR TITLE
Fix githubctl

### DIFF
--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -286,7 +286,8 @@ func DailyReleaseQualification() error {
 	verbose := true
 	ci := u.NewCIState()
 	retryDelay := 5 * time.Minute
-	totalRetries := 240 // Max 20 hours wait before we automatically close the PR and fail release qualification.
+	maxWait := 20 * time.Hour
+	totalRetries := int(maxWait / retryDelay)
 	log.Printf("Waiting for all jobs starting. Results Polling starts in %v.\n", retryDelay)
 	time.Sleep(retryDelay)
 

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -285,7 +285,7 @@ func DailyReleaseQualification() error {
 
 	verbose := true
 	ci := u.NewCIState()
-	retryDelay := 5 * time.Second
+	retryDelay := 5 * time.Minute
 	totalRetries := 240 // Max 20 hours wait before we automatically close the PR and fail release qualification.
 	log.Printf("Waiting for all jobs starting. Results Polling starts in %v.\n", retryDelay)
 	time.Sleep(retryDelay)


### PR DESCRIPTION
My previous change broke githubctl as it would exit the loop after just one cycle of wait.
The fix has been tested locally, and pushed to the airflow gcs bucket last night. We have a daily release today. =)