### PR TITLE
Mason config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -487,7 +487,7 @@
     "prow/slack",
     "testgrid/util/gcs"
   ]
-  revision = "73bd8213b67cb45a6fb2f3f82b2cb4fd8a1311d6"
+  revision = "037e4589ab3847901d8ad860b3fc6e2a5087f352"
   source = "github.com/sebastienvas/k8s-test-infra"
 
 [solve-meta]

--- a/boskos/configs.yaml
+++ b/boskos/configs.yaml
@@ -10,17 +10,14 @@ configs:
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.10
-            zone: us-central1-f
             enablekubernetesalpha: true
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.10
-            zone: us-west1-a
             enablekubernetesalpha: true
           vms:
           - machinetype: n1-standard-4
             sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
-            zone: us-central1-f
             tags:
             - http-server
             - https-server
@@ -37,17 +34,14 @@ configs:
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.9
-            zone: us-central1-f
             enablekubernetesalpha: true
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.9
-            zone: us-west1-a
             enablekubernetesalpha: true
           vms:
           - machinetype: n1-standard-4
             sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
-            zone: us-central1-f
             tags:
             - http-server
             - https-server

--- a/boskos/janitor-deployment.yaml
+++ b/boskos/janitor-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20180402-43203f868
+        image: gcr.io/k8s-testimages/janitor:v20180531-f752a067a
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gcp-project,gcp-perf-test

--- a/boskos/mason-deployment.yaml
+++ b/boskos/mason-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-mason
-        image: gcr.io/istio-testing/mason:v20180531-tag-test-273-g857fac9a
+        image: gcr.io/istio-testing/mason:v20180601-stable-3191e68-448-g774a6c49
         args:
         - --config=/etc/config/configs.yaml
         - --service-account=/etc/service-account/service-account.json

--- a/go_vendor_repositories.bzl
+++ b/go_vendor_repositories.bzl
@@ -285,6 +285,6 @@ def go_vendor_repositories():
 
   go_repository(
     name = "io_k8s_test_infra",
-    commit = "73bd8213b67cb45a6fb2f3f82b2cb4fd8a1311d6",
+    commit = "037e4589ab3847901d8ad860b3fc6e2a5087f352",
     importpath = "github.com/sebastienvas/k8s-test-infra",
   )

--- a/vendor/k8s.io/test-infra/prow/config/config.go
+++ b/vendor/k8s.io/test-infra/prow/config/config.go
@@ -327,6 +327,9 @@ func parseConfig(c *Config) error {
 		if err := validateLabels(v.Name, v.Labels); err != nil {
 			return err
 		}
+		if err := validateTriggering(v); err != nil {
+			return err
+		}
 	}
 
 	// Validate postsubmits.
@@ -695,6 +698,18 @@ func validatePodSpec(name string, jobType kube.ProwJobType, spec *v1.PodSpec) er
 				return fmt.Errorf("job %s attempted to add a Prow-controlled volume %s", name, volume.Name)
 			}
 		}
+	}
+
+	return nil
+}
+
+func validateTriggering(job Presubmit) error {
+	if job.AlwaysRun && job.RunIfChanged != "" {
+		return fmt.Errorf("job %s is set to always run but also declares run_if_changed targets, which are mutually exclusive", job.Name)
+	}
+
+	if !job.SkipReport && job.Context == "" {
+		return fmt.Errorf("job %s is set to report but has no context configured", job.Name)
 	}
 
 	return nil

--- a/vendor/k8s.io/test-infra/prow/github/helpers.go
+++ b/vendor/k8s.io/test-infra/prow/github/helpers.go
@@ -17,6 +17,9 @@ limitations under the License.
 package github
 
 import (
+	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -28,4 +31,23 @@ func HasLabel(label string, issueLabels []Label) bool {
 		}
 	}
 	return false
+}
+
+// ImageTooBig checks if image is bigger than github limits
+func ImageTooBig(url string) (bool, error) {
+	// limit is 10MB
+	limit := 10000000
+	// try to get the image size from Content-Length header
+	resp, err := http.Head(url)
+	if err != nil {
+		return true, fmt.Errorf("error getting size of image, cannot get headers for %s: %s", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return true, fmt.Errorf("error getting size of image %s: %s", url, resp.Status)
+	}
+	size, _ := strconv.Atoi(resp.Header.Get("Content-Length"))
+	if size > limit {
+		return true, nil
+	}
+	return false, nil
 }

--- a/vendor/k8s.io/test-infra/prow/hook/events.go
+++ b/vendor/k8s.io/test-infra/prow/hook/events.go
@@ -51,6 +51,7 @@ var (
 )
 
 func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  re.Repo.Owner.Login,
 		github.RepoLogField: re.Repo.Name,
@@ -61,7 +62,9 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 	})
 	l.Infof("Review %s.", re.Action)
 	for p, h := range s.Plugins.ReviewEventHandlers(re.PullRequest.Base.Repo.Owner.Login, re.PullRequest.Base.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.ReviewEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -103,6 +106,7 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 }
 
 func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewCommentEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  rce.Repo.Owner.Login,
 		github.RepoLogField: rce.Repo.Name,
