### PR TITLE
Experiment mark all affer_success job as always_run: true

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.collab-gcp-identity.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.collab-gcp-identity.yaml
@@ -61,6 +61,7 @@ presubmits:
     run_after_success:
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       rerun_command: "/test istio-pilot-e2e-envoyv2-v1alpha3"
@@ -72,6 +73,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-mixer-no_auth.sh
       rerun_command: "/test e2e-mixer-no_auth"
@@ -83,6 +85,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-dashboard
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-dashboard.sh
       rerun_command: "/test e2e-dashboard"
@@ -94,6 +97,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-bookInfoTests-v1alpha3.sh
       rerun_command: "/test e2e-bookInfo-envoyv2-v1alpha3"
@@ -105,6 +109,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-simpleTests
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-simpleTests.sh
       rerun_command: "/test e2e-simple"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -61,6 +61,7 @@ presubmits:
     run_after_success:
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       rerun_command: "/test istio-pilot-e2e-envoyv2-v1alpha3"
@@ -72,6 +73,7 @@ presubmits:
         <<: *common_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-mixer-no_auth.sh
       rerun_command: "/test e2e-mixer-no_auth"
@@ -83,6 +85,7 @@ presubmits:
         <<: *common_spec
     - name: e2e-dashboard
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-dashboard.sh
       rerun_command: "/test e2e-dashboard"
@@ -94,6 +97,7 @@ presubmits:
         <<: *common_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-bookInfoTests-v1alpha3.sh
       rerun_command: "/test e2e-bookInfo-envoyv2-v1alpha3"
@@ -105,6 +109,7 @@ presubmits:
         <<: *common_spec
     - name: e2e-simpleTests
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-simpleTests.sh
       rerun_command: "/test e2e-simple"
@@ -116,6 +121,7 @@ presubmits:
         <<: *common_spec
     - name: istio-pilot-multicluster-e2e
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/istio-pilot-multicluster-e2e.sh
       optional: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-0.8.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-0.8.yaml
@@ -58,6 +58,7 @@ presubmits:
     run_after_success:
     - name: istio-pilot-e2e
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/istio-pilot-e2e.sh
       rerun_command: "/test istio-pilot-e2e"
@@ -69,6 +70,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       optional: false
@@ -81,6 +83,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-bookInfoTests
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-bookInfoTests.sh
       optional: false
@@ -93,6 +96,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-bookInfoTests-v1alpha3.sh
       optional: false
@@ -104,6 +108,7 @@ presubmits:
       spec:
         <<: *common_e2e_spec
     - name: e2e-simpleTests
+      always_run: true
       branches: *branch_spec
       agent: kubernetes
       context: prow/e2e-simpleTests.sh

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.0.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.0.yaml
@@ -62,6 +62,7 @@ presubmits:
     run_after_success:
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       rerun_command: "/test istio-pilot-e2e-envoyv2-v1alpha3"
@@ -73,6 +74,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-mixer-no_auth.sh
       rerun_command: "/test e2e-mixer-no_auth"
@@ -84,6 +86,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-dashboard
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-dashboard.sh
       rerun_command: "/test e2e-dashboard"
@@ -95,6 +98,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-bookInfoTests-v1alpha3.sh
       rerun_command: "/test e2e-bookInfo-envoyv2-v1alpha3"
@@ -106,6 +110,7 @@ presubmits:
         <<: *common_e2e_spec
     - name: e2e-simpleTests
       branches: *branch_spec
+      always_run: true
       agent: kubernetes
       context: prow/e2e-simpleTests.sh
       rerun_command: "/test e2e-simple"


### PR DESCRIPTION
My guess is that after_success job that are not always_run: true are confusing tide to make endless loop.

https://github.com/istio/test-infra/issues/957