### PR TITLE
Sisyphus triggers reruns sequentially and reliable PR commit SHA retrieval

### DIFF
--- a/sisyphus/ci.go
+++ b/sisyphus/ci.go
@@ -166,10 +166,22 @@ func (p *ProwAccessor) GetResult(jobName string, runNo int) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Presubmit
-	// "master:241d69701ebf3c57c0d86d016937d23615dae390,554:cc02e59987163c8deb80db8bcc203c318c1b752e"
-	// Postsubmit
-	// "master:241d69701ebf3c57c0d86d016937d23615dae390"
+	/*	The .repos field in started.json is a string to string map that contains exactly
+		one kv pair. For example, a pre-submit run may look like
+			"repos": {
+				"repo": "master:1920a01a8df75baf71ae5fa38d68e4b055bad65c,554:cc02e59987163c8deb80db8bcc203c318c1b752e"
+			}
+		which records the PR number and sha, as well as the base branch and sha.
+		A post-submit run looks like
+			"repos": {
+				"repo": "master:241d69701ebf3c57c0d86d016937d23615dae390"
+			}
+	*/
+	if len(cfg.Repos) != 1 {
+		return nil, fmt.Errorf(
+			"the .repos field in started.json contains %d kv pairs and we expect only one",
+			len(cfg.Repos))
+	}
 	for _, baseSHAprSHA := range cfg.Repos {
 		splitted := strings.Split(baseSHAprSHA, ",")
 		// the PR sha is always the last one
@@ -179,7 +191,7 @@ func (p *ProwAccessor) GetResult(jobName string, runNo int) (*Result, error) {
 			SHA:    sha,
 		}, nil
 	}
-	return nil, fmt.Errorf("the .metadata.repos field is ill-defined in finished.json")
+	return nil, fmt.Errorf("the .repos field is ill-defined in started.json")
 }
 
 // GetDetailsURL returns the gubernator URL to that job at the run number

