### PR TITLE
disable bazel cache for proxy

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -32,7 +32,6 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec
 
@@ -42,7 +41,6 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec
 
@@ -52,7 +50,6 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec
 
@@ -66,6 +63,5 @@ postsubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.0.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.0.yaml
@@ -32,7 +32,6 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec
 
@@ -42,7 +41,6 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec
 
@@ -52,7 +50,6 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec
 
@@ -66,6 +63,5 @@ postsubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.sds_api.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.sds_api.yaml
@@ -32,6 +32,5 @@ postsubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-      preset-bazel: "true"
     spec:
       <<: *bazel_spec


### PR DESCRIPTION
Not being to fix the current cache situation so disabling for now.