### PR TITLE
skip sourcing of param file for build

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -191,6 +191,8 @@ periodics:
       env:
       - name: GIT_BRANCH
         value: master
+      - name: SKIP_SOURCE_PIPELINE_PARAM
+        value: "true"
       command:
       - entrypoint
       - rel_scripts/trigger_daily_build.sh


### PR DESCRIPTION
skip sourcing of param file for build since it needs to be created new for every build