### PR TITLE
Update k8s version to 1.10.

### DIFF
--- a/boskos/configs.yaml
+++ b/boskos/configs.yaml
@@ -1,4 +1,26 @@
 configs:
+- name: gke-e2e-test-1-11
+  needs:
+    gcp-project: 1
+  config:
+    type: GCPResourceConfig
+    content: |
+      gcp-project:
+        - clusters:
+          - machinetype: n1-standard-2
+            numnodes: 4
+            version: 1.11
+          - machinetype: n1-standard-2
+            numnodes: 4
+            version: 1.11
+          vms:
+          - machinetype: n1-standard-4
+            sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
+            tags:
+            - http-server
+            - https-server
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
 - name: gke-e2e-test-1-10
   needs:
     gcp-project: 1
@@ -31,10 +53,10 @@ configs:
         - clusters:
           - machinetype: n1-standard-2
             numnodes: 4
-            version: 1.9
+            version: 1.10
           - machinetype: n1-standard-2
             numnodes: 4
-            version: 1.9
+            version: 1.10
           vms:
           - machinetype: n1-standard-4
             sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
@@ -54,7 +76,7 @@ configs:
         - clusters:
           - machinetype: n1-highcpu-2
             numnodes: 6
-            version: 1.9
+            version: 1.10
             zone: us-central1-f
           vms:
           - machinetype: n1-highcpu-2

--- a/boskos/configs.yaml
+++ b/boskos/configs.yaml
@@ -1,5 +1,4 @@
-configs:
-- name: gke-e2e-test-1-11
+- name: gke-e2e-test-latest
   needs:
     gcp-project: 1
   config:
@@ -13,28 +12,6 @@ configs:
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.11
-          vms:
-          - machinetype: n1-standard-4
-            sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
-            tags:
-            - http-server
-            - https-server
-            scopes:
-            - https://www.googleapis.com/auth/cloud-platform
-- name: gke-e2e-test-1-10
-  needs:
-    gcp-project: 1
-  config:
-    type: GCPResourceConfig
-    content: |
-      gcp-project:
-        - clusters:
-          - machinetype: n1-standard-2
-            numnodes: 4
-            version: 1.10
-          - machinetype: n1-standard-2
-            numnodes: 4
-            version: 1.10
           vms:
           - machinetype: n1-standard-4
             sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206

--- a/boskos/configs.yaml
+++ b/boskos/configs.yaml
@@ -1,3 +1,4 @@
+configs:
 - name: gke-e2e-test-latest
   needs:
     gcp-project: 1

--- a/boskos/metrics-deployment.yaml
+++ b/boskos/metrics-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       - name: metrics
         image: gcr.io/k8s-testimages/metrics:v20180604-ea866c2e8
         args:
-        - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test,gke-e2e-test-1-10
+        - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test,gke-e2e-test-latest
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -200,25 +200,25 @@ resources:
   - gke-e2e-test-77
   - gke-e2e-test-78
   - gke-e2e-test-79
-- type: gke-e2e-test-1-10
+- type: gke-e2e-test-latest
   state: dirty
   names:
-  - gke-e2e-test-1-10-01
-  - gke-e2e-test-1-10-02
-  - gke-e2e-test-1-10-03
-  - gke-e2e-test-1-10-04
-  - gke-e2e-test-1-10-05
-  - gke-e2e-test-1-10-06
-  - gke-e2e-test-1-10-07
-  - gke-e2e-test-1-10-08
-  - gke-e2e-test-1-10-09
-  - gke-e2e-test-1-10-10
-  - gke-e2e-test-1-10-11
-  - gke-e2e-test-1-10-12
-  - gke-e2e-test-1-10-13
-  - gke-e2e-test-1-10-14
-  - gke-e2e-test-1-10-15
-  - gke-e2e-test-1-10-16
-  - gke-e2e-test-1-10-17
-  - gke-e2e-test-1-10-18
-  - gke-e2e-test-1-10-19
+  - gke-e2e-test-latest-01
+  - gke-e2e-test-latest-02
+  - gke-e2e-test-latest-03
+  - gke-e2e-test-latest-04
+  - gke-e2e-test-latest-05
+  - gke-e2e-test-latest-06
+  - gke-e2e-test-latest-07
+  - gke-e2e-test-latest-08
+  - gke-e2e-test-latest-09
+  - gke-e2e-test-latest-10
+  - gke-e2e-test-latest-11
+  - gke-e2e-test-latest-12
+  - gke-e2e-test-latest-13
+  - gke-e2e-test-latest-14
+  - gke-e2e-test-latest-15
+  - gke-e2e-test-latest-16
+  - gke-e2e-test-latest-17
+  - gke-e2e-test-latest-18
+  - gke-e2e-test-latest-19


### PR DESCRIPTION
This updates the default jobs to k8s 1.10, and renames gke-e2e-test-1-10 to gke-e2e-test-latest to avoid constant name changes in future.

The jobs that use gke-e2e-test-1-10 will be broken but they run in postsubmit only. Will fix them later once this is deployed.
