### PR TITLE
Enable prow tests for auth-v2 branch

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.authz-v2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.authz-v2.yaml
@@ -1,0 +1,400 @@
+job_template: &job_template
+  branches:
+  - "^authz-v2$"
+  decorate: true
+  path_alias: istio.io/istio
+
+istio_container: &istio_container
+  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  # Docker in Docker
+  securityContext:
+    privileged: true
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "24Gi"
+      cpu: "7000m"
+
+presubmits:
+
+  istio/istio:
+
+  - name: istio-unit-tests
+    <<: *job_template
+    context: prow/istio-unit-tests.sh
+    always_run: true
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-unit-tests.sh
+      nodeSelector:
+        testing: build-pool
+
+  - name: istio-integ-local-tests
+    <<: *job_template
+    context: prow/istio-integ-local-tests.sh
+    always_run: true
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-integ-local-tests.sh
+      nodeSelector:
+        testing: build-pool
+
+  - name: istio-integ-k8s-tests
+    <<: *job_template
+    context: prow/istio-integ-k8s-tests.sh
+    optional: true
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-integ-k8s-tests.sh
+      nodeSelector:
+        testing: build-pool
+
+  - name: test-e2e-mixer-no_auth
+    <<: *job_template
+    optional: true
+    skip_report: true
+    context: "prow: test-e2e-mixer-no_auth"
+    max_concurrency: 5
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/test-e2e-mixer-no_auth.sh
+      nodeSelector:
+        testing: test-pool
+
+  - name: istio-presubmit
+    <<: *job_template
+    context: prow/istio-presubmit.sh
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-presubmit.sh
+      nodeSelector:
+        testing: build-pool
+    run_after_success:
+    - name: istio-pilot-e2e-envoyv2-v1alpha3
+      <<: *job_template
+      always_run: true
+      context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-mixer-no_auth
+      <<: *job_template
+      always_run: true
+      context: prow/e2e-mixer-no_auth.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-mixer-no_auth.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-dashboard
+      <<: *job_template
+      always_run: true
+      context: prow/e2e-dashboard.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-dashboard.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-bookInfoTests-envoyv2-v1alpha3
+      <<: *job_template
+      always_run: true
+      context: prow/e2e-bookInfoTests-v1alpha3.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-simpleTests
+      <<: *job_template
+      always_run: true
+      context: prow/e2e-simpleTests.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-simpleTests.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-simpleTestsMinProfile
+      <<: *job_template
+      optional: true
+      context: prow/e2e-simpleTests-minProfile.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-simpleTests-minProfile.sh
+        nodeSelector:
+          testing: test-pool
+    - name: istio-pilot-multicluster-e2e
+      <<: *job_template
+      always_run: true
+      context: prow/istio-pilot-multicluster-e2e.sh
+      optional: true
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/istio-pilot-multicluster-e2e.sh
+        nodeSelector:
+          testing: test-pool
+    - name: istio_auth_sds_e2e
+      <<: *job_template
+      always_run: true
+      context: prow/e2e_pilotv2_auth_sds.sh
+      optional: true
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e_pilotv2_auth_sds.sh
+        nodeSelector:
+          testing: test-pool
+    - name: release-test
+      <<: *job_template
+      always_run: true
+      context: prow/release-test.sh
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/release-test.sh
+        nodeSelector:
+          testing: test-pool
+
+
+
+postsubmits:
+
+  istio/istio:
+  - name: istio-integ-local-tests
+    <<: *job_template
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-integ-local-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-integ-k8s-tests
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-integ-k8s-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-postsubmit
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-postsubmit.sh
+      nodeSelector:
+        testing: test-pool
+    run_after_success:
+    - name: e2e-simpleTests
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-simpleTests.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-simpleTestsMinProfile
+      <<: *job_template
+      optional: true
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-simpleTests-minProfile.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-simpleTests-non-mcp
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-simpleTests-non-mcp.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-bookInfoTests-envoyv2-v1alpha3
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+        nodeSelector:
+          testing: test-pool
+    - name: istio-pilot-e2e-envoyv2-v1alpha3
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+        nodeSelector:
+          testing: test-pool
+    - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-mixer-no_auth
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-mixer-no_auth.sh
+        nodeSelector:
+          testing: test-pool
+    - name: e2e-dashboard
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e-dashboard.sh
+        nodeSelector:
+          testing: test-pool
+    - name: istio_auth_sds_e2e
+      <<: *job_template
+      labels:
+        preset-service-account: "true"
+      max_concurrency: 5
+      spec:
+        containers:
+        - <<: *istio_container
+          command:
+          - entrypoint
+          - prow/e2e_pilotv2_auth_sds.sh
+        nodeSelector:
+          testing: test-pool


### PR DESCRIPTION
We branched off a new branch from **release-1.1** called [authz-v2](https://github.com/istio/istio/tree/authz-v2). We'd like to have same prow tests as **release-1.1**'s triggered when a PR is created for **authz-v2**. 