### PR TITLE
Mark ci/circleci: e2e-pilot-noauth-v1alpha3-v2 as required.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -79,7 +79,7 @@ branch-protection:
               required_status_checks:
                 contexts:
                 - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
-
+                - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
         istio.github.io:
           protect: false
           required_status_checks:


### PR DESCRIPTION
For https://github.com/istio/istio/issues/6196

We could remove this from required in case the test is not stable enough. But given it's been in release-0.8 for quite a while, it should be fine to be required.
