### PR TITLE
Make ci/circleci: shellcheck required.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -101,6 +101,7 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                - "ci/circleci: shellcheck"
                 - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"


### PR DESCRIPTION
Now that it has been passing fairly consistently, it's a good time to
make it required.