### PR TITLE
add githubctl to istio-builder

### DIFF
--- a/docker/istio_builders/CHANGELOG.md
+++ b/docker/istio_builders/CHANGELOG.md
@@ -8,3 +8,4 @@
 * 0.5.8: update golang to 1.10.4 and docker to 18.06.1-CE
 * 0.5.9: update docker to use overlay2 fs for performance and update bazel to 0.16.1
 * 0.5.10: update entrpypoint
+* 0.5.11: add githubctl binary as of 9/26/18

--- a/docker/istio_builders/Makefile
+++ b/docker/istio_builders/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION = 0.5.10
+VERSION = 0.5.11
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/scripts/linux-install-software
+++ b/scripts/linux-install-software
@@ -18,6 +18,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . ${DIR}/tools/linux-install-wrk || error_exit "Cannot load wrk install script"
 . ${DIR}/tools/linux-install-protoc || error_exit "Cannot load protoc install script"
 . ${DIR}/tools/linux-install-helm || error_exit "Cannot load helm install script"
+. ${DIR}/tools/linux-install-githubctl || error_exit "Cannot load githubctl install script"
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -90,6 +91,7 @@ update_wrk
 update_bazel
 update_clang
 update_helm
+update_githubctl
 clear_apt
 
 echo "Software installation complete."

--- a/scripts/tools/linux-install-githubctl
+++ b/scripts/tools/linux-install-githubctl
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [[ "$(uname)" != "Linux" ]]; then
+  echo "Run on Linux only."
+  exit 1
+fi
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
+
+
+# Install githubctl
+function install_githubctl() {
+    pushd $DIR/..
+    git clone https://github.com/istio/test-infra.git -b master --depth 1
+      pushd test-infra
+       bazel build //toolbox/githubctl
+       cp bazel-bin/toolbox/githubctl/linux_amd64_stripped/githubctl /usr/local/bin
+      popd
+    popd
+    ls -l /usr/local/bin/githubctl
+}
+
+function update_githubctl() {
+  install_githubctl
+  echo 'githubctl up-to-date.'
+}


### PR DESCRIPTION
add githubctl to istio-builder
githubctl is used for finding green build
githubctl is used for starting tests in daily-releases

having it as part of the docker image makes the builds easier