### PR TITLE
Adds a CNI based e2e prow test

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -189,6 +189,21 @@ presubmits:
           - prow/istio-pilot-multicluster-e2e.sh
         nodeSelector:
           testing: test-pool
+    - name: e2e-simpleTests-cni
+      <<: *job_template
+      always_run: false
+      context: prow/e2e-simpleTests-cni.sh
+      optional: true
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-simpleTests-cni.sh
+        nodeSelector:
     - name: build-tests
       <<: *job_template
       always_run: true


### PR DESCRIPTION
This adds a manually triggered e2e_simple
test that installs the optional CNI plugin.
This needs to be combined with istio
PR #9577 and test-infra issue #1018 to be
effective.