### PR TITLE
Add noauth pilot e2e test as required again.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -79,6 +79,7 @@ branch-protection:
               required_status_checks:
                 contexts:
                 - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
+                - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
 
         istio.github.io:


### PR DESCRIPTION
It's been stable for a while, https://k8s-testgrid.appspot.com/istio-presubmits#circleci-e2e-pilot-noauth-v1alpha3-v2-presubmit.

In case of anyone complaining about flakiness, we can skip the flaky test rather than skip the whole test suite.

Fixe https://github.com/istio/istio/issues/6196