### PR TITLE
Rename daily prow jobs to be globally unique

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -524,35 +524,35 @@ presubmits:
 
   istio-releases/daily-release:
 
-  - name: istio-perf-tests
+  - name: daily-perf-tests
     agent: kubernetes
-    context: prow/istio-perf-tests.sh
+    context: prow/daily-perf-tests.sh
     always_run: true
-    rerun_command: "/test istio-perf-tests"
-    trigger: "(?m)^/(retest|test (all|istio-perf-tests))?,?(\\s+|$)"
+    rerun_command: "/test daily-perf-tests"
+    trigger: "(?m)^/(retest|test (all|daily-perf-tests))?,?(\\s+|$)"
     labels:
       preset-service-account: true
     spec:
       <<: *common_e2e_spec
 
-  - name: istio-unit-tests
+  - name: daily-unit-tests
     agent: kubernetes
-    context: prow/istio-unit-tests.sh
+    context: prow/daily-unit-tests.sh
     always_run: true
-    rerun_command: "/test istio-unit-tests"
-    trigger: "(?m)^/(retest|test (all|istio-unit-tests))?,?(\\s+|$)"
+    rerun_command: "/test daily-unit-tests"
+    trigger: "(?m)^/(retest|test (all|daily-unit-tests))?,?(\\s+|$)"
     labels:
       preset-service-account: true
       preset-istio-kubeconfig: true
     spec:
       <<: *common_e2e_spec
 
-  - name: istio-pilot-e2e-envoyv2-v1alpha3
+  - name: daily-pilot-e2e-envoyv2-v1alpha3
     agent: kubernetes
-    context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+    context: prow/daily-pilot-e2e-envoyv2-v1alpha3.sh
     always_run: true
-    rerun_command: "/test istio-pilot-e2e-envoyv2-v1alpha3"
-    trigger: "(?m)^/(retest|test (all|istio-pilot-e2e-envoyv2-v1alpha3))?,?(\\s+|$)"
+    rerun_command: "/test daily-pilot-e2e-envoyv2-v1alpha3"
+    trigger: "(?m)^/(retest|test (all|daily-pilot-e2e-envoyv2-v1alpha3))?,?(\\s+|$)"
     labels:
       preset-service-account: true
     spec:


### PR DESCRIPTION
This is required by sisyphus since the GCS path used by Prow makes the assumption that job names are globally unique. As such, sisyphus actually also triggers rerun on istio jobs even though we only enabled it on the daily releases.

Sister PR https://github.com/istio-releases/daily-release/pull/555