### PR TITLE
Enables GKE network policy

### DIFF
--- a/boskos/configs.yaml
+++ b/boskos/configs.yaml
@@ -10,9 +10,15 @@ configs:
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.11
+            networkpolicy:
+              enabled: true
+              provider: CALICO
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.11
+            networkpolicy:
+              enabled: true
+              provider: CALICO
           vms:
           - machinetype: n1-standard-4
             sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206

--- a/boskos/gcp/config_test.go
+++ b/boskos/gcp/config_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/container/v1"
+
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/mason"
 	"k8s.io/test-infra/boskos/ranch"
@@ -54,6 +56,34 @@ func TestParseInvalidConfig(t *testing.T) {
 			},
 		}},
 	}
+	expectedCni := resourceConfigs{
+		"type1": {{
+			Clusters: []clusterConfig{
+				{
+					MachineType:   "n1-standard-2",
+					NumNodes:      4,
+					Version:       "1.7",
+					Zone:          "us-central-1f",
+					NetworkPolicy: &container.NetworkPolicy{Enabled: true, Provider: "CALICO"},
+				},
+			},
+			Vms: []virtualMachineConfig{
+				{
+					MachineType: "n1-standard-4",
+					SourceImage: "projects/debian-cloud/global/images/debian-9-stretch-v20180105",
+					Zone:        "us-central-1f",
+					Tags: []string{
+						"http-server",
+						"https-server",
+					},
+					Scopes: []string{
+						"https://www.googleapis.com/auth/cloud-platform",
+					},
+				},
+			},
+		}},
+	}
+
 	conf, err := mason.ParseConfig("test-configs.yaml")
 	if err != nil {
 		t.Error("could not parse config")
@@ -61,10 +91,16 @@ func TestParseInvalidConfig(t *testing.T) {
 	config, err := ConfigConverter(conf[0].Config.Content)
 	if err != nil {
 		t.Errorf("cannot parse object")
-	} else {
-		if !reflect.DeepEqual(expected, *config.(*resourceConfigs)) {
-			t.Error("Object differ")
-		}
+	}
+	configCni, err := ConfigConverter(conf[1].Config.Content)
+	if err != nil {
+		t.Errorf("cannot parse networkpolicy object")
+	}
+	if !reflect.DeepEqual(expected, *config.(*resourceConfigs)) {
+		t.Error("Object differ")
+	}
+	if !reflect.DeepEqual(expectedCni, *configCni.(*resourceConfigs)) {
+		t.Error("Object with Networkpolicy differ")
 	}
 }
 

--- a/boskos/gcp/gke.go
+++ b/boskos/gcp/gke.go
@@ -37,11 +37,12 @@ const (
 )
 
 type clusterConfig struct {
-	MachineType           string `json:"machinetype,omitempty"`
-	NumNodes              int64  `json:"numnodes,omitempty"`
-	Version               string `json:"version,omitempty"`
-	Zone                  string `json:"zone,ompitempty"`
-	EnableKubernetesAlpha bool   `json:"enablekubernetesalpha"`
+	MachineType           string                   `json:"machinetype,omitempty"`
+	NumNodes              int64                    `json:"numnodes,omitempty"`
+	Version               string                   `json:"version,omitempty"`
+	Zone                  string                   `json:"zone,omitempty"`
+	EnableKubernetesAlpha bool                     `json:"enablekubernetesalpha"`
+	NetworkPolicy         *container.NetworkPolicy `json:"networkpolicy,omitempty"`
 }
 
 type containerEngine struct {
@@ -141,6 +142,7 @@ func (cc *containerEngine) create(ctx context.Context, project string, config cl
 			NodeConfig: &container.NodeConfig{
 				MachineType: config.MachineType,
 			},
+			NetworkPolicy:         config.NetworkPolicy,
 			EnableKubernetesAlpha: config.EnableKubernetesAlpha,
 		},
 	}

--- a/boskos/gcp/test-configs.yaml
+++ b/boskos/gcp/test-configs.yaml
@@ -20,4 +20,27 @@ configs:
             - https-server
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
-
+- name: type3
+  needs:
+    type1: 1
+  config:
+    type: GCPResourceConfig
+    content: |
+      type1:
+        - clusters:
+          - machinetype: n1-standard-2
+            numnodes: 4
+            version: 1.7
+            zone: us-central-1f
+            networkpolicy:
+              enabled: true
+              provider: CALICO
+          vms:
+          - machinetype: n1-standard-4
+            sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180105
+            zone: us-central-1f
+            tags:
+            - http-server
+            - https-server
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
This change enables the NetworkPolicy
on GKE clusters and sets the provider
to Calico.  This change is needed to
test with the CNI plugin.