### PR TITLE
Remove the "needs-ok-to-test" check in Tide config for istio.github.io.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -130,7 +130,6 @@ tide:
   - repos:
     - istio/api
     - istio/test-infra
-    - istio/istio.github.io
     - istio/istio
     - istio/proxy
     labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -144,13 +144,23 @@ tide:
     - needs-ok-to-test
     - needs-rebase
   - repos:
+    - istio/istio.github.io
+    labels:
+    - lgtm
+    - approved
+    - "cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
     - istio-releases/daily-release
     labels:
     missingLabels:
     - do-not-merge
     - do-not-merge/hold
     - do-not-merge/work-in-progress
-    - needs-ok-to-test
     - needs-rebase
   merge_method:
     istio/api: squash


### PR DESCRIPTION
There are a lot of outside contributor fixing docs so we should not
block merges using that label.