### PR TITLE
Update prow with latest from sebastienvas/test-infra@master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -553,7 +553,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b10bfda5dac862312eab31534db623e9ebc58a029bce765cd846986ef3f6638e"
+  digest = "1:aa718a219894f5505b2c7aaed8b82116044a241cdca92d72b5035e87470afb60"
   name = "k8s.io/test-infra"
   packages = [
     "boskos/client",
@@ -628,7 +628,7 @@
     "testgrid/util/gcs",
   ]
   pruneopts = "NUT"
-  revision = "d88c17ee6d5c44809f8416f05729d6d006dd436e"
+  revision = "0427f40f413cf9e05abe21b9662e44b476a0eacf"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/boskos/gcp/BUILD.bazel
+++ b/boskos/gcp/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     embed = [":go_default_library"],
     importpath = "istio.io/test-infra/boskos/gcp",
     deps = [
+        "//vendor/google.golang.org/api/container/v1:go_default_library",
         "//vendor/k8s.io/test-infra/boskos/common:go_default_library",
         "//vendor/k8s.io/test-infra/boskos/mason:go_default_library",
         "//vendor/k8s.io/test-infra/boskos/ranch:go_default_library",

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/istio-testing/branchprotector:v20181102-436efed11
+            image: gcr.io/istio-testing/branchprotector:v20181106-19d4eccc3
             args:
             - --config-path=/etc/config/config.yaml
             - --github-token-path=/etc/github/oauth

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/istio-testing/deck:v20181102-436efed11
+        image: gcr.io/istio-testing/deck:v20181106-19d4eccc3
         ports:
           - name: http
             containerPort: 8080

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/istio-testing/hook:v20181102-436efed11
+        image: gcr.io/istio-testing/hook:v20181106-19d4eccc3
         args:
         - --dry-run=false
         - --slack-token-file=/etc/slack/token

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -14,7 +14,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/istio-testing/horologium:v20181102-436efed11
+        image: gcr.io/istio-testing/horologium:v20181106-19d4eccc3
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/istio-testing/needs-rebase:v20181102-436efed11
+        image: gcr.io/istio-testing/needs-rebase:v20181106-19d4eccc3
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/istio-testing/plank:v20181102-436efed11
+        image: gcr.io/istio-testing/plank:v20181106-19d4eccc3
         args:
         - --tot-url=http://tot
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/istio-testing/sinker:v20181102-436efed11
+        image: gcr.io/istio-testing/sinker:v20181106-19d4eccc3
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/istio-testing/tide:v20181102-436efed11
+        image: gcr.io/istio-testing/tide:v20181106-19d4eccc3
         args:
         - --job-config-path=/etc/job-config
         - --dry-run=false

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/istio-testing/tot:v20181102-436efed11
+        image: gcr.io/istio-testing/tot:v20181106-19d4eccc3
         args:
         - -storage=/store/tot.json
         - -fallback

--- a/vendor/k8s.io/test-infra/prow/plugins/lgtm/BUILD.bazel
+++ b/vendor/k8s.io/test-infra/prow/plugins/lgtm/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//vendor/k8s.io/test-infra/prow/labels:go_default_library",
         "//vendor/k8s.io/test-infra/prow/pluginhelp:go_default_library",
         "//vendor/k8s.io/test-infra/prow/plugins:go_default_library",
-        "//vendor/k8s.io/test-infra/prow/plugins/trigger:go_default_library",
         "//vendor/k8s.io/test-infra/prow/repoowners:go_default_library",
     ],
 )

--- a/vendor/k8s.io/test-infra/prow/plugins/plugins.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/plugins.go
@@ -373,12 +373,9 @@ type Lgtm struct {
 	// WARNING: This disables the security mechanism that prevents a malicious member (or
 	// compromised GitHub account) from merging arbitrary code. Use with caution.
 	//
-	// StickyForTrustedAuthors indicates if LGTM is sticky for PRs authored by trusted users, and
-	// eliminates the need to re-lgtm minor fixes/updates. This does not apply if the author is
-	// not trusted. Trusted users are by default collaborators and org members, but can also be
-	// restricted to only org members using Trigger.OnlyOrgMembers. i.e. the same set of users
-	// who can issue "/ok-to-test".
-	StickyForTrustedAuthors bool `json:"sticky_for_trusted_authors,omitempty"`
+	// StickyLgtmTeam specifies the Github team whose members are trusted with sticky LGTM,
+	// which eliminates the need to re-lgtm minor fixes/updates.
+	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
 }
 
 type Cat struct {


### PR DESCRIPTION
sebastienvas/test-infra@master includes the Tide patch that allows run_after_success jobs to work properly.