--- a/sisyphus/ci.go
+++ b/sisyphus/ci.go
@@ -29,7 +29,7 @@ import (
 type CI interface {
 	GetLatestRun(jobName string) (int, error)
 	GetResult(jobName string, runNo int) (*Result, error)
-	Rerun(jobName string, runNo, numRerun int) error
+	Rerun(jobName string, runNo int) error
 	GetDetailsURL(jobName string, runNo int) string
 }
 
@@ -172,13 +172,13 @@ func (p *ProwAccessor) GetDetailsURL(jobName string, runNo int) string {
 	return fmt.Sprintf("%s/%s/%d", p.gubernatorURL, jobName, runNo)
 }
 
-// Rerun starts on Prow the reruns on specified jobs
-func (p *ProwAccessor) Rerun(jobName string, runNo, numRerun int) error {
+// Rerun starts on Prow the ONE rerun on the specified job
+func (p *ProwAccessor) Rerun(jobName string, runNo int) error {
 	cfg, err := p.getProwJobConfig(jobName, runNo)
 	if err != nil {
 		return err
 	}
-	if err = p.triggerConcurrentReruns(jobName, cfg.Node, numRerun); err != nil {
+	if err = p.triggerRerun(jobName, cfg.Node); err != nil {
 		return err
 	}
 	return nil
@@ -203,16 +203,14 @@ func (p *ProwAccessor) getProwJobConfig(jobName string, runNo int) (*ProwJobConf
 	return &cfg, nil
 }
 
-func (p *ProwAccessor) triggerConcurrentReruns(jobName, node string, numRerun int) error {
+func (p *ProwAccessor) triggerRerun(jobName, node string) error {
 	log.Printf("Rerunning %s\n", jobName)
 	recess := 1 * time.Minute
 	maxRetry := 3
-	for i := 0; i < numRerun; i++ {
-		if err := u.Retry(recess, maxRetry, func() error {
-			return p.rerunCmd(node)
-		}); err != nil {
-			log.Printf("Unable to trigger the %d-th rerun of job %v", i, jobName)
-		}
+	if err := u.Retry(recess, maxRetry, func() error {
+		return p.rerunCmd(node)
+	}); err != nil {
+		log.Printf("Unable to trigger rerun of job %v", jobName)
 	}
 	return nil
 }

--- a/sisyphus/ci_test.go
+++ b/sisyphus/ci_test.go
@@ -82,7 +82,7 @@ func TestGetResultOnProw(t *testing.T) {
 	}
 	expectedResult := &Result{
 		Passed: true,
-		SHA:    "1920a01a8df75baf71ae5fa38d68e4b055bad65c",
+		SHA:    "cc02e59987163c8deb80db8bcc203c318c1b752e",
 	}
 	if !reflect.DeepEqual(res, expectedResult) {
 		t.Errorf("ProwResult retrieved from Prow is not as expected")
@@ -101,8 +101,9 @@ func TestGetProwJobConfig(t *testing.T) {
 		Version:     "unknown",
 		TimeStamp:   1520646538,
 		RepoVersion: "unknown",
-		Pull:        "some_pr_number: sha",
-		Repos:       map[string]string{"repo": "some_pr_number: sha"},
+		Pull:        "some_pr_number:sha",
+		Repos: map[string]string{
+			"repo": "master:1920a01a8df75baf71ae5fa38d68e4b055bad65c,554:cc02e59987163c8deb80db8bcc203c318c1b752e"},
 	}
 	if !reflect.DeepEqual(cfg, cfgExpected) {
 		fmt.Printf("cfg = %v\n", cfg)

--- a/sisyphus/ci_test.go
+++ b/sisyphus/ci_test.go
@@ -118,8 +118,8 @@ func TestRerunOnProw(t *testing.T) {
 		counts[node]++
 		return nil
 	}
-	expectedNumRerun := 5
-	err := prowAccessor.Rerun(jobName, runNo, expectedNumRerun)
+	expectedNumRerun := 1
+	err := prowAccessor.Rerun(jobName, runNo)
 	if err != nil {
 		t.Errorf("Error when calling GetProwJobConfig: %v", err)
 	}

--- a/sisyphus/istio_deployment/BUILD.bazel
+++ b/sisyphus/istio_deployment/BUILD.bazel
@@ -1,46 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-
-go_library(
-    name = "sisyphus_main",
-    srcs = [
-        "main.go",
-    ],
-    importpath = "istio.io/test-infra/sisyphus/istio_deployment",
-    visibility = ["//visibility:private"],
-    deps = [
-        "//sisyphus:go_default_library",
-        "//toolbox/util:go_default_library",
-    ],
-)
-
-go_binary(
-    name = "sisyphus_static",
-    embed = [":sisyphus_main"],
-    gc_linkopts = [
-        "-linkmode",
-        "external",
-        "-extldflags",
-        "-static",
-    ],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-docker_build(
-    name = "sisyphus_image",
-    base = "@distroless//image:image.tar",
-    cmd = ["./sisyphus_static"],
-    files = [":sisyphus_static"],
-    tags = ["manual"],
-)
-
-go_binary(
-    name = "sisyphus",
-    embed = [":sisyphus_main"],
-    importpath = "istio.io/test-infra/sisyphus/istio_deployment",
-    visibility = ["//visibility:public"],
-)
 
 go_library(
     name = "go_default_library",

--- a/sisyphus/istio_deployment/Makefile
+++ b/sisyphus/istio_deployment/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.2.0
+VERSION = 0.2.1
 ZONE    ?= us-west1-a
 CLUSTER ?= istio-sisyphus
 MODIFIED_YAML := "/tmp/local.sisyphus-deployment.yaml"

--- a/sisyphus/istio_deployment/Makefile
+++ b/sisyphus/istio_deployment/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.1.0
+VERSION = 0.2.0
 ZONE    ?= us-west1-a
 CLUSTER ?= istio-sisyphus
 MODIFIED_YAML := "/tmp/local.sisyphus-deployment.yaml"

--- a/sisyphus/istio_deployment/README.md
+++ b/sisyphus/istio_deployment/README.md
@@ -1,0 +1,4 @@
+## Change Log
+
+* 0.2.0: Trigger reruns sequentially
+* 0.1.0: Initial deployment

--- a/sisyphus/istio_deployment/README.md
+++ b/sisyphus/istio_deployment/README.md
@@ -1,4 +1,5 @@
 ## Change Log
 
+* 0.2.1: Remove all cluster wide jobs and add new ones for daily
 * 0.2.0: Trigger reruns sequentially
 * 0.1.0: Initial deployment

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -54,9 +54,9 @@ var (
 	catchFlakesByRun     = flag.Bool("catch_flakes_by_rerun", true, "whether to rerun failed jobs to detect flakyness")
 
 	protectedJobs = []string{
-		"istio-unit-tests",
-		"istio-pilot-e2e-envoyv2-v1alpha3",
-		"istio-perf-tests",
+		"daily-unit-tests",
+		"daily-pilot-e2e-envoyv2-v1alpha3",
+		"daily-perf-tests",
 		"daily-e2e-rbac-auth-default",
 		"daily-e2e-rbac-auth-skew",
 		"daily-e2e-rbac-auth",

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"time"
 
 	"istio.io/test-infra/sisyphus"
 	u "istio.io/test-infra/toolbox/util"

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"log"
-	"time"
 
 	"istio.io/test-infra/sisyphus"
 	u "istio.io/test-infra/toolbox/util"

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -53,9 +53,9 @@ var (
 	catchFlakesByRun     = flag.Bool("catch_flakes_by_rerun", true, "whether to rerun failed jobs to detect flakyness")
 
 	protectedJobs = []string{
-		"prow/istio-unit-tests.sh",
-		"prow/istio-pilot-e2e-envoyv2-v1alpha3.sh",
-		"prow/istio-perf-tests.sh",
+		"istio-unit-tests",
+		"istio-pilot-e2e-envoyv2-v1alpha3",
+		"istio-perf-tests",
 		"daily-e2e-rbac-auth-default",
 		"daily-e2e-rbac-auth-skew",
 		"daily-e2e-rbac-auth",

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -53,9 +53,9 @@ var (
 	catchFlakesByRun     = flag.Bool("catch_flakes_by_rerun", true, "whether to rerun failed jobs to detect flakyness")
 
 	protectedJobs = []string{
-		"daily-e2e-cluster_wide-auth-default",
-		"daily-e2e-cluster_wide-auth-skew",
-		"daily-e2e-cluster_wide-auth",
+		"prow/istio-unit-tests.sh",
+		"prow/istio-pilot-e2e-envoyv2-v1alpha3.sh",
+		"prow/istio-perf-tests.sh",
 		"daily-e2e-rbac-auth-default",
 		"daily-e2e-rbac-auth-skew",
 		"daily-e2e-rbac-auth",

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -57,10 +57,8 @@ var (
 		"daily-pilot-e2e-envoyv2-v1alpha3",
 		"daily-perf-tests",
 		"daily-e2e-rbac-auth-default",
-		"daily-e2e-rbac-auth-skew",
 		"daily-e2e-rbac-auth",
 		"daily-e2e-rbac-no_auth-default",
-		"daily-e2e-rbac-no_auth-skew",
 		"daily-e2e-rbac-no_auth",
 	}
 	presubmitJobs = protectedJobs

--- a/sisyphus/istio_deployment/main.go
+++ b/sisyphus/istio_deployment/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"strings"
 
 	"istio.io/test-infra/sisyphus"
 	u "istio.io/test-infra/toolbox/util"
@@ -40,8 +41,8 @@ const (
 	gcsBucket     = "istio-prow"
 
 	// Branch protection
-	owner           = "istio"
-	protectedRepo   = "istio"
+	owner           = "istio-releases"
+	protectedRepo   = "daily-release"
 	protectedBranch = "master"
 )
 
@@ -51,17 +52,6 @@ var (
 	guardProtectedBranch = flag.Bool("guard", false, "Suspend merge bot if postsubmit fails")
 	emailSending         = flag.Bool("email_sending", false, "Sending alert email")
 	catchFlakesByRun     = flag.Bool("catch_flakes_by_rerun", true, "whether to rerun failed jobs to detect flakyness")
-
-	protectedJobs = []string{
-		"daily-unit-tests",
-		"daily-pilot-e2e-envoyv2-v1alpha3",
-		"daily-perf-tests",
-		"daily-e2e-rbac-auth-default",
-		"daily-e2e-rbac-auth",
-		"daily-e2e-rbac-no_auth-default",
-		"daily-e2e-rbac-no_auth",
-	}
-	presubmitJobs = protectedJobs
 )
 
 func init() {
@@ -74,10 +64,34 @@ func init() {
 	}
 }
 
+func getProtectedJobs() ([]string, error) {
+	var prowTests []string
+	prowPrefix := "prow/"
+	shSuffix := ".sh"
+	ghClnt := u.NewGithubClientNoAuth(owner)
+	checks, err := ghClnt.GetLatestChecks(protectedRepo)
+	if err != nil {
+		return prowTests, err
+	}
+	for _, check := range checks {
+		if strings.HasPrefix(check, prowPrefix) {
+			check = strings.TrimPrefix(check, prowPrefix)
+			check = strings.TrimSuffix(check, shSuffix)
+			prowTests = append(prowTests, check)
+		}
+	}
+	return prowTests, nil
+}
+
 func main() {
+	prowTests, err := getProtectedJobs()
+	if err != nil {
+		log.Fatalf("Failed to get the list of prow jobs: %v", err)
+	}
+	presubmitJobs := prowTests
 	gcsClient := u.NewGCSClient(gcsBucket)
 	sisyphusd := sisyphus.NewDaemonUsingProw(
-		protectedJobs, presubmitJobs, prowProject, prowZone, gubernatorURL,
+		prowTests, presubmitJobs, prowProject, prowZone, gubernatorURL,
 		gcsBucket,
 		gcsClient,
 		sisyphus.NewStorage(),

--- a/sisyphus/sisyphusd.go
+++ b/sisyphus/sisyphusd.go
@@ -273,6 +273,8 @@ func (d *Daemon) processResult(job *jobStatus, runNo int, result *Result) *failu
 			} else {
 				// flakeStatPtr.TotalRerun < d.numRerun
 				// start the next rerun
+				log.Printf("Starting the %d-th rerun on job [%s] at sha [%s]",
+					flakeStatPtr.TotalRerun+1, job.name, result.SHA)
 				if err := d.ci.Rerun(job.name, runNo); err != nil {
 					log.Printf("failed when starting reruns on [%s]: %v\n", job.name, err)
 				}
@@ -285,6 +287,7 @@ func (d *Daemon) processResult(job *jobStatus, runNo int, result *Result) *failu
 					SHA:      result.SHA,
 				}
 				// start the first rerun
+				log.Printf("Starting the first rerun on job [%s] at sha [%s]", job.name, result.SHA)
 				if err := d.ci.Rerun(job.name, runNo); err != nil {
 					log.Printf("failed when starting reruns on [%s]: %v\n", job.name, err)
 				}

--- a/sisyphus/sisyphusd_test.go
+++ b/sisyphus/sisyphusd_test.go
@@ -120,7 +120,7 @@ func (p *ProwAccessorMock) GetDetailsURL(jobName string, runNo int) string {
 	return ""
 }
 
-func (p *ProwAccessorMock) Rerun(jobName string, runNo, numRerun int) error {
+func (p *ProwAccessorMock) Rerun(jobName string, runNo int) error {
 	return nil
 }
 

--- a/sisyphus/test_data/mock-finished.json
+++ b/sisyphus/test_data/mock-finished.json
@@ -7,8 +7,8 @@
   "metadata": {
     "repo": "github.com/istio/istio",
     "repos": {
-      "github.com/istio/istio": "master:1920a01a8df75baf71ae5fa38d68e4b055bad65c"
+      "github.com/istio/istio": "master:1920a01a8df75baf71ae5fa38d68e4b055bad65c,554:cc02e59987163c8deb80db8bcc203c318c1b752e"
     },
-    "repo-commit": "1920a01a8df75baf71ae5fa38d68e4b055bad65c"
+    "repo-commit": "15c2728113ea80e202e9793972dd26895802cb11"
   }
 }

--- a/sisyphus/test_data/mock-started.json
+++ b/sisyphus/test_data/mock-started.json
@@ -4,8 +4,8 @@
   "version": "unknown",
   "timestamp": 1520646538,
   "repo-version": "unknown",
-  "pull": "some_pr_number: sha",
+  "pull": "some_pr_number:sha",
   "repos": {
-    "repo": "some_pr_number: sha"
+    "repo": "master:1920a01a8df75baf71ae5fa38d68e4b055bad65c,554:cc02e59987163c8deb80db8bcc203c318c1b752e"
   }
 }


### PR DESCRIPTION
This is required as Prow does not support concurrent reruns on the same failed jobs. 

Previously Sisyphus seemed to be stuck in a loop and keeps rerunning the same job at the same commit. The issue is that the `repo-commit` field reported by Prow is bogus and changes after every rerun. This PR also adds a reliable routine to get the actual PR commit SHA from which the rerun is made so we only do the rerun for a pre-specified number of times.