### PR TITLE
Longer e2e timeout to avoid premature abortion

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -108,7 +108,7 @@ common_e2e_spec: &common_e2e_spec
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
-    - "--timeout=60"
+    - "--timeout=90"
     # Bazel needs privileged mode in order to sandbox builds.
     securityContext:
       privileged: true


### PR DESCRIPTION
Nowadays the e2e test suite takes about an hour to finish, and the timeout is set to be an hour. Hence we see quite a few timeout termination on otherwise healthy tests, which in turns failed the daily releases (https://k8s-testgrid.appspot.com/istio#daily-e2e-rbac-no_auth). This PR intends to extend the timeout to accommodate lengthy tests.