### PR TITLE
adds CF test back as required

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -82,6 +82,7 @@ branch-protection:
                 - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
+                - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
 
         istio.github.io:
           protect: false


### PR DESCRIPTION
This rarely fails, unless something is actually broken, and should be a default test that must pass.

Co-authored-by: Utako Ueda <uueda@pivotal.io>