### PR TITLE
Update Prow deployments and Jobs to ease Cluster pool maintenance

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -41,3 +41,5 @@ spec:
           - name: job-config
             configMap:
               name: job-config
+          nodeSelector:
+            prod: prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -41,3 +41,5 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -65,3 +65,5 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -31,3 +31,5 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -1,4 +1,17 @@
 
+test_spec: &test_spec
+  containers:
+  - image: gcr.io/istio-testing/prowbazel:0.4.11
+    args:
+    - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+    - "--clean"
+    - "--timeout=30"
+    # Bazel needs privileged mode in order to sandbox builds.
+    securityContext:
+      privileged: true
+  nodeSelector:
+    testing: test-pool
+
 periodics:
 
 - interval: 10m
@@ -8,17 +21,7 @@ periodics:
     preset-service-account: "true"
     preset-istio-kubeconfig: "true"
   spec:
-    containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.11
-      args:
-      - "--repo=github.com/istio/test-infra=master"
-      - "--clean"
-      - "--timeout=20"
-      # Docker needs privileged mode in order to sandbox builds.
-      securityContext:
-        privileged: true
-    nodeSelector:
-      cloud.google.com/gke-nodepool: new-cluster-pool
+    <<: *test_spec
 
 - interval: 10m
   agent: kubernetes
@@ -27,17 +30,7 @@ periodics:
     preset-service-account: "true"
     preset-daily-kubeconfig: "true"
   spec:
-    containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.11
-      args:
-      - "--repo=github.com/istio/test-infra=master"
-      - "--clean"
-      - "--timeout=20"
-      # Docker needs privileged mode in order to sandbox builds.
-      securityContext:
-        privileged: true
-    nodeSelector:
-      cloud.google.com/gke-nodepool: new-cluster-pool
+    <<: *test_spec
 
 - interval: 10m
   agent: kubernetes
@@ -45,17 +38,7 @@ periodics:
   labels:
     preset-service-account: "true"
   spec:
-    containers:
-    - image: gcr.io/istio-testing/prowbazel:0.4.11
-      args:
-      - "--repo=github.com/istio/test-infra=master"
-      - "--clean"
-      - "--timeout=30"
-      # Docker needs privileged mode in order to sandbox builds.
-      securityContext:
-        privileged: true
-    nodeSelector:
-      cloud.google.com/gke-nodepool: new-cluster-pool
+    <<: *test_spec
 
 - interval: 1h
   agent: kubernetes
@@ -85,7 +68,7 @@ periodics:
       secret:
         secretName: oauth-token
     nodeSelector:
-      cloud.google.com/gke-nodepool: new-cluster-pool
+      testing: test-pool
 
 - interval: 30m
   agent: kubernetes
@@ -128,7 +111,7 @@ periodics:
       secret:
         secretName: istio-testing-netrc
     nodeSelector:
-      cloud.google.com/gke-nodepool: new-cluster-pool
+      testing: test-pool
 
 - interval: 24h
   agent: kubernetes
@@ -156,4 +139,4 @@ periodics:
       secret:
         secretName: oauth-token
     nodeSelector:
-      cloud.google.com/gke-nodepool: new-cluster-pool
+      testing: test-pool

--- a/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.collab-gcp-identity.yaml
+++ b/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.collab-gcp-identity.yaml
@@ -1,5 +1,5 @@
 
-common_e2e_spec: &common_e2e_spec
+build_spec: &build_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,7 +10,20 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: build-pool
+
+test_spec: &test_spec
+  containers:
+  - image: gcr.io/istio-testing/prowbazel:0.4.11
+    args:
+    - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+    - "--clean"
+    - "--timeout=90"
+    # Bazel needs privileged mode in order to sandbox builds.
+    securityContext:
+      privileged: true
+  nodeSelector:
+    testing: test-pool
 
 presubmits:
 
@@ -28,7 +41,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *build_spec
 
   - name: daily-e2e-pilot-no_auth
     agent: kubernetes
@@ -41,7 +54,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-bookinfoTests
     agent: kubernetes
@@ -54,7 +67,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-simpleTests
     agent: kubernetes
@@ -67,7 +80,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-mixer-no_auth
     agent: kubernetes
@@ -80,7 +93,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-dashboard
     agent: kubernetes
@@ -93,7 +106,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 

--- a/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.master.yaml
+++ b/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.master.yaml
@@ -1,5 +1,5 @@
 
-build_e2e_spec: &build_e2e_spec
+build_spec: &build_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,9 +10,9 @@ build_e2e_spec: &build_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -23,7 +23,7 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
 
 presubmits:
 
@@ -40,7 +40,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-unit-tests
     agent: kubernetes
@@ -54,7 +54,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *build_e2e_spec
+      <<: *build_spec
 
   - name: daily-e2e-pilot-no_auth
     agent: kubernetes
