### PR TITLE
Update tide to working version

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180723-3632407bc
+        image: gcr.io/k8s-prow/tide:v20180803-387a62015
         args:
         - --job-config-path=/etc/job-config
         - --dry-run=false


### PR DESCRIPTION
Previous version had an issue assuming job name and context would be the same.