### PR TITLE
no cache when building sisyphus docker img

### DIFF
--- a/sisyphus/istio_deployment/Makefile
+++ b/sisyphus/istio_deployment/Makefile
@@ -7,7 +7,7 @@ MODIFIED_YAML := "/tmp/local.sisyphus-deployment.yaml"
 default: image push
 
 image:
-	docker build -t "gcr.io/$(PROJECT)/sisyphus:$(VERSION)" -f Dockerfile .
+	docker build --no-cache -t "gcr.io/$(PROJECT)/sisyphus:$(VERSION)" -f Dockerfile .
 
 push:
 	gcloud docker -- push "gcr.io/$(PROJECT)/sisyphus:$(VERSION)"


### PR DESCRIPTION
When calling go get, Docker cannot tell that the download target has change. Enforcing no cache ensures the image built is always up to date