### PR TITLE
Update Prow configuration and Fix issue with branch protection

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20180827-b14cf3e25
+            image: gcr.io/istio-testing/branchprotector:v20180830-cad43b007
             args:
             - --config-path=/etc/config/config.yaml
             - --github-token-path=/etc/github/oauth

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/deck:v20180830-cad43b007
         ports:
           - name: http
             containerPort: 8080

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/hook:v20180830-cad43b007
         args:
         - --dry-run=false
         - --slack-token-file=/etc/slack/token

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -14,7 +14,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/horologium:v20180830-cad43b007
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/jobs/istio/istio/istio.istio.collab-gcp-identity.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.collab-gcp-identity.yaml
@@ -119,6 +119,7 @@ presubmits:
     context: prow/e2e-suite-rbac-no_auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-no_auth"
     trigger: "(?m)^/(test e2e-suite-rbac-no_auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -131,6 +132,7 @@ presubmits:
     context: prow/e2e-suite-rbac-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-auth"
     trigger: "(?m)^/(test e2e-suite-rbac-auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -143,6 +145,7 @@ presubmits:
     context: prow/e2e-cluster_wide-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-cluster_wide-auth"
     trigger: "(?m)^/(test e2e-cluster_wide-auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -155,6 +158,7 @@ presubmits:
     context: prow/istio-pilot-multicluster-e2e.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test istio-pilot-multicluster-e2e"
     trigger: "(?m)^/(test istio-pilot-multicluster-e2e)?,?(\\s+|$)"
     agent: kubernetes

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -131,6 +131,7 @@ presubmits:
     context: prow/e2e-suite-rbac-no_auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-no_auth"
     trigger: "(?m)^/(test e2e-suite-rbac-no_auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -143,6 +144,7 @@ presubmits:
     context: prow/e2e-suite-rbac-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-auth"
     trigger: "(?m)^/(test e2e-suite-rbac-auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -155,6 +157,7 @@ presubmits:
     context: prow/e2e-cluster_wide-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-cluster_wide-auth"
     trigger: "(?m)^/(test e2e-cluster_wide-auth)?,?(\\s+|$)"
     agent: kubernetes

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-0.8.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-0.8.yaml
@@ -120,6 +120,7 @@ presubmits:
     context: prow/e2e-suite-rbac-no_auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-no_auth"
     trigger: "(?m)^/(test e2e-suite-rbac-no_auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -132,6 +133,7 @@ presubmits:
     context: prow/e2e-suite-rbac-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-auth"
     trigger: "(?m)^/(test e2e-suite-rbac-auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -144,6 +146,7 @@ presubmits:
     context: prow/e2e-cluster_wide-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-cluster_wide-auth"
     trigger: "(?m)^/(test e2e-cluster_wide-auth)?,?(\\s+|$)"
     agent: kubernetes

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.0.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.0.yaml
@@ -120,6 +120,7 @@ presubmits:
     context: prow/e2e-suite-rbac-no_auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-no_auth"
     trigger: "(?m)^/(test e2e-suite-rbac-no_auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -132,6 +133,7 @@ presubmits:
     context: prow/e2e-suite-rbac-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-suite-rbac-auth"
     trigger: "(?m)^/(test e2e-suite-rbac-auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -144,6 +146,7 @@ presubmits:
     context: prow/e2e-cluster_wide-auth.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test e2e-cluster_wide-auth"
     trigger: "(?m)^/(test e2e-cluster_wide-auth)?,?(\\s+|$)"
     agent: kubernetes
@@ -156,6 +159,7 @@ presubmits:
     context: prow/istio-pilot-multicluster-e2e.sh
     branches: *branch_spec
     always_run: false
+    optional: true
     rerun_command: "/test istio-pilot-multicluster-e2e"
     trigger: "(?m)^/(test istio-pilot-multicluster-e2e)?,?(\\s+|$)"
     agent: kubernetes

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/needs-rebase:v20180830-cad43b007
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/plank:v20180830-cad43b007
         args:
         - --tot-url=http://tot
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/sinker:v20180830-cad43b007
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/tide:v20180830-cad43b007
         args:
         - --job-config-path=/etc/job-config
         - --dry-run=false

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20180827-b14cf3e25
+        image: gcr.io/istio-testing/tot:v20180830-cad43b007
         args:
         - -storage=/store/tot.json
         - -fallback


### PR DESCRIPTION
I noticed that branch protection was failing which could also impact tide. The reason was that the branch speficifed in the job config was considered as a regex and therefore assuming that jobs from branch pr_4343_master should run since we have jobs defined for master.

The second issues is that we have jobs that are defined as always_run: false but are not marked as optional: true, which Tide consider as required, and therefore explain why some PR that can be merged do not show up in Tide UI

Should help with https://github.com/istio/test-infra/issues/957