### PR TITLE
WIP moving velodrome and gcsweb to test-infra

### DIFF
--- a/sites/README.md
+++ b/sites/README.md
@@ -1,0 +1,4 @@
+# istio.io
+Files for various *.istio.io sites
+
+This repo is derived from https://github.com/kubernetes/k8s.io.

--- a/sites/istio.io/.gitignore
+++ b/sites/istio.io/.gitignore
@@ -1,0 +1,3 @@
+tls.crt
+tls.key
+tls.csr

--- a/sites/istio.io/Makefile
+++ b/sites/istio.io/Makefile
@@ -1,0 +1,15 @@
+# GKE variables.
+PROJECT ?= istio-testing
+ZONE    ?= us-west1-a
+CLUSTER ?= prow
+
+# ensures that kubectl has access to the prow cluster's config context
+get-cluster-credentials:
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+# TODO add deployment step for multi-domain certificate.
+.PHONY: deploy
+deploy: get-cluster-credentials
+	kubectl apply -f configmap-nginx.yaml
+	kubectl apply -f service.yaml
+	kubectl apply -f deployment.yaml

--- a/sites/istio.io/README.md
+++ b/sites/istio.io/README.md
@@ -1,0 +1,153 @@
+Overview
+====
+This contains the Nginx configuration for istio.io and the associated subdomain
+redirectors.
+
+Testing
+===
+Configure kubectl to target a test cluster on GKE.
+
+Run `make deploy-fake-secret deploy` and wait for the service to be available--
+the load balancer may take some time to configure.
+
+Set `TARGET_IP` to the ingress IP of the running service:
+
+    export TARGET_IP=$(kubectl get svc istio-io '--template={{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
+
+Use `make test` to run unit tests to verify the various endpoints on the server.
+
+Deploying
+===
+
+Use canary.sh to verify configuration changes. This creates a seperate
+nginx deployment in the `istio-io-canary` namespace of the istio-io
+GKE cluster and runs some basic tests.
+
+    ./canary.sh
+    NAME       TYPE      DATA      AGE
+    istio.io   Opaque    2         4h
+    configmap "nginx" configured
+    deployment "istio-io" configured
+    service "istio-io" configured
+    deployment "istio-io" scaled
+    deployment "istio-io" scaled
+    waiting for all replicas to be up
+    python test.py -q
+    GET: https://istio.io => 200
+    REDIR: http://istio.io => https://istio.io/
+    REDIR: http://istio.io/4385 => https://istio.io/4385
+    ----------------------------------------------------------------------
+    Ran 3 tests in 0.710s
+
+    OK
+
+The canary cluster has a separate load balanced IP which can be used
+for additional manual checks. Use steps in the testing section above
+to determine the ingress IP of the canary cluster.
+
+For the real deployment set kubectl to target the production cluster
+and run `make deploy`. Nginx doesn't auto-detect configuration file
+changes so pods may need to be manually killed to force deployment to
+restart nginx with new configuration via ConfigMaps.
+
+Design
+===
+
+This repo is based on https://github.com/kubernetes/k8s.io and uses
+various Google Cloud platform services for the actual
+infrastructure. This document describes the high-level design for the
+istio.io infrastructure beyond what is already documented by the
+kubernetes YAML files. When in doubt read the source and
+https://cloud.google.com/dns/docs or open an GH issue. There are
+certainly ways to improve upon this approach so suggestions and PR
+welcome.
+
+The basic idea is to use a L4 load balancer in front of a cluster of
+nginx proxies. The L4 load balancer distributes traffic to all healthy
+proxy instances whose number can be scaled up/down based on system
+load and desired reliability.
+
+### DNS and addresses
+
+Cloud DNS is used for easy automatic management of DNS records,
+e.g. auto-certificate renewal via DNS challenge with ACMA client can
+be easily integrated into cluster.
+
+    $ gcloud dns record-sets list --zone=istio-io
+    NAME                               TYPE   TTL    DATA
+    istio.io.                          A      300    35.185.199.142
+    istio.io.                          NS     21600  ns-cloud-e1.googledomains.com.,ns-cloud-e2.googledomains.com.,ns-cloud-e3.googledomains.com.,ns-cloud-e4.googledomains.com.
+    istio.io.                          SOA    21600  ns-cloud-e1.googledomains.com. cloud-dns-hostmaster.google.com. 1 21600 3600 259200 300
+    www.istio.io.                      CNAME  300    istio.io.
+
+Two public ipv4 addresses are used for istio.io: `istio-io-prod` for
+the *.istio.io sites and `istio-io-canary` for canary tests. The A
+records for the `istio.io` domain point to the `istio-io-prod`
+address.
+
+    $ gcloud compute addresses list
+    NAME             REGION    ADDRESS         STATUS
+    istio-io-canary  us-west1  104.198.5.229   IN_USE
+    istio-io-prod    us-west1  35.185.199.142  IN_USE
+
+### Network load balancer and kubernetes services
+
+A kubernetes service with `type: LoadBalancer` maps an externally
+accessible IP to the backend services. GKE does most of the work here
+and sets up the necessary GCP load balancer rules when the kubernetes
+service is created.
+
+- [`service-prod.yaml`](https://github.com/istio/istio.io/blob/master/istio.io/service-prod.yaml) handles *.istio.io.
+- [`service-canary.yaml`](https://github.com/istio/istio.io/blob/master/istio.io/service-prod.yaml) handles the `istio-io-canary` address and should be run in a seperate namespace.
+- [`service-dev.yaml`](https://github.com/istio/istio.io/blob/master/istio.io/service-prod.yaml) allows for developers to test configuration changes with an ephemeral address.
+
+### TLS
+
+Certificates for TLS termination are from [Let's
+Encrypt](https://letsencrypt.org/). The current certificates are
+generated out-of-band and provided to nginx proxies via kubernetes
+secrets. Something like
+[kube-cert-manager](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=kube-cert-manager&*)
+could be used to automate certificate renewal.
+
+- Manual method:
+
+Use [certbot](https://certbot.eff.org/) to renew certificates for the
+necessary (sub)domains. Add the required DNS `TXT` records through
+Cloud DNS. Its best to wait 5-10 minutes after DNS records are updated
+before completing verification as it may take some time for DNS
+changes to propogate and be picked up by Let's Encrypt's verification
+server.
+
+    sudo certbot-auto certonly --manual -d istio.io,www.istio.io,velodrome.istio.io,gcsweb.istio.io,prow.istio.io --preferred-challenges=dns
+
+Backup current certificate secret in case changes need to be rolled
+back.
+
+    kubectl get secret istio.io -o yaml > previous-secret-istio-io.yaml
+
+Copy generated key and certificate file to current directory and
+refresh kubernetes certificate secret.
+
+    sudo cp /etc/letsencrypt/live/istio.io/privkey.pem tls.key
+    sudo cp /etc/letsencrypt/live/istio.io/fullchain.pem tls.crt
+    kubectl create secret generic istio.io --from-file=tls.key --from-file=tls.crt --dry-run -o yaml | kubectl apply -f -
+
+Force nginx to pick-up the new certificates by using `/usr/sbin/nginx -s reload`
+or delete the nginx pods and letting kubernetes restart with udpated
+configuration and certs.
+
+- Automatic method: *TODO*
+
+Download trusted CA certificates for backend (e.g. istio.github.io)
+verification and store as a kubernetes secret.
+
+    curl -O https://www.digicert.com/CACerts/DigiCertHighAssuranceEVRootCA.crt
+    curl -O https://www.geotrust.com/resources/root_certificates/certificates/GeoTrust_Global_CA.pem
+
+    openssl x509 -inform DER -in DigiCertHighAssuranceEVRootCA.crt -outform PEM -out DigiCertHighAssuranceEVRootCA.pem
+
+    kubectl create secret generic \
+        --from-file=DigiCertHighAssuranceEVRootCA.pem \
+        --from-file=GeoTrust_Global_CA.pem \
+        --dry-run -o yaml > secret-cacerts.yaml

--- a/sites/istio.io/configmap-nginx.yaml
+++ b/sites/istio.io/configmap-nginx.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+data:
+  # Adding new entries here will make them appear as files in the deployment.
+  nginx.conf: |
+    worker_processes 5;
+
+    events {
+    }
+
+    http {
+      # Compression
+      gzip              on;
+      gzip_vary         on;
+      gzip_disable      msie6;
+      gzip_proxied      any;
+      gzip_http_version 1.0;
+      gzip_min_length   256;
+
+      # Certs for all SSL server_names.
+      ssl_certificate     /certs/tls.crt;
+      ssl_certificate_key /certs/tls.key;
+
+      # SSL Session cache
+      ssl_session_cache   shared:SSL:10m;
+      ssl_session_timeout 18h;
+
+      # Proxy settings
+      proxy_http_version      1.1;
+      proxy_next_upstream     error timeout http_500 http_502 http_503 http_504;
+      proxy_ssl_name          $server_name;
+      proxy_ssl_server_name   on;
+      proxy_ssl_session_reuse on;
+      proxy_ssl_verify_depth  3;
+
+      # Cache settings
+      proxy_cache_path              /cache levels=1:2 keys_zone=cache:10m use_temp_path=off;
+      proxy_cache_key               $scheme$server_name$request_uri;
+      proxy_cache_use_stale         updating error timeout http_500 http_502 http_503 http_504;
+      proxy_cache_background_update on;
+
+      # gcsweb.istio.io
+      # Upgrade HTTP to HTTPS
+      server {
+        server_name gcsweb.istio.io;
+        listen 80;
+
+        location = /_healthz {
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        return 301 https://$server_name$request_uri;
+      }
+
+      # Handle HTTPS.
+      upstream gcsweb {
+        server    gcsweb.default.svc.cluster.local:80;
+        keepalive 10;
+      }
+
+      server {
+        server_name gcsweb.istio.io;
+        listen 443 ssl http2;
+
+        location = /_healthz {
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        location / {
+          proxy_set_header Host gcsweb.istio.io;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $remote_addr;
+          proxy_set_header Connection "";
+          proxy_pass       http://gcsweb;
+
+          add_header       X-Cache-Status $upstream_cache_status;
+          proxy_cache      off;
+        }
+      }
+
+      # velodrome.istio.io
+      # Upgrade HTTP to HTTPS
+      server {
+        server_name velodrome.istio.io;
+        listen 80;
+
+        location = /_healthz {
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        return 301 https://$server_name$request_uri;
+      }
+
+      # Handle HTTPS.
+      upstream velodrome {
+        server    130.211.224.127:80;
+        keepalive 10;
+      }
+
+      server {
+        server_name velodrome.istio.io;
+        listen 443 ssl http2;
+
+        location = /_healthz {
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        location / {
+          proxy_set_header Host velodrome.istio.io;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $remote_addr;
+          proxy_set_header Connection "";
+          proxy_pass       http://velodrome;
+
+          add_header       X-Cache-Status $upstream_cache_status;
+          proxy_cache      off;
+        }
+      }
+
+      # return 404 for any unknown servers (i.e. subdomains).
+      server {
+          listen 80 default_server;
+          listen 443 ssl http2 default_server;
+          server_name _;
+          return 404;
+      }
+    }

--- a/sites/istio.io/deployment.yaml
+++ b/sites/istio.io/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-io
+  labels:
+    app: istio-io
+    version: v1
+spec:
+  replicas: 2
+  # selector defaults to template's labels
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: istio-io
+        version: v1
+    spec:
+      terminationGracePeriodSeconds: 5
+      volumes:
+      - name: nginx
+        configMap:
+          name: nginx
+          # Map all keys to files.
+      - name: certs
+        secret:
+          secretName: istio-io-tls
+          # Map all keys to files.
+      - name: cache
+        emptyDir: {}
+      containers:
+      - name: nginx
+        image: nginx:1.13.0-alpine  # = :mainline-alpine as of 2017/4/25
+        resources:
+         limits:
+           cpu: 1
+           memory: 512Mi
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        livenessProbe:
+          httpGet:
+            path: /_healthz
+            port: 80
+            httpHeaders:
+              - name: Host
+                value: istio.io
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 2
+        volumeMounts:
+        - name: nginx
+          mountPath: /etc/nginx
+          readOnly: true
+        - name: certs
+          mountPath: /certs
+          readOnly: true
+        - name: cache
+          mountPath: /cache
+          readOnly: false

--- a/sites/istio.io/gcsweb/Makefile
+++ b/sites/istio.io/gcsweb/Makefile
@@ -1,0 +1,12 @@
+PROJECT ?= istio-testing
+ZONE    ?= us-west1-a
+CLUSTER ?= prow
+
+deploy: get-cluster-credentials
+	kubectl apply -f deployment.yaml
+	kubectl apply -f service.yaml
+
+get-cluster-credentials:
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+.PHONY: deploy get-cluster-credentials

--- a/sites/istio.io/gcsweb/README.md
+++ b/sites/istio.io/gcsweb/README.md
@@ -1,0 +1,38 @@
+`gcsweb` is a tiny web frontend to [GCS](https://cloud.google.com/storage/docs/) browsing that DOES NOT REQUIRE A GOOGLE LOGIN.
+
+See it in action: http://gcsweb.istio.io/gcs/istio-release/releases/
+
+#### Problem
+
+`istio` releases can be downloaded using direct API links to specific
+files. However, to browse all available files at
+https://console.cloud.google.com/storage/browser/istio-release/releases/
+or with `gsutil` people
+[need Google login](https://cloud.google.com/storage/docs/access-public-data).
+
+#### Solution
+
+Run a web app that uses pubic API to access public buckets, extract
+information about directory structure and present it to the users with direct
+links to specific files.
+
+#### More info
+
+1. `gcsweb` is just a tool, anyone can run it at any URL with any allowed
+[buckets](https://cloud.google.com/storage/docs/key-terms#buckets) they want.
+
+2. `gcsweb` is not designed for initial browsing (yet?) - it doesn't list
+which GCS buckets are available, and because bucket is a part of URL, you
+need a documented link to browse.
+
+#### Installation and deployment
+
+`gcsweb` is built from source code at
+https://github.com/kubernetes/test-infra/tree/master/gcsweb into Docker
+container, which is then uploaded to private container storage at
+https://gcr.io/google_containers/gcsweb-amd64 and fetched during processing
+of `deployment.yaml` by `kubectl apply`.
+
+```
+make deploy
+```

--- a/sites/istio.io/gcsweb/deployment.yaml
+++ b/sites/istio.io/gcsweb/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  replicas: 2
+  # selector defaults from template labels
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gcsweb
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: gcsweb
+          image: k8s.gcr.io/gcsweb-amd64:v1.0.6
+          args:
+            - -b=istio-build
+            - -b=istio-artifacts
+            - -b=istio-release
+            - -b=istio-prerelease
+            - -b=istio-release-pipeline-data
+            - -p=8080
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2

--- a/sites/istio.io/gcsweb/service.yaml
+++ b/sites/istio.io/gcsweb/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  selector:
+    app: gcsweb
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/sites/istio.io/service.yaml
+++ b/sites/istio.io/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-io
+  annotations:
+    service.beta.kubernetes.io/external-traffic: OnlyLocal
+spec:
+  selector:
+    app: istio-io
+  type: LoadBalancer
+  loadBalancerIP: 35.185.199.142
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443

--- a/sites/kube-cert-manager/README.md
+++ b/sites/kube-cert-manager/README.md
@@ -1,0 +1,41 @@
+# Creating a HTTPs Nginx ingress
+
+We are using cert-manager with Let's encrypt
+
+More detail information at https://cert-manager.readthedocs.io/en/latest/getting-started/1-configuring-helm.html
+
+
+## Installing Cert Manager
+
+Make sure you have helm installed.
+
+Create a ClusterRoleBinding such that tiller can can install deployments in
+every namespace:
+
+    kubectl apply -f rbac-config.yaml
+
+Then install tiller
+
+    helm init --service-account tiller
+
+Once helm is installed properly, you can proceed by installing cert-manager
+
+    helm install \
+    --name cert-manager \
+    --namespace kube-system \
+    stable/cert-manager
+
+## Setting Up Cert Management
+
+We are using a cluster issuer to generate certs with Let's encrypt using DNS
+validation
+
+    kubectl apply -f cluster-issuer.yaml
+
+We can now have create a cert
+
+    kubectl apply -f istio.io-cert.yaml
+
+This will automatically create the istio-io-tls secret containing the certs used
+in the nginx deployment.
+

--- a/sites/kube-cert-manager/cluster-issuer.yaml
+++ b/sites/kube-cert-manager/cluster-issuer.yaml
@@ -1,0 +1,26 @@
+---
+# cluster-issuer
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  namespace: default
+  # Adjust the name here accordingly
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: jasonyoung@google.com
+    # Name of a secret used to store the ACME account private key from step 3
+    privateKeySecretRef:
+      name: letsencrypt-private-key
+    dns01:
+      providers:
+      - name: clouddns
+        clouddns:
+          serviceAccountSecretRef:
+            name: clouddns
+            key: clouddns.key.json
+          project: istio-io
+

--- a/sites/kube-cert-manager/istio.io-cert.yaml
+++ b/sites/kube-cert-manager/istio.io-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: istio-io
+  namespace: default
+spec:
+  secretName: istio-io-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: '*.istio.io'
+  dnsNames:
+  - istio.io
+  acme:
+    config:
+    - dns01:
+        provider: clouddns
+      domains:
+      - '*.istio.io'
+      - istio.io

--- a/sites/kube-cert-manager/rbac-config.yaml
+++ b/sites/kube-cert-manager/rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system


### PR DESCRIPTION
Left to do:
- Create a new IP address in istio-testing for both service
- Update cert manager config with the one from site
- Update documentation (get rid of canary, use only prod)
- Copy the service account use by cert manager to the prow cluster
- Once all traffic is routed to the prow cluster, let Jason know to kill the old cluster
