### PR TITLE
Use pod-utils for upgrade test

### DIFF
--- a/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.master.yaml
+++ b/prow/cluster/jobs/istio-releases/daily-release/istio-releases.daily-release.master.yaml
@@ -1,3 +1,20 @@
+job_template: &job_template
+  branches:
+  - "^master$"
+  decorate: true
+
+istio_container: &istio_container
+  image: gcr.io/istio-testing/istio-builder:v20180927-e1ac2070
+  # Docker in Docker
+  securityContext:
+    privileged: true
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "24Gi"
+      cpu: "7000m"
 
 build_spec: &build_spec
   containers:
@@ -43,14 +60,20 @@ presubmits:
       <<: *test_spec
 
   - name: daily-upgrade-tests
+    <<: *job_template
     context: prow/daily-upgrade-tests.sh
-    branches: *branch_spec
     always_run: true
     optional: true
     labels:
       preset-service-account: "true"
     spec:
-      <<: *test_spec
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/daily-upgrade-test.sh
+      nodeSelector:
+        testing: test-pool
 
   - name: daily-unit-tests
     context: prow/daily-unit-tests.sh


### PR DESCRIPTION
Since its a new job, we might as well use pod-utils directly.