### PR TITLE
Remove v1 tests from required context.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -57,9 +57,7 @@ branch-protection:
             contexts:
             - "ci/circleci: build"
             - "ci/circleci: codecov"
-            - "ci/circleci: dependencies"
-            - "ci/circleci: e2e-pilot"
-            - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
+            - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
             - "ci/circleci: e2e-simple"
             - "ci/circleci: lint"
             - "ci/circleci: test"


### PR DESCRIPTION
@sebastienvas  Is this the right way to make test not required? And how come the prow tests are not on the list?