### PR TITLE
Comment out secret mounts of sisyphus deployment yaml

### DIFF
--- a/sisyphus/istio_deployment/sisyphus-deployment.yaml
+++ b/sisyphus/istio_deployment/sisyphus-deployment.yaml
@@ -18,17 +18,17 @@ spec:
       - name: sisyphus-container
         image: gcr.io/istio-testing/sisyphus:0.0.2
         imagePullPolicy: Always
-        volumeMounts:
-        - name: git-token
-          mountPath: /etc/github
-          readOnly: true
-        - name: gmail-app-pass
-          mountPath: /etc/gmail
-          readOnly: true
-      volumes:
-      - name: git-token
-        secret:
-          secretName: github-token
-      - name: gmail-app-pass
-        secret:
-          secretName: gmail-app-password
+        # volumeMounts:
+        # - name: git-token
+        #   mountPath: /etc/github
+        #   readOnly: true
+        # - name: gmail-app-pass
+        #   mountPath: /etc/gmail
+        #   readOnly: true
+      # volumes:
+      # - name: git-token
+      #   secret:
+      #     secretName: github-token
+      # - name: gmail-app-pass
+      #   secret:
+      #     secretName: gmail-app-password


### PR DESCRIPTION
These secrets are not configured or used right now and kubernetes complains keeping them around while they are not set. This PR comments out the secret volume mounts and they can be easily added back if sisyphus will be extended in that way.