### PR TITLE
Use clang 5.0 for istio/proxy release-1.0 branch.

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.0.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.0.yaml
@@ -1,7 +1,7 @@
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.4.11
+  - image: gcr.io/istio-testing/prowbazel:0.4.10
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>