### PR TITLE
Move https://github.com/istio/admin-sites/gcsweb.istio.io to https://github.com/istio/test-infra/gcsweb.istio.io

### DIFF
--- a/gcsweb.istio.io/Makefile
+++ b/gcsweb.istio.io/Makefile
@@ -1,0 +1,12 @@
+PROJECT ?= istio-io
+ZONE ?= us-west1-b
+CLUSTER ?= istio-io-cluster
+
+deploy: get-cluster-credentials
+	kubectl apply -f deployment.yaml
+	kubectl apply -f service.yaml
+
+get-cluster-credentials:
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+.PHONY: deploy get-cluster-credentials

--- a/gcsweb.istio.io/README.md
+++ b/gcsweb.istio.io/README.md
@@ -1,0 +1,34 @@
+`gcsweb` is a tiny web frontend to [GCS](https://cloud.google.com/storage/docs/) browsing that DOES NOT REQUIRE A GOOGLE LOGIN.
+
+See it in action: http://gcsweb.k8s.io/gcs/kubernetes-release/release/
+
+#### Problem
+
+`kubernetes` releases can be downloaded using direct API links to specific
+files. However, to browse all available files at
+https://console.cloud.google.com/storage/browser/kubernetes-release/release/
+or with `gsutil` people
+[need Google login](https://cloud.google.com/storage/docs/access-public-data).
+
+#### Solution
+
+Run a web app that uses pubic API to access public buckets, extract
+information about directory structure and present it to the users with direct
+links to specific files.
+
+#### More info
+
+1. `gcsweb` is just a tool, anyone can run it at any URL with any allowed
+[buckets](https://cloud.google.com/storage/docs/key-terms#buckets) they want.
+
+2. `gcsweb` is not designed for initial browsing (yet?) - it doesn't list
+which GCS buckets are available, and because bucket is a part of URL, you
+need a documented link to browse.
+
+#### Installation and deployment
+
+`gcsweb` is built from source code at
+https://github.com/kubernetes/test-infra/tree/master/gcsweb into Docker
+container, which is then uploaded to private container storage at
+https://gcr.io/google_containers/gcsweb-amd64 and fetched during processing
+of `deployment.yaml` by `kubectl apply`.

--- a/gcsweb.istio.io/README.md
+++ b/gcsweb.istio.io/README.md
@@ -32,3 +32,7 @@ https://github.com/kubernetes/test-infra/tree/master/gcsweb into Docker
 container, which is then uploaded to private container storage at
 https://gcr.io/google_containers/gcsweb-amd64 and fetched during processing
 of `deployment.yaml` by `kubectl apply`.
+
+```
+make deploy
+```

--- a/gcsweb.istio.io/README.md
+++ b/gcsweb.istio.io/README.md
@@ -1,12 +1,12 @@
 `gcsweb` is a tiny web frontend to [GCS](https://cloud.google.com/storage/docs/) browsing that DOES NOT REQUIRE A GOOGLE LOGIN.
 
-See it in action: http://gcsweb.k8s.io/gcs/kubernetes-release/release/
+See it in action: http://gcsweb.istio.io/gcs/istio-release/releases/
 
 #### Problem
 
-`kubernetes` releases can be downloaded using direct API links to specific
+`istio` releases can be downloaded using direct API links to specific
 files. However, to browse all available files at
-https://console.cloud.google.com/storage/browser/kubernetes-release/release/
+https://console.cloud.google.com/storage/browser/istio-release/releases/
 or with `gsutil` people
 [need Google login](https://cloud.google.com/storage/docs/access-public-data).
 

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -23,10 +23,9 @@ spec:
           image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
           args:
             - -b=istio-artifacts
-            - -b=istio-prow
             - -b=istio-release
-            - -b=istio-release-dev
             - -b=istio-prerelease
+            - -b=istio-release-pipeline-data
             - -p=8080
           ports:
             - containerPort: 8080

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -22,9 +22,8 @@ spec:
         - name: gcsweb
           image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
           args:
-            - -b=kubernetes-jenkins
-            - -b=kubernetes-release
-            - -b=kubernetes-release-dev
+            - -b=istio-release
+            - -b=istio-release-dev
             - -p=8080
           ports:
             - containerPort: 8080

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
+          image: k8s.gcr.io/gcsweb-amd64:v1.0.6
           args:
             - -b=istio-build
             - -b=istio-artifacts

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
           args:
             - -b=istio-release
+            - -b=istio-artifacts
             - -b=istio-release-dev
             - -p=8080
           ports:

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  replicas: 2
+  # selector defaults from template labels
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gcsweb
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: gcsweb
+          image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
+          args:
+            - -b=kubernetes-jenkins
+            - -b=kubernetes-release
+            - -b=kubernetes-release-dev
+            - -p=8080
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - name: gcsweb
           image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
           args:
+            - -b=istio-build
             - -b=istio-artifacts
             - -b=istio-release
             - -b=istio-prerelease

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -22,8 +22,9 @@ spec:
         - name: gcsweb
           image: gcr.io/google_containers/gcsweb-amd64:v1.0.4
           args:
-            - -b=istio-release
             - -b=istio-artifacts
+            - -b=istio-prow
+            - -b=istio-release
             - -b=istio-release-dev
             - -p=8080
           ports:

--- a/gcsweb.istio.io/deployment.yaml
+++ b/gcsweb.istio.io/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - -b=istio-prow
             - -b=istio-release
             - -b=istio-release-dev
+            - -b=istio-prerelease
             - -p=8080
           ports:
             - containerPort: 8080

--- a/gcsweb.istio.io/service.yaml
+++ b/gcsweb.istio.io/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gcsweb
+  annotations:
+    service.beta.kubernetes.io/external-traffic: OnlyLocal
   labels:
     app: gcsweb
 spec:

--- a/gcsweb.istio.io/service.yaml
+++ b/gcsweb.istio.io/service.yaml
@@ -7,8 +7,6 @@ metadata:
 spec:
   selector:
     app: gcsweb
-  type: LoadBalancer
-  loadBalancerIP: 104.198.108.251
   ports:
     - name: http
       port: 80

--- a/gcsweb.istio.io/service.yaml
+++ b/gcsweb.istio.io/service.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gcsweb
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
   labels:
     app: gcsweb
 spec:

--- a/gcsweb.istio.io/service.yaml
+++ b/gcsweb.istio.io/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  selector:
+    app: gcsweb
+  type: LoadBalancer
+  loadBalancerIP: 104.197.177.166
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/gcsweb.istio.io/service.yaml
+++ b/gcsweb.istio.io/service.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     app: gcsweb
   type: LoadBalancer
-  loadBalancerIP: 104.197.177.166
+  loadBalancerIP: 104.198.108.251
   ports:
     - name: http
       port: 80


### PR DESCRIPTION
Moved istio/admin-sites/gcsweb.istio.io under istio/test-infra for better understanding who is owner of the  gcsweb.