@@ -67,7 +67,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-bookinfoTests
     agent: kubernetes
@@ -80,7 +80,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-simpleTests
     agent: kubernetes
@@ -93,7 +93,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-mixer-no_auth
     agent: kubernetes
@@ -106,7 +106,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-dashboard
     agent: kubernetes
@@ -119,7 +119,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 

--- a/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.release-0.8.yaml
+++ b/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.release-0.8.yaml
@@ -1,5 +1,5 @@
 
-common_e2e_spec: &common_e2e_spec
+build_spec: &build_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,7 +10,20 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: build-pool
+
+test_spec: &test_spec
+  containers:
+  - image: gcr.io/istio-testing/prowbazel:0.4.11
+    args:
+    - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+    - "--clean"
+    - "--timeout=90"
+    # Bazel needs privileged mode in order to sandbox builds.
+    securityContext:
+      privileged: true
+  nodeSelector:
+    testing: test-pool
 
 presubmits:
 
@@ -26,7 +39,7 @@ presubmits:
     labels:
       preset-service-account: true
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
   - name: daily-unit-tests
     agent: kubernetes
     context: prow/daily-unit-tests.sh
@@ -39,7 +52,7 @@ presubmits:
       preset-service-account: true
       preset-istio-kubeconfig: true
     spec:
-      <<: *common_e2e_spec
+      <<: *build_spec
   - name: daily-pilot-e2e-envoyv2-v1alpha3
     agent: kubernetes
     context: prow/daily-pilot-e2e-envoyv2-v1alpha3.sh
@@ -51,7 +64,7 @@ presubmits:
     labels:
       preset-service-account: true
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
   - name: daily-e2e-rbac-no_auth
     agent: kubernetes
     context: prow/daily-e2e-rbac-no_auth.sh
@@ -63,7 +76,7 @@ presubmits:
     labels:
       preset-service-account: true
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
   - name: daily-e2e-rbac-no_auth-default
     agent: kubernetes
     context: prow/daily-e2e-rbac-no_auth-default.sh
@@ -75,7 +88,7 @@ presubmits:
     labels:
       preset-service-account: true
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
   - name: daily-e2e-rbac-auth
     agent: kubernetes
     context: prow/daily-e2e-rbac-auth.sh
@@ -87,7 +100,7 @@ presubmits:
     labels:
       preset-service-account: true
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
   - name: daily-e2e-rbac-auth-default
     agent: kubernetes
     context: prow/daily-e2e-rbac-auth-default.sh
@@ -99,7 +112,7 @@ presubmits:
     labels:
       preset-service-account: true
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 

--- a/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.release-1.0.yaml
+++ b/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.release-1.0.yaml
@@ -1,5 +1,5 @@
 
-build_e2e_spec: &build_e2e_spec
+build_spec: &build_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,9 +10,9 @@ build_e2e_spec: &build_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -23,7 +23,7 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
 
 presubmits:
 
@@ -40,7 +40,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-unit-tests
     agent: kubernetes
@@ -54,7 +54,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *build_e2e_spec
+      <<: *build_spec
 
   - name: daily-e2e-pilot-no_auth
     agent: kubernetes
@@ -67,7 +67,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-bookinfoTests
     agent: kubernetes
@@ -80,7 +80,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-simpleTests
     agent: kubernetes
@@ -93,7 +93,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-mixer-no_auth
     agent: kubernetes
@@ -106,7 +106,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: daily-e2e-dashboard
     agent: kubernetes
@@ -119,7 +119,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 

--- a/prow/cluster/jobs/istio/api/istio.api.master.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.yaml
@@ -1,5 +1,5 @@
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,8 +10,7 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
-
+    testing: test-pool
 presubmits:
 
   istio/api:
@@ -27,7 +26,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 
@@ -40,4 +39,4 @@ postsubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec

--- a/prow/cluster/jobs/istio/api/istio.api.release-0.8.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-0.8.yaml
@@ -1,5 +1,5 @@
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,7 +10,7 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
 
 presubmits:
 
@@ -27,7 +27,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 
@@ -40,4 +40,4 @@ postsubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec

--- a/prow/cluster/jobs/istio/istio/istio.istio.collab-gcp-identity.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.collab-gcp-identity.yaml
@@ -1,5 +1,5 @@
 
-build_e2e_spec: &build_e2e_spec
+build_spec: &build_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,9 +10,9 @@ build_e2e_spec: &build_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -23,7 +23,7 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
 
 branch_spec: &branch_spec
 - collab-gcp-identity
@@ -44,7 +44,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *build_e2e_spec
+      <<: *build_spec
 
   - name: istio-presubmit
     agent: kubernetes
