### PR TITLE
Remove bot warning about branches

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -31,15 +31,6 @@ config_updater:
 slack:
   mergewarnings:
   - repos:
-    - istio/istio
-    - istio/api
-    - istio/proxy
-    - istio/istio.github.io
-    channels:
-    - oncall
-    whitelist:
-    - istio-testing
-  - repos:
     - istio/test-infra
     channels:
     - test-and-release


### PR DESCRIPTION
Configuration options do not work as is for istio use case, and bot is too verbose. Keeping this for istio/test-infra which has simpler requirements.