### PR TITLE
Block merge to istio/istio:release-0.8, and open up master.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -65,9 +65,9 @@ branch-protection:
             - "ci/circleci: test"
           branches:
             <<: *blocked_branches
-            release-0.8:
+            release-0.8: *blocking_merge
+            master:
               protect: true
-            master: *blocking_merge
         istio.github.io:
           protect: false
           required_status_checks:


### PR DESCRIPTION
release-0.8 will be moved to the common block when the branch is also blocked in istio.github,io.