@@ -57,7 +57,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *build_spec
     run_after_success:
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
@@ -70,7 +70,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
       always_run: true
@@ -82,7 +82,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-dashboard
       branches: *branch_spec
       always_run: true
@@ -94,7 +94,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       always_run: true
@@ -106,7 +106,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-simpleTests
       branches: *branch_spec
       always_run: true
@@ -118,7 +118,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
 
   - name: e2e-suite-rbac-no_auth
     context: prow/e2e-suite-rbac-no_auth.sh
@@ -131,7 +131,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
@@ -144,7 +144,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
@@ -157,7 +157,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: istio-pilot-multicluster-e2e
     context: prow/istio-pilot-multicluster-e2e.sh
@@ -171,7 +171,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 5
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 
@@ -184,7 +184,7 @@ postsubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
     run_after_success:
     - name: e2e-simpleTests
       branches: *branch_spec
@@ -192,39 +192,39 @@ postsubmits:
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-1.10
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-dashboard
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -10,9 +10,9 @@ build_spec: &build_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: build-pool
 
-common_spec: &common_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -23,7 +23,7 @@ common_spec: &common_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
 
 branch_spec: &branch_spec
 - master
@@ -57,7 +57,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_spec
+      <<: *build_spec
     run_after_success:
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
@@ -70,7 +70,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
       always_run: true
@@ -82,7 +82,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-dashboard
       branches: *branch_spec
       always_run: true
@@ -94,7 +94,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       always_run: true
@@ -106,7 +106,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-simpleTests
       branches: *branch_spec
       always_run: true
@@ -118,7 +118,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: istio-pilot-multicluster-e2e
       branches: *branch_spec
       always_run: true
@@ -131,7 +131,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_spec
+        <<: *test_spec
 
   - name: e2e-suite-rbac-no_auth
     context: prow/e2e-suite-rbac-no_auth.sh
@@ -144,7 +144,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_spec
+      <<: *test_spec
 
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
@@ -157,7 +157,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_spec
+      <<: *test_spec
 
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
@@ -170,7 +170,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_spec
+      <<: *test_spec
 
 postsubmits:
 
@@ -183,7 +183,7 @@ postsubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_spec
+      <<: *test_spec
     run_after_success:
     - name: e2e-simpleTests
       branches: *branch_spec
@@ -191,39 +191,39 @@ postsubmits:
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-1.10
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_spec
+        <<: *test_spec
     - name: e2e-dashboard
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_spec
+        <<: *test_spec

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-0.8.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-0.8.yaml
@@ -1,5 +1,5 @@
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,7 +10,20 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
+
+build_spec: &build_spec
+  containers:
+  - image: gcr.io/istio-testing/prowbazel:0.4.11
+    args:
+    - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+    - "--clean"
+    - "--timeout=90"
+    # Bazel needs privileged mode in order to sandbox builds.
+    securityContext:
+      privileged: true
+  nodeSelector:
+    testing: build-pool
 
 branch_spec: &branch_spec
 - release-0.8
@@ -32,16 +45,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      containers:
-      - image: gcr.io/istio-testing/prowbazel:0.4.11
-        args:
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--clean"
-        - "--timeout=60"
-        securityContext:
-          privileged: true
-      nodeSelector:
-        cloud.google.com/gke-nodepool: build-pool
+      <<: *build_spec
 
   - name: istio-presubmit
     branches: *branch_spec
@@ -54,7 +58,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *build_spec
     run_after_success:
     - name: istio-pilot-e2e
       branches: *branch_spec
@@ -67,7 +71,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
       always_run: true
@@ -80,7 +84,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests
       branches: *branch_spec
       always_run: true
@@ -93,7 +97,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       always_run: true
@@ -106,7 +110,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-simpleTests
       always_run: true
       branches: *branch_spec
@@ -119,7 +123,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
 
   - name: e2e-suite-rbac-no_auth
     context: prow/e2e-suite-rbac-no_auth.sh
@@ -132,7 +136,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
@@ -145,7 +149,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
@@ -158,7 +162,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 
@@ -171,7 +175,7 @@ postsubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
     run_after_success:
     - name: e2e-suite-rbac-auth
       branches: *branch_spec
@@ -179,7 +183,7 @@ postsubmits:
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     run_after_success:
     - name: e2e-suite-rbac-auth-k8s-1.10
       branches: *branch_spec
@@ -187,32 +191,32 @@ postsubmits:
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-suite-rbac-no_auth
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-cluster_wide-auth
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-1.10
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.0.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.0.yaml
@@ -1,5 +1,5 @@
 
-build_e2e_spec: &build_e2e_spec
+build_spec: &build_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -10,9 +10,9 @@ build_e2e_spec: &build_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
-common_e2e_spec: &common_e2e_spec
+test_spec: &test_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.11
     args:
