### PR TITLE
Change pkg_check to return 0 for package violation.

### DIFF
--- a/toolbox/pkg_check/main.go
+++ b/toolbox/pkg_check/main.go
@@ -304,7 +304,7 @@ func (c *codecovChecker) checkPackageCoverage() (code int) {
 		for _, p := range c.failedPackage {
 			glog.Errorf(p)
 		}
-		return 2 //Error code 2: Unsatisfied coverage requirement
+		return 0 //Do not fail the job in case of package violation. This is advisory only.
 	}
 	return 0
 }

--- a/toolbox/pkg_check/main_test.go
+++ b/toolbox/pkg_check/main_test.go
@@ -217,8 +217,8 @@ func TestFailedCheck(t *testing.T) {
 		requirement:     requirementFile,
 	}
 
-	if code := c.checkPackageCoverage(); code != 2 {
-		t.Errorf("Unexpected return code, expected: %d, actual: %d", 2, code)
+	if code := c.checkPackageCoverage(); code != 0 {
+		t.Errorf("Unexpected return code, expected: %d, actual: %d", 0, code)
 	}
 }
 


### PR DESCRIPTION
So that the codecov job will not fail. Otherwise, PR authors can be
easily confused since job failure can be caused by others and the error
is not actionable by the PR author.

The error messages are thus informational only, and we will figure out a
plan to fail if the actual delta before and after a PR is large.