### PR TITLE
Modify Tide URL to a valid one

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -219,7 +219,7 @@ tide:
     istio/proxy: squash
     istio/test-infra: squash
     istio-releases/daily-release: squash
-  target_url: https://prow.istio.io/tide.html
+  target_url: https://prow.istio.io/tide
 
   context_options:
     from-branch-protection: true


### PR DESCRIPTION
Current URL returns 404