@@ -23,7 +23,7 @@ common_e2e_spec: &common_e2e_spec
     securityContext:
       privileged: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: new-cluster-pool
+    testing: test-pool
 
 branch_spec: &branch_spec
 - release-1.0
@@ -45,7 +45,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *build_e2e_spec
+      <<: *build_spec
 
   - name: istio-presubmit
     agent: kubernetes
@@ -58,7 +58,7 @@ presubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *build_spec
     run_after_success:
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
@@ -71,7 +71,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
       always_run: true
@@ -83,7 +83,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-dashboard
       branches: *branch_spec
       always_run: true
@@ -95,7 +95,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       always_run: true
@@ -107,7 +107,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-simpleTests
       branches: *branch_spec
       always_run: true
@@ -119,7 +119,7 @@ presubmits:
         preset-service-account: "true"
       max_concurrency: 5
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
 
   - name: e2e-suite-rbac-no_auth
     context: prow/e2e-suite-rbac-no_auth.sh
@@ -132,7 +132,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: e2e-suite-rbac-auth
     context: prow/e2e-suite-rbac-auth.sh
@@ -145,7 +145,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: e2e-cluster_wide-auth
     context: prow/e2e-cluster_wide-auth.sh
@@ -158,7 +158,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
   - name: istio-pilot-multicluster-e2e
     context: prow/istio-pilot-multicluster-e2e.sh
@@ -172,7 +172,7 @@ presubmits:
       preset-service-account: "true"
     max_concurrency: 5
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
 
 postsubmits:
 
@@ -185,7 +185,7 @@ postsubmits:
       preset-service-account: "true"
       preset-istio-kubeconfig: "true"
     spec:
-      <<: *common_e2e_spec
+      <<: *test_spec
     run_after_success:
     - name: e2e-simpleTests
       branches: *branch_spec
@@ -193,39 +193,39 @@ postsubmits:
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-bookInfoTests-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-1.10
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-mixer-no_auth
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec
     - name: e2e-dashboard
       branches: *branch_spec
       agent: kubernetes
       labels:
         preset-service-account: "true"
       spec:
-        <<: *common_e2e_spec
+        <<: *test_spec

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -9,9 +9,6 @@ bazel_spec: &bazel_spec
     # Bazel needs privileged mode in order to sandbox builds.
     securityContext:
       privileged: true
-    ports:
-    - containerPort: 9999
-      hostPort: 9998
     resources:
       requests:
         memory: "512Mi"
@@ -20,7 +17,7 @@ bazel_spec: &bazel_spec
         memory: "24Gi"
         cpu: "7000m"
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.0.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.0.yaml
@@ -9,9 +9,6 @@ bazel_spec: &bazel_spec
     # Bazel needs privileged mode in order to sandbox builds.
     securityContext:
       privileged: true
-    ports:
-    - containerPort: 9999
-      hostPort: 9998
     resources:
       requests:
         memory: "512Mi"
@@ -20,7 +17,7 @@ bazel_spec: &bazel_spec
         memory: "24Gi"
         cpu: "7000m"
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.sds_api.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.sds_api.yaml
@@ -9,9 +9,6 @@ bazel_spec: &bazel_spec
     # Bazel needs privileged mode in order to sandbox builds.
     securityContext:
       privileged: true
-    ports:
-    - containerPort: 9999
-      hostPort: 9998
     resources:
       requests:
         memory: "512Mi"
@@ -20,7 +17,7 @@ bazel_spec: &bazel_spec
         memory: "24Gi"
         cpu: "7000m"
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
 postsubmits:
 

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -9,9 +9,6 @@ bazel_spec: &bazel_spec
     # Bazel needs privileged mode in order to sandbox builds.
     securityContext:
       privileged: true
-    ports:
-    - containerPort: 9999
-      hostPort: 9998
     resources:
       requests:
         memory: "512Mi"
@@ -20,7 +17,7 @@ bazel_spec: &bazel_spec
         memory: "24Gi"
         cpu: "7000m"
   nodeSelector:
-    cloud.google.com/gke-nodepool: build-pool
+    testing: build-pool
 
 presubmits:
 

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -54,3 +54,5 @@ spec:
       - name: plugins
         configMap:
           name: plugins
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -38,3 +38,5 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -30,3 +30,5 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -40,3 +40,5 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -57,3 +57,5 @@ spec:
         - name: tot-volume
           persistentVolumeClaim:
             claimName: tot-storage
+      nodeSelector:
+        prod: prow


### PR DESCRIPTION
Instead of using the pre-made node label, we are defining the following labels:

- prow: prow: Used to run Prow deployments
- testing: build-pool: Used to run prow jobs that require more resources
- testing: test-pool: Used to run tests that don't need high CPU

This will ease maintenance as we can create a new node pool with the label and delete the one being use.