### PR TITLE
Get Latest Green SHA to Kick off Release

### DIFF
--- a/toolbox/githubctl/BUILD.bazel
+++ b/toolbox/githubctl/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "istio.io/test-infra/toolbox/githubctl",
     visibility = ["//visibility:private"],
     deps = [
-    	"//sisyphus:go_default_library",
-    	"//toolbox/util:go_default_library",
+        "//sisyphus:go_default_library",
+        "//toolbox/util:go_default_library",
     ],
 )
 

--- a/toolbox/githubctl/BUILD.bazel
+++ b/toolbox/githubctl/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["main.go"],
     importpath = "istio.io/test-infra/toolbox/githubctl",
     visibility = ["//visibility:private"],
-    deps = ["//toolbox/util:go_default_library"],
+    deps = [
+    	"//sisyphus:go_default_library",
+    	"//toolbox/util:go_default_library",
+    ],
 )
 
 go_binary(

--- a/toolbox/githubctl/README.md
+++ b/toolbox/githubctl/README.md
@@ -43,3 +43,4 @@ export GREEN_SHA=$(githubctl --token_file=<github token file> \
 	--repo=istio \
 	--base_branch=master)
 ```
+When using `githubctl` for this purpose, additional configuration such as `--max_commit_depth` and `--max_run_depth` is available for customization.

--- a/toolbox/githubctl/README.md
+++ b/toolbox/githubctl/README.md
@@ -1,5 +1,7 @@
 # GitHub Control
 
+## Triggering Release Qualification
+
 This file triggers release qualification in the latest release pipeline (and automates 0.2.* releases, more information can be found [here](https://github.com/istio/istio/blob/master/release/README.md)).
 It is a tool of our own that acts as a GitHub client making REST calls through the GitHub API.
 
@@ -29,4 +31,15 @@ githubctl --token_file=<github token file> \
 	--hub=<hub of remote docker image registry> \
 	--tag=<tag of the release candidate> \
 	--gcsPath=<GCS path where istioctl is stored>
+```
+
+
+## Get Latest Green SHA
+
+A green SHA is a commit sha that has passed all post submit checks. `githubctl` can also be used to get the latest green SHA of branch in a repo.
+```
+export GREEN_SHA=$(githubctl --token_file=<github token file> \
+	--op=getLatestGreenSHA \
+	--repo=istio \
+	--base_branch=master)
 ```

--- a/toolbox/githubctl/README.md
+++ b/toolbox/githubctl/README.md
@@ -43,4 +43,7 @@ export GREEN_SHA=$(githubctl --token_file=<github token file> \
 	--repo=istio \
 	--base_branch=master)
 ```
-When using `githubctl` for this purpose, additional configuration such as `--max_commit_depth` and `--max_run_depth` is available for customization.
+
+Logs are output to stderr and only the latest green sha is directed to stdout.
+
+When using `githubctl` for this purpose, additional configuration such as `--max_commit_depth`, `--max_run_depth`, and `--maxConcurrentRequests` is available for customization.

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -19,45 +19,45 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
+	s "istio.io/test-infra/sisyphus"
 	u "istio.io/test-infra/toolbox/util"
 )
 
 var (
-	owner                              = flag.String("owner", "istio", "Github owner or org")
-	tokenFile                          = flag.String("token_file", "", "File containing Github API Access Token")
-	op                                 = flag.String("op", "", "Operation to be performed")
-	repo                               = flag.String("repo", "", "Repository to which op is applied")
-	baseBranch                         = flag.String("base_branch", "", "Branch to which op is applied")
-	refSHA                             = flag.String("ref_sha", "", "Reference commit SHA used to update base branch")
-	nextRelease                        = flag.String("next_release", "", "Tag of the next release")
-	hub                                = flag.String("hub", "", "Hub of the docker images")
-	tag                                = flag.String("tag", "", "Tag of the release candidate")
-	releaseOrg                         = flag.String("rel_org", "istio-releases", "GitHub Release Org")
-	gcsPath                            = flag.String("gcs_path", "", "The path to the GCS bucket")
-	extraBranchesUpdateDownloadVersion = flag.String("update_rel_branches", "",
-		"Extra branches where you want to update downloadIstioCandidate.sh, separated by comma")
+	owner      = flag.String("owner", "istio", "Github owner or org")
+	tokenFile  = flag.String("token_file", "", "File containing Github API Access Token")
+	op         = flag.String("op", "", "Operation to be performed")
+	repo       = flag.String("repo", "", "Repository to which op is applied")
+	baseBranch = flag.String("base_branch", "", "Branch to which op is applied")
+	refSHA     = flag.String("ref_sha", "", "Reference commit SHA used to update base branch")
+	hub        = flag.String("hub", "", "Hub of the docker images")
+	tag        = flag.String("tag", "", "Tag of the release candidate")
+	releaseOrg = flag.String("rel_org", "istio-releases", "GitHub Release Org")
+	gcsPath    = flag.String("gcs_path", "", "The path to the GCS bucket")
 	githubClnt *u.GithubClient
 	ghClntRel  *u.GithubClient
+	// unable to query post-submit jobs as GitHub is unaware of them
+	// needs to be consistent with prow config map
+	postSubmitJobs = []string{
+		"istio-postsubmit",
+		"e2e-suite-rbac-no_auth",
+		"e2e-suite-rbac-auth",
+		"e2e-cluster_wide-auth",
+	}
 )
 
 const (
-	// 0.2 release tooling
-	istioVersionFile     = "istio.VERSION"
-	istioDepsFile        = "istio.deps"
-	releaseTagFile       = "istio.RELEASE"
-	downloadScript       = "release/downloadIstioCandidate.sh"
-	istioRepo            = "istio"
-	masterBranch         = "master"
-	export               = "export "
-	dockerHub            = "docker.io/istio"
-	releaseBaseDir       = "/tmp/release"
-	releasePRTtilePrefix = "[Auto Release] "
-	releaseBucketFmtStr  = "https://storage.googleapis.com/istio-release/releases/%s/%s"
-	istioctlSuffix       = "istioctl"
-	debianSuffix         = "deb"
+	masterBranch = "master"
+	// Prow
+	prowProject   = "istio-testing"
+	prowZone      = "us-west1-a"
+	gubernatorURL = "https://k8s-gubernator.appspot.com/build/istio-prow"
+	gcsBucket     = "istio-prow"
+	// latest green SHA
+	maxCommitDepth = 10
+	maxRunDepth    = 100
 	// release qualification trigger
 	relQualificationPRTtilePrefix = "Release Qualification"
 	greenBuildVersionFile         = "greenBuild.VERSION"
@@ -79,167 +79,57 @@ func fastForward(repo, baseBranch, refSHA *string) error {
 	return githubClnt.FastForward(*repo, *baseBranch, *refSHA)
 }
 
-func processIstioVersion(content *string) map[string]string {
-	kv := make(map[string]string)
-	lines := strings.Split(*content, "\n")
-	for _, line := range lines {
-		if idx := strings.Index(line, "="); idx != -1 {
-			key := line[len(export):idx]
-			value := strings.Trim(line[idx+1:], "\"")
-			kv[key] = value
+// TODO (chx) caching scheme to reduce IO to GCS. Also use go routines to increase parallelism
+func isJobSuccessOnSHA(sha, job string, prowAccessor *s.ProwAccessor) (bool, error) {
+	runNumber, err := prowAccessor.GetLatestRun(job)
+	if err != nil {
+		return false, fmt.Errorf("failed to get latest run number of %s: %v", job, err)
+	}
+	for i := 0; i < maxRunDepth; i++ {
+		result, err := prowAccessor.GetResult(job, runNumber)
+		if err != nil {
+			return false, fmt.Errorf(
+				"failed to get result of %s at run number %d: %v", job, runNumber, err)
+		}
+		if result.SHA == sha {
+			return result.Passed, nil
 		}
 	}
-	return kv
+	return false, fmt.Errorf(
+		"Did not find matching sha [%s] for job %s after checking latest %d runs", sha, job, maxRunDepth)
 }
 
-func getReleaseTag() (string, error) {
+func getLatestGreenSHA() (string, error) {
+	u.AssertNotEmpty("repo", repo)
 	u.AssertNotEmpty("base_branch", baseBranch)
-	releaseTag, err := githubClnt.GetFileContent(istioRepo, *baseBranch, releaseTagFile)
+	gcsClient := u.NewGCSClient(gcsBucket)
+	prowAccessor := s.NewProwAccessor(prowProject, prowZone, gubernatorURL, gcsBucket, gcsClient)
+	sha, err := githubClnt.GetHeadCommitSHA(*repo, *baseBranch)
 	if err != nil {
-		return "", err
+		log.Fatalf("failed to get the head commit sha of %s/%s", *repo, *baseBranch)
 	}
-	return strings.Trim(releaseTag, "\n"), nil
-}
-
-// TagIstioDepsForRelease creates release tag on each dependent repo of istio
-func TagIstioDepsForRelease() error {
-	u.AssertNotEmpty("base_branch", baseBranch)
-	log.Printf("Fetching and processing istio.VERSION\n")
-	istioVersion, err := githubClnt.GetFileContent(istioRepo, *baseBranch, istioVersionFile)
-	if err != nil {
-		return err
-	}
-	kv := processIstioVersion(&istioVersion)
-	pickledDeps, err := githubClnt.GetFileContent(istioRepo, *baseBranch, istioDepsFile)
-	if err != nil {
-		return err
-	}
-	deps, err := u.DeserializeDepsFromString(pickledDeps)
-	if err != nil {
-		return err
-	}
-	log.Printf("Fetching release tag\n")
-	releaseTag, err := getReleaseTag()
-	if err != nil {
-		return err
-	}
-	releaseMsg := "Istio Release " + releaseTag
-	for _, dep := range deps {
-		// use sha directly read from istio.VERSION in case updateVersion.sh was run
-		// manually without also updating istio.deps
-		log.Printf("Creating annotated tag [%s] on %s\n", releaseTag, dep.RepoName)
-		ref, exists := kv[dep.Name]
-		if !exists {
-			return fmt.Errorf("ill-defined %s: unable to find %s", istioVersionFile, dep.Name)
-		}
-		// make sure ref is a SHA, special case where previous release is used in this release
-		if u.ReleaseTagRegex.MatchString(ref) {
-			ref, err = githubClnt.GetTagCommitSHA(dep.RepoName, ref)
+	for i := 0; i < maxCommitDepth; i++ {
+		allChecksPassed := true
+		for _, postSubmitJob := range postSubmitJobs {
+			passed, err := isJobSuccessOnSHA(sha, postSubmitJob, prowAccessor)
 			if err != nil {
-				return err
+				log.Fatalf("failed to check if sha %s passed job %s", sha, postSubmitJob)
+			}
+			if !passed {
+				allChecksPassed = false
+				break
 			}
 		}
-		if err := githubClnt.CreateAnnotatedTag(
-			dep.RepoName, releaseTag, ref, releaseMsg); err != nil {
-			if strings.Contains(err.Error(), "Reference already exists") {
-				log.Printf("Tag [%s] already exists on %s\n", releaseTag, dep.RepoName)
-				prevTagSHA, err := githubClnt.GetTagCommitSHA(dep.RepoName, releaseTag)
-				if err != nil {
-					return err
-				}
-				if prevTagSHA == ref {
-					log.Printf("Intended to tag [%s] at the same SHA, resort to no-op and continue\n", ref)
-					continue
-				} else {
-					return fmt.Errorf("trying to tag [%s] at different SHA", ref)
-				}
-			}
+		if allChecksPassed {
+			return sha, nil
 		}
-	}
-	return nil
-}
-
-// UpdateIstioVersionAfterReleaseTagsMadeOnDeps runs updateVersion.sh to update
-// istio.VERSION and then create a PR on istio
-func UpdateIstioVersionAfterReleaseTagsMadeOnDeps() error {
-	u.AssertNotEmpty("base_branch", baseBranch)
-	releaseTag, err := getReleaseTag()
-	if err != nil {
-		return err
-	}
-	edit := func() error {
-		hubCommaTag := fmt.Sprintf("%s,%s", dockerHub, releaseTag)
-		istioctlURL := fmt.Sprintf(releaseBucketFmtStr, releaseTag, istioctlSuffix)
-		debianURL := fmt.Sprintf(releaseBucketFmtStr, releaseTag, debianSuffix)
-		cmd := fmt.Sprintf("./install/updateVersion.sh")
-		// Auth
-		cmd += fmt.Sprintf(" -c %s -A %s", hubCommaTag, debianURL)
-		// Mixer
-		cmd += fmt.Sprintf(" -x %s", hubCommaTag)
-		// Pilot
-		cmd += fmt.Sprintf(" -p %s -i %s -P %s", hubCommaTag, istioctlURL, debianURL)
-		// Proxy
-		cmd += fmt.Sprintf(" -r %s -E %s", releaseTag, debianURL)
-		_, err = u.Shell(cmd)
-		return err
-	}
-	releaseBranch := "Istio_Release_" + releaseTag
-	body := "Update istio.Version"
-	prTitle := releasePRTtilePrefix + body
-	_, err = githubClnt.CreatePRUpdateRepo(releaseBranch, *baseBranch, istioRepo, prTitle, body, edit)
-	return err
-}
-
-// CreateIstioReleaseUploadArtifacts creates a release on istio from the refSHA provided and uploads dependent artifacts
-func CreateIstioReleaseUploadArtifacts() error {
-	u.AssertNotEmpty("ref_sha", refSHA)
-	u.AssertNotEmpty("base_branch", baseBranch)
-	u.AssertNotEmpty("next_release", nextRelease)
-	releaseTag, err := getReleaseTag()
-	if releaseTag == *nextRelease {
-		return fmt.Errorf("next_release should be greater than the current release")
-	}
-	if err != nil {
-		return err
-	}
-	releaseBranch := "finalizeRelease-" + releaseTag
-	prBody := fmt.Sprintf("Finalize release %s on istio", releaseTag)
-	updateVersion := func() error {
-		log.Printf("Updating downloadIstioCandidate.sh with latest release")
-		return u.UpdateKeyValueInFile(
-			downloadScript, "ISTIO_VERSION", fmt.Sprintf("${ISTIO_VERSION:-%s}", releaseTag))
-	}
-	edit := func() error {
-		if _, err = u.Shell(
-			"./release/create_release_archives.sh -d " + releaseBaseDir); err != nil {
-			return err
+		parentSHA, err := githubClnt.GetParentSHA(*repo, *baseBranch, sha)
+		if err != nil {
+			log.Fatalf("failed to find the parent sha of %s in %s/%s", sha, *repo, *baseBranch)
 		}
-		archiveDir := releaseBaseDir + "/archives"
-		if err = githubClnt.CreateReleaseUploadArchives(
-			istioRepo, releaseTag, *refSHA, archiveDir); err != nil {
-			return err
-		}
-		if err = u.WriteTextFile(releaseTagFile, *nextRelease); err != nil {
-			return err
-		}
-		return updateVersion()
+		sha = parentSHA
 	}
-	prTitle := releasePRTtilePrefix + prBody
-	_, err = githubClnt.CreatePRUpdateRepo(releaseBranch, *baseBranch, istioRepo, prTitle, prBody, edit)
-	if err != nil {
-		return err
-	}
-	if *extraBranchesUpdateDownloadVersion != "" {
-		extraBranches := strings.Split(*extraBranchesUpdateDownloadVersion, ",")
-		for _, branch := range extraBranches {
-			localBranch := fmt.Sprintf("%s-local", branch)
-			if _, err := githubClnt.CreatePRUpdateRepo(localBranch, branch, istioRepo, prTitle, prBody, updateVersion); err != nil {
-				// Only log out errors if failing update extra branches
-				log.Printf("Warning! Failed to update downloadIstioCandidate.sh in branch %s", branch)
-			}
-		}
-	}
-	return nil
+	return "", fmt.Errorf("exceeded max commit depth")
 }
 
 // DailyReleaseQualification triggers test jobs buy creating a PR that generates
@@ -366,23 +256,18 @@ func main() {
 		if err := fastForward(repo, baseBranch, refSHA); err != nil {
 			log.Printf("Error during fastForward: %v\n", err)
 		}
-	case "tagIstioDepsForRelease":
-		if err := TagIstioDepsForRelease(); err != nil {
-			log.Printf("Error during TagIstioDepsForRelease: %v\n", err)
-		}
-	case "updateIstioVersion":
-		if err := UpdateIstioVersionAfterReleaseTagsMadeOnDeps(); err != nil {
-			log.Printf("Error during UpdateIstioVersionAfterReleaseTagsMadeOnDeps: %v\n", err)
-		}
-	case "uploadArtifacts":
-		if err := CreateIstioReleaseUploadArtifacts(); err != nil {
-			log.Printf("Error during CreateIstioReleaseUploadArtifacts: %v\n", err)
-		}
 	case "dailyRelQual":
 		if err := DailyReleaseQualification(baseBranch); err != nil {
 			log.Printf("Error during DailyReleaseQualification: %v\n", err)
 			os.Exit(1)
 		}
+	case "getLatestGreenSHA":
+		latestGreenSHA, err := getLatestGreenSHA()
+		if err != nil {
+			log.Printf("Error during getLatestGreenSHA: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s", latestGreenSHA)
 	default:
 		log.Printf("Unsupported operation: %s\n", *op)
 	}

--- a/toolbox/util/commonUtils.go
+++ b/toolbox/util/commonUtils.go
@@ -227,6 +227,13 @@ func AssertIntDefined(name string, value *int, undefinedVal int) {
 	}
 }
 
+// AssertPositive check if an int value is positive, exit if value not specified
+func AssertPositive(name string, value *int) {
+	if value == nil || *value <= 0 {
+		log.Fatalf("%s must be specified\n", name)
+	}
+}
+
 // Pair contains key and value for sorting.
 type Pair struct {
 	Key   string

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -97,6 +97,16 @@ func (g *GithubClient) SHAIsAncestorOfBranch(repo, branch, targetSHA string) (bo
 	return false, err
 }
 
+// GetParentSHA returns the parent sha of the sha
+func (g *GithubClient) GetParentSHA(repo, branch, sha string) (string, error) {
+	commit, _, err := g.client.Repositories.GetCommit(
+		context.Background(), g.owner, repo, sha)
+	if err != nil {
+		return "", err
+	}
+	return *commit.Parents[0].SHA, nil
+}
+
 // FastForward moves :branch on :repo to the given sha
 func (g *GithubClient) FastForward(repo, branch, sha string) error {
 	ref := fmt.Sprintf("refs/heads/%s", branch)


### PR DESCRIPTION
The overall overhead is about 2 min despite caching and parallel go routines, which I think still saves us quite some time. It is possible that a green SHA cannot be found given the constraints on `max_commit_depth` and `max_run_depth`. We could set them as large as possible or still keep green build repo around if this happens. 

EDIT: I took another approach to implement this, which caches all prow results to local before any checks on SHA. It now takes 50 seconds to run. 