### PR TITLE
Push presubmit results to different GCS path so testgrid could multiplex

### DIFF
--- a/toolbox/ci2gubernator/README.md
+++ b/toolbox/ci2gubernator/README.md
@@ -45,7 +45,10 @@ The binary `ci_to_gubernator` constructs these files and uploads these artifacts
 
 ## Usage
 
-At the start of a build, execute the following command to create and upload `started.json` on GCS.
+At the start of a build, execute the following command to create and upload `started.json` on GCS. If the job is running as part of the presubmit, one should
+also specify the `--presubmit` flag. Presubmits are uploaded to a different
+locations on GCS so we could have different panels on testgrid that makes
+multiplexing results attainable.
 
 ```bash
 $ ci_to_gubernator --job_starts \
@@ -62,7 +65,7 @@ At the end of a build, execute the following command to
 * upload `finished.json`, `artifacts/junit_*.xml`, and `build-log.txt` to GCS
 * update `latest-build.txt` of this job with the current build number
 
-Caveat: this command exits with the same exit code as supplied by --exit_code.
+The same rules on `--presubmit` usage apply in here.
 
 ```bash
 $ ci_to_gubernator \

--- a/toolbox/ci2gubernator/README.md
+++ b/toolbox/ci2gubernator/README.md
@@ -45,8 +45,9 @@ The binary `ci_to_gubernator` constructs these files and uploads these artifacts
 
 ## Usage
 
-At the start of a build, execute the following command to create and upload `started.json` on GCS. If the job is running as part of the presubmit, one should
-also specify the `--presubmit` flag. Presubmits are uploaded to a different
+At the start of a build, execute the following command to create and upload `started.json` on GCS.
+If the job is running as part of the presubmit, one should
+also specify the `--stage=presubmit` flag. Presubmits are uploaded to a different
 locations on GCS so we could have different panels on testgrid that makes
 multiplexing results attainable.
 

--- a/toolbox/ci2gubernator/README.md
+++ b/toolbox/ci2gubernator/README.md
@@ -66,7 +66,7 @@ At the end of a build, execute the following command to
 * upload `finished.json`, `artifacts/junit_*.xml`, and `build-log.txt` to GCS
 * update `latest-build.txt` of this job with the current build number
 
