### PR TITLE
remove preset-istio-config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -563,7 +563,6 @@ presubmits:
     trigger: "(?m)^/(retest|test (all|istio-pilot-e2e-envoyv2-v1alpha3))?,?(\\s+|$)"
     labels:
       preset-service-account: true
-      preset-istio-kubeconfig: true
     spec:
       <<: *common_e2e_spec
 


### PR DESCRIPTION
kube config is created by boskos, we should not be mounting it from preset