### PR TITLE
Update prowconfig for branch protector

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -13,10 +13,10 @@ get-cluster-credentials:
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 
 update-config: get-cluster-credentials
-	kubectl create configmap config --from-file=config=./config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+	kubectl create configmap config --from-file=./config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
 
 update-plugins: get-cluster-credentials
-	kubectl create configmap plugins --from-file=plugins=./plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
+	kubectl create configmap plugins --from-file=./plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
 
 # use to guarantee that on command completion all deployments see new configs
 update-configs: update-config update-plugins

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           - name: branchprotector
             image: gcr.io/k8s-prow/branchprotector:v20180620-3b98af6f3
             args:
-            - --config-path=/etc/config/config
+            - --config-path=/etc/config/config.yaml
             - --github-token-path=/etc/github/oauth
             - --confirm
             volumeMounts:


### PR DESCRIPTION
There was some inconsistency in the config files. Makefile would create a config file, while the prow config update plugin would update config.yaml. Update makefile to also create a config.yaml and updated branch protector to use that file as well.