-The same rules on `--presubmit` usage apply in here.
+The same rules on `--stage=presubmit` usage apply in here.
 
 ```bash
 $ ci_to_gubernator \

--- a/toolbox/ci2gubernator/lib/ci2gubernator.go
+++ b/toolbox/ci2gubernator/lib/ci2gubernator.go
@@ -30,16 +30,15 @@ import (
 )
 
 const (
-	lastBuildTXT    = "latest-build.txt"
-	buildLogTXT     = "build-log.txt"
-	finishedJSON    = "finished.json"
-	startedJSON     = "started.json"
-	junitXML        = "junit.xml"
-	artifacts       = "artifacts"
-	unknown         = "unknown"
-	resultSuccess   = "SUCCESS"
-	resultFailure   = "FAILURE"
-	presubmitFolder = "presubmit"
+	lastBuildTXT  = "latest-build.txt"
+	buildLogTXT   = "build-log.txt"
+	finishedJSON  = "finished.json"
+	startedJSON   = "started.json"
+	junitXML      = "junit.xml"
+	artifacts     = "artifacts"
+	unknown       = "unknown"
+	resultSuccess = "SUCCESS"
+	resultFailure = "FAILURE"
 )
 
 var (
@@ -58,20 +57,16 @@ type Converter struct {
 }
 
 // NewConverter creates a Converter
-func NewConverter(bucket, org, repo, job string, build int, presubmit bool) *Converter {
-	cvt := &Converter{
+func NewConverter(bucket, org, repo, job, mux string, build int) *Converter {
+	return &Converter{
 		gcsClient:     u.NewGCSClient(bucket),
-		gcsPathPrefix: fmt.Sprintf("%s/%d", job, build),
+		gcsPathPrefix: fmt.Sprintf("%s/%s/%d", mux, job, build),
 		bucket:        bucket,
 		org:           org,
 		repo:          repo,
 		job:           job,
 		build:         build,
 	}
-	if presubmit {
-		cvt.gcsPathPrefix = filepath.Join(presubmitFolder, cvt.gcsPathPrefix)
-	}
-	return cvt
 }
 
 // SetGCSPathPrefix allows customized gcs location
@@ -148,7 +143,7 @@ func (c *Converter) UpdateLastBuildTXT() error {
 			log.Fatalf("Unlock %s has timed out: %v", lastBuildTXT, err)
 		}
 	}()
-	gcsPath := filepath.Join(presubmitFolder, c.job, lastBuildTXT)
+	gcsPath := filepath.Join(filepath.Dir(c.gcsPathPrefix), lastBuildTXT)
 	val, err := c.gcsClient.Read(gcsPath)
 	if err != nil {
 		return err

--- a/toolbox/ci2gubernator/lib/ci2gubernator.go
+++ b/toolbox/ci2gubernator/lib/ci2gubernator.go
@@ -30,15 +30,16 @@ import (
 )
 
 const (
-	lastBuildTXT  = "latest-build.txt"
-	buildLogTXT   = "build-log.txt"
-	finishedJSON  = "finished.json"
-	startedJSON   = "started.json"
-	junitXML      = "junit.xml"
-	artifacts     = "artifacts"
-	unknown       = "unknown"
-	resultSuccess = "SUCCESS"
-	resultFailure = "FAILURE"
+	lastBuildTXT    = "latest-build.txt"
+	buildLogTXT     = "build-log.txt"
+	finishedJSON    = "finished.json"
+	startedJSON     = "started.json"
+	junitXML        = "junit.xml"
+	artifacts       = "artifacts"
+	unknown         = "unknown"
+	resultSuccess   = "SUCCESS"
+	resultFailure   = "FAILURE"
+	presubmitFolder = "presubmit"
 )
 
 var (
@@ -57,8 +58,8 @@ type Converter struct {
 }
 
 // NewConverter creates a Converter
-func NewConverter(bucket, org, repo, job string, build int) *Converter {
-	return &Converter{
+func NewConverter(bucket, org, repo, job string, build int, presubmit bool) *Converter {
+	cvt := &Converter{
 		gcsClient:     u.NewGCSClient(bucket),
 		gcsPathPrefix: fmt.Sprintf("%s/%d", job, build),
 		bucket:        bucket,
@@ -67,6 +68,10 @@ func NewConverter(bucket, org, repo, job string, build int) *Converter {
 		job:           job,
 		build:         build,
 	}
+	if presubmit {
+		cvt.gcsPathPrefix = filepath.Join(presubmitFolder, cvt.gcsPathPrefix)
+	}
+	return cvt
 }
 
 // SetGCSPathPrefix allows customized gcs location
@@ -143,7 +148,7 @@ func (c *Converter) UpdateLastBuildTXT() error {
 			log.Fatalf("Unlock %s has timed out: %v", lastBuildTXT, err)
 		}
 	}()
-	gcsPath := filepath.Join(c.job, lastBuildTXT)
+	gcsPath := filepath.Join(presubmitFolder, c.job, lastBuildTXT)
 	val, err := c.gcsClient.Read(gcsPath)
 	if err != nil {
 		return err

--- a/toolbox/ci2gubernator/lib/ci2gubernator.go
+++ b/toolbox/ci2gubernator/lib/ci2gubernator.go
@@ -57,10 +57,10 @@ type Converter struct {
 }
 
 // NewConverter creates a Converter
-func NewConverter(bucket, org, repo, job, mux string, build int) *Converter {
+func NewConverter(bucket, org, repo, job, stage string, build int) *Converter {
 	return &Converter{
 		gcsClient:     u.NewGCSClient(bucket),
-		gcsPathPrefix: fmt.Sprintf("%s/%s/%d", mux, job, build),
+		gcsPathPrefix: filepath.Join(stage, job, strconv.Itoa(build)),
 		bucket:        bucket,
 		org:           org,
 		repo:          repo,

--- a/toolbox/ci2gubernator/main.go
+++ b/toolbox/ci2gubernator/main.go
@@ -31,7 +31,6 @@ const (
 
 var (
 	jobStarts          = flag.Bool("job_starts", false, "Mark the start of a job by creating started.json")
-	presubmit          = flag.Bool("presubmit", false, "True if this job runs during presubmit, false for postsubmit")
 	exitCode           = flag.Int("exit_code", unspecifiedInt, "Exit code returned from the test command")
 	buildNum           = flag.Int("build_number", unspecifiedInt, "Build number genereated by CI")
 	prNum              = flag.Int("pr_number", unspecifiedInt, "Pull request number on GitHub")
@@ -42,6 +41,7 @@ var (
 	junitXML           = flag.String("junit_xml", "", "Path to the junit xml report")
 	buildLogTXT        = flag.String("build_log_txt", "", "Path to the build log")
 	serviceAccountJSON = flag.String("service_account", "", "Path to the service account key")
+	stage              = flag.String("stage", "", "Used to multiplex results on GCS")
 )
 
 func init() {
@@ -70,7 +70,7 @@ func main() {
 
 func createPushStartedJSON() {
 	u.AssertIntDefined("pr_number", prNum, unspecifiedInt)
-	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *buildNum, *presubmit)
+	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *stage, *buildNum)
 	if err := cvt.CreateUploadStartedJSON(*prNum, *sha); err != nil {
 		log.Fatalf("Failed to create started.json: %v", err)
 	}
@@ -78,7 +78,7 @@ func createPushStartedJSON() {
 
 func uploadArtifactsUpdateLatestBuild() {
 	u.AssertNotEmpty("junit_xml", junitXML)
-	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *buildNum, *presubmit)
+	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *stage, *buildNum)
 	if err := cvt.CreateUploadFinishedJSON(*exitCode, *sha); err != nil {
 		log.Fatalf("Failed to create started.json: %v", err)
 	}

--- a/toolbox/ci2gubernator/main.go
+++ b/toolbox/ci2gubernator/main.go
@@ -31,6 +31,7 @@ const (
 
 var (
 	jobStarts          = flag.Bool("job_starts", false, "Mark the start of a job by creating started.json")
+	presubmit          = flag.Bool("presubmit", false, "True if this job runs during presubmit, false for postsubmit")
 	exitCode           = flag.Int("exit_code", unspecifiedInt, "Exit code returned from the test command")
 	buildNum           = flag.Int("build_number", unspecifiedInt, "Build number genereated by CI")
 	prNum              = flag.Int("pr_number", unspecifiedInt, "Pull request number on GitHub")
@@ -69,7 +70,7 @@ func main() {
 
 func createPushStartedJSON() {
 	u.AssertIntDefined("pr_number", prNum, unspecifiedInt)
-	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *buildNum)
+	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *buildNum, *presubmit)
 	if err := cvt.CreateUploadStartedJSON(*prNum, *sha); err != nil {
 		log.Fatalf("Failed to create started.json: %v", err)
 	}
@@ -77,7 +78,7 @@ func createPushStartedJSON() {
 
 func uploadArtifactsUpdateLatestBuild() {
 	u.AssertNotEmpty("junit_xml", junitXML)
-	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *buildNum)
+	cvt := ci2g.NewConverter(circleciBucket, *org, *repo, *job, *buildNum, *presubmit)
 	if err := cvt.CreateUploadFinishedJSON(*exitCode, *sha); err != nil {
 		log.Fatalf("Failed to create started.json: %v", err)
 	}


### PR DESCRIPTION
The goal is to create multiple testgrid panels for istio based on attributes such as presubmit vs postsubmits, and each panel could use different gcs prefix to multiplex the test results.