### PR TITLE
change timeout for proxy postsubmit for master to 2 hours

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -1,4 +1,24 @@
 
+bazel_postsubmit_spec: &bazel_postsubmit_spec
+  containers:
+  - image: gcr.io/istio-testing/prowbazel:0.4.13
+    args:
+    - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+    - "--clean"
+    - "--timeout=120"
+    # Bazel needs privileged mode in order to sandbox builds.
+    securityContext:
+      privileged: true
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "24Gi"
+        cpu: "7000m"
+  nodeSelector:
+    testing: build-pool
+
 bazel_spec: &bazel_spec
   containers:
   - image: gcr.io/istio-testing/prowbazel:0.4.13
@@ -64,4 +84,4 @@ postsubmits:
     labels:
       preset-service-account: "true"
     spec:
-      <<: *bazel_spec
+      <<: *bazel_postsubmit_spec


### PR DESCRIPTION
Proxy post submit for master needs more time, change timeout to 2 hours for master branch
As per request from @qiwzhang 