### PR TITLE
Assorted fixes to test-infra

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -105,6 +105,7 @@ presubmits:
       branches: *branch_spec
       agent: kubernetes
       context: prow/istio-pilot-multicluster-e2e.sh
+      optional: true
       rerun_command: "/test istio-pilot-multicluster-e2e"
       trigger: "(?m)^/test (istio-pilot-multicluster-e2e)?,?(\\s+|$)"
       labels:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -51,9 +51,6 @@ branch-protection:
         - cla/google
       required_pull_request_reviews:
         required_approving_review_count: 1
-        dismissal_restrictions:
-          teams:
-          - repo-admins
       restrictions:
         teams:
         - repo-admins
@@ -69,7 +66,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - "ci/circleci: build"
-            - "ci/circleci: codecov"
             - "ci/circleci: e2e-simple"
             - "ci/circleci: lint"
             - "ci/circleci: test"

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -54,7 +54,7 @@ approve:
   - istio/test-infra
   - istio/proxy
   - istio-releases/daily-release
-  implicit_self_approve: true
+  implicit_self_approve: false
   lgtm_acts_as_approve: true
 
 plugins:


### PR DESCRIPTION
Do not self approve PRs
Make codecov optional
Make multi-cluster optional (i.e. not required)
Do not allow repo-admins to dismiss pull-request reviews