### PR TITLE
install fpm on the istio builder image

### DIFF
--- a/docker/istio/istio/install.sh
+++ b/docker/istio/istio/install.sh
@@ -12,9 +12,14 @@ apt-get -qqy --no-install-recommends install \
   curl \
   lsb-release \
   python \
+  ruby \
+  rubygems \
+  ruby-dev \
   software-properties-common \
   unzip \
   wget
+
+gem install --no-ri --no-rdoc fpm
 
 ./install-docker.sh
 ./install-gcloud.sh

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -25,8 +25,6 @@ presubmits:
     <<: *job_template
     context: prow/istio-unit-tests.sh
     always_run: true
-    labels:
-      preset-istio-kubeconfig: "true"
     spec:
       containers:
       - <<: *istio_container
@@ -201,7 +199,6 @@ postsubmits:
     <<: *job_template
     labels:
       preset-service-account: "true"
-      preset-istio-kubeconfig: "true"
     spec:
       containers:
       - <<: *istio_container

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20180927-30391f3f
+  image: gcr.io/istio-testing/istio-builder:v20180927-e1ac2070
   # Docker in Docker
   securityContext:
     privileged: true


### PR DESCRIPTION
Image with missing fpm. 
We don't access to a cluster anymore to run tests. Removing that dependency.