### PR TITLE
Create new prowbazel image for bazel 0.22

### DIFF
--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION ?= 0.4.13
+VERSION ?= 0.5.0
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -44,3 +44,4 @@ Our dependency on this script is because it appropariately writes test job resul
 * 0.4.11: update clang to 6.0
 * 0.4.12: update golang to 1.10.4 and docker to 18.06.1-CE
 * 0.4.13: Update docker to use overlay2 fs for performance and bazel to 0.16.1
+* 0.5.0: Update bazel to 0.22

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.4.13
+  - image: gcr.io/istio-testing/prowbazel:0.5.0
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.4.13
+  - image: gcr.io/istio-testing/prowbazel:0.5.0
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"


### PR DESCRIPTION
Create new prowbazel image for bazel 0.22 and update proxy jobs on master to use it.