### PR TITLE
Adding a new mixer test job, and remove e2e-pilot which uses v1alpha1…

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -421,12 +421,12 @@ presubmits:
             privileged: true
         nodeSelector:
           cloud.google.com/gke-nodepool: new-cluster-pool
-    - name: istio-pilot-e2e
+    - name: e2e-mixer-no_auth
       agent: kubernetes
-      context: prow/istio-pilot-e2e.sh
+      context: prow/e2e-mixer-no_auth.sh
       optional: true
-      rerun_command: "/test istio-pilot-e2e"
-      trigger: "(?m)^/test (istio-pilot-e2e)?,?(\\s+|$)"
+      rerun_command: "/test e2e-mixer-no_auth"
+      trigger: "(?m)^/test (e2e-mixer-no_auth)?,?(\\s+|$)"
       labels:
         preset-service-account: "true"
       max_concurrency: 5
@@ -834,6 +834,22 @@ postsubmits:
         nodeSelector:
           cloud.google.com/gke-nodepool: new-cluster-pool
     - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-1.10
+      agent: kubernetes
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.9
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+        nodeSelector:
+          cloud.google.com/gke-nodepool: new-cluster-pool
+   - name: e2e-mixer-no_auth
       agent: kubernetes
       labels:
         preset-service-account: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -849,22 +849,22 @@ postsubmits:
             privileged: true
         nodeSelector:
           cloud.google.com/gke-nodepool: new-cluster-pool
-     - name: e2e-mixer-no_auth
-        agent: kubernetes
-        labels:
-          preset-service-account: "true"
-        spec:
-          containers:
-          - image: gcr.io/istio-testing/prowbazel:0.4.9
-            args:
-            - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-            - "--clean"
-            - "--timeout=60"
-            # Bazel needs privileged mode in order to sandbox builds.
-            securityContext:
-              privileged: true
-          nodeSelector:
-            cloud.google.com/gke-nodepool: new-cluster-pool
+    - name: e2e-mixer-no_auth
+      agent: kubernetes
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - image: gcr.io/istio-testing/prowbazel:0.4.9
+          args:
+          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--timeout=60"
+          # Bazel needs privileged mode in order to sandbox builds.
+          securityContext:
+            privileged: true
+        nodeSelector:
+          cloud.google.com/gke-nodepool: new-cluster-pool
 
   istio/proxy:
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -849,22 +849,22 @@ postsubmits:
             privileged: true
         nodeSelector:
           cloud.google.com/gke-nodepool: new-cluster-pool
-   - name: e2e-mixer-no_auth
-      agent: kubernetes
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - image: gcr.io/istio-testing/prowbazel:0.4.9
-          args:
-          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-          - "--clean"
-          - "--timeout=60"
-          # Bazel needs privileged mode in order to sandbox builds.
-          securityContext:
-            privileged: true
-        nodeSelector:
-          cloud.google.com/gke-nodepool: new-cluster-pool
+     - name: e2e-mixer-no_auth
+        agent: kubernetes
+        labels:
+          preset-service-account: "true"
+        spec:
+          containers:
+          - image: gcr.io/istio-testing/prowbazel:0.4.9
+            args:
+            - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+            - "--clean"
+            - "--timeout=60"
+            # Bazel needs privileged mode in order to sandbox builds.
+            securityContext:
+              privileged: true
+          nodeSelector:
+            cloud.google.com/gke-nodepool: new-cluster-pool
 
   istio/proxy:
 


### PR DESCRIPTION
… (obsolete)


This depends on https://github.com/istio/istio/pull/6412