@@ -113,7 +117,9 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 	})
 	l.Infof("Review comment %s.", rce.Action)
 	for p, h := range s.Plugins.ReviewCommentEventHandlers(rce.PullRequest.Base.Repo.Owner.Login, rce.PullRequest.Base.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.ReviewCommentEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -155,6 +161,7 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 }
 
 func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  pr.Repo.Owner.Login,
 		github.RepoLogField: pr.Repo.Name,
@@ -164,7 +171,9 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 	})
 	l.Infof("Pull request %s.", pr.Action)
 	for p, h := range s.Plugins.PullRequestHandlers(pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.PullRequestHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -208,6 +217,7 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 }
 
 func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  pe.Repo.Owner.Name,
 		github.RepoLogField: pe.Repo.Name,
@@ -216,7 +226,9 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 	})
 	l.Info("Push event.")
 	for p, h := range s.Plugins.PushEventHandlers(pe.Repo.Owner.Name, pe.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.PushEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -229,6 +241,7 @@ func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
 }
 
 func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  i.Repo.Owner.Login,
 		github.RepoLogField: i.Repo.Name,
@@ -238,7 +251,9 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 	})
 	l.Infof("Issue %s.", i.Action)
 	for p, h := range s.Plugins.IssueHandlers(i.Repo.Owner.Login, i.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.IssueHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -282,6 +297,7 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 }
 
 func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueCommentEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  ic.Repo.Owner.Login,
 		github.RepoLogField: ic.Repo.Name,
@@ -291,7 +307,9 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 	})
 	l.Infof("Issue comment %s.", ic.Action)
 	for p, h := range s.Plugins.IssueCommentHandlers(ic.Repo.Owner.Login, ic.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.IssueCommentHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -333,6 +351,7 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 }
 
 func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
+	defer s.wg.Done()
 	l = l.WithFields(logrus.Fields{
 		github.OrgLogField:  se.Repo.Owner.Login,
 		github.RepoLogField: se.Repo.Name,
@@ -343,7 +362,9 @@ func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
 	})
 	l.Infof("Status description %s.", se.Description)
 	for p, h := range s.Plugins.StatusEventHandlers(se.Repo.Owner.Login, se.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.StatusEventHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
@@ -372,7 +393,9 @@ func genericCommentAction(action string) github.GenericCommentEventAction {
 
 func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericCommentEvent) {
 	for p, h := range s.Plugins.GenericCommentHandlers(ce.Repo.Owner.Login, ce.Repo.Name) {
+		s.wg.Add(1)
 		go func(p string, h plugins.GenericCommentHandler) {
+			defer s.wg.Done()
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()

--- a/vendor/k8s.io/test-infra/prow/plugins/dog/dog.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/dog/dog.go
@@ -108,6 +108,13 @@ func (u realPack) readDog() (string, error) {
 	if !filetypes.MatchString(a.URL) {
 		return "", errors.New("unsupported doggo :( unknown filetype: " + a.URL)
 	}
+	// checking size, GitHub doesn't support big images
+	toobig, err := github.ImageTooBig(a.URL)
+	if err != nil {
+		return "", err
+	} else if toobig {
+		return "", errors.New("unsupported doggo :( size too big: " + a.URL)
+	}
 	return a.Format()
 }
 

--- a/vendor/k8s.io/test-infra/prow/plugins/lifecycle/lifecycle.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/lifecycle/lifecycle.go
@@ -37,7 +37,6 @@ var (
 
 func init() {
 	plugins.RegisterGenericCommentHandler("lifecycle", lifecycleHandleGenericComment, help)
-	logrus.SetLevel(logrus.DebugLevel)
 }
 
 func help(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
@@ -125,9 +124,7 @@ func handleOne(gc lifecycleClient, log *logrus.Entry, e *github.GenericCommentEv
 	// Let's start simple and allow anyone to add/remove frozen, stale, putrid, rotten labels.
 	// Adjust if we find evidence of the community abusing these labels.
 	if remove {
-		log.Infof("/remove-%s", cmd)
 		return gc.RemoveLabel(org, repo, number, lbl)
 	}
-	log.Infof("/%s", cmd)
 	return gc.AddLabel(org, repo, number, lbl)
 }


### PR DESCRIPTION
All the cluster and vms were being created on the same zone. Updating the config such that it will query the zones available for a given projects and round robing around the zones for clusters and vms creation.

Note that when we query the zone per project, we shuffle the zones, such that each cluster and vm creation on different project don't use the same zone. If this problem persists we could consider querying GCP to get zones where it is less likely to get a quota or failure. 