### PR TITLE
Using a different host path for test infra and proxy

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -248,7 +248,7 @@ presets:
   volumes:
   - name: cache-ssd
     hostPath:
-      path: /mnt/disks/ssd0
+      path: /mnt/disks/ssd0/test-infra
 - labels:
     preset-bazel: "true"
   volumeMounts:
@@ -257,7 +257,7 @@ presets:
   volumes:
   - name: cache-ssd
     hostPath:
-      path: /mnt/disks/ssd0
+      path: /mnt/disks/ssd0/proxy
 - labels:
     preset-istio-kubeconfig: "true"
   volumeMounts:


### PR DESCRIPTION
This may not work since the data in the cache is already owned by a different UID. So we'll need to clear the existing cache on every node.