### PR TITLE
Extending prometheus metrics server with flakiness

### DIFF
--- a/toolbox/metrics/cmd/BUILD.bazel
+++ b/toolbox/metrics/cmd/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//toolbox/metrics:go_default_library",
         "//toolbox/metrics/coverage:go_default_library",
+        "//toolbox/metrics/flakes:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/toolbox/metrics/cmd/main.go
+++ b/toolbox/metrics/cmd/main.go
@@ -30,6 +30,7 @@ import (
 
 	"istio.io/test-infra/toolbox/metrics"
 	"istio.io/test-infra/toolbox/metrics/coverage"
+	"istio.io/test-infra/toolbox/metrics/flakes"
 )
 
 const (
@@ -50,6 +51,7 @@ var (
 func newMetricPublisher(storage coverage.Storage) *metrics.Publisher {
 	suite := metrics.Suite{
 		"codecov": coverage.NewMetric(storage),
+		"flake":   flakes.NewMetric(),
 	}
 	return metrics.NewPublisher(suite, defaultUpdateInterval, defaultUpdateTimeout)
 }

--- a/toolbox/metrics/flakes/BUILD.bazel
+++ b/toolbox/metrics/flakes/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "flakes.go",
+    ],
+    importpath = "istio.io/test-infra/toolbox/metrics/flakes",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//toolbox/util:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+    ],
+)

--- a/toolbox/metrics/flakes/flakes.go
+++ b/toolbox/metrics/flakes/flakes.go
@@ -54,7 +54,7 @@ func NewMetric() *FlakeGauge {
 		gauge: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "consistency",
-				Help: "In past 7 days, Number of successful runs over number of total runs",
+				Help: "In yesterday, Number of successful runs over number of total runs",
 			},
 			[]string{"job"},
 		),

--- a/toolbox/metrics/flakes/flakes.go
+++ b/toolbox/metrics/flakes/flakes.go
@@ -88,7 +88,7 @@ func (f *FlakeGauge) update() error {
 
 // Update implements metrics.Metric interface
 func (f *FlakeGauge) Update(ctx context.Context) error {
-	glog.Infof("upading flakes matrics")
+	glog.Infof("updaing flakes matrics")
 	errc := make(chan error)
 	go func() {
 		errc <- f.update()

--- a/toolbox/metrics/flakes/flakes.go
+++ b/toolbox/metrics/flakes/flakes.go
@@ -1,0 +1,102 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flakes
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	u "istio.io/test-infra/toolbox/util"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	bucket             = "k8s-metrics"
+	latestFlakesMetric = "istio-job-flakes-latest.json"
+)
+
+var (
+	gcsClient = u.NewGCSClient(bucket)
+)
+
+// FlakeGauge implement the metrics.Metric interface
+type FlakeGauge struct {
+	gauge *prometheus.GaugeVec
+}
+
+// FlakeMetric is how the metric is defined in the json output by bigquery metrics
+type FlakeMetric struct {
+	Consistency string `json:"consistency"`
+	Job         string `json:"job"`
+	Passed      string `json:"passed"`
+	Runs        string `json:"runs"`
+	Stamp       string `json:"stamp"`
+}
+
+// NewMetric instantiates a new Flake metric
+func NewMetric() *FlakeGauge {
+	return &FlakeGauge{
+		gauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "consistency",
+				Help: "In past 7 days, Number of successful runs over number of total runs",
+			},
+			[]string{"job"},
+		),
+	}
+}
+
+// GetCollector implements metrics.Metric interface
+func (f *FlakeGauge) GetCollector() prometheus.Collector {
+	return f.gauge
+}
+
+func (f *FlakeGauge) update() error {
+	flattened, err := gcsClient.Read(latestFlakesMetric)
+	if err != nil {
+		return err
+	}
+	var flakes []FlakeMetric
+	if err = json.Unmarshal([]byte(flattened), &flakes); err != nil {
+		return err
+	}
+	for _, flake := range flakes {
+		glog.Infof("setting %s to %s", flake.Job, flake.Consistency)
+		if consistency, err := strconv.ParseFloat(flake.Consistency, 64); err != nil {
+			glog.Errorf("Failed to convert %s to float64: %v", flake.Consistency, err)
+		} else {
+			f.gauge.WithLabelValues(flake.Job).Set(consistency)
+		}
+	}
+	return nil
+}
+
+// Update implements metrics.Metric interface
+func (f *FlakeGauge) Update(ctx context.Context) error {
+	glog.Infof("upading flakes matrics")
+	errc := make(chan error)
+	go func() {
+		errc <- f.update()
+	}()
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
After https://github.com/kubernetes/test-infra/pull/8424 is merged, data will be available in bucket `k8s-metrics`. Until then, for testing purposes, could use bucket `istio-flakes`.