### PR TITLE
Make istio-unit-tests required in master.

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -37,7 +37,6 @@ presubmits:
     context: prow/istio-unit-tests.sh
     branches: *branch_spec
     always_run: true
-    optional: true
     rerun_command: "/test istio-unit-tests"
     trigger: "(?m)^/(retest|test (all|istio-unit-tests))?,?(\\s+|$)"
     labels:


### PR DESCRIPTION
It is also used by Tide for merging for it is important to make it and keep it required.