### PR TITLE
Fix branch protector configuration

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -88,6 +88,11 @@ branch-protection:
             - "ci/circleci: test"
           branches:
             <<: *blocked_branches
+            collab-galley:
+              protect: true
+              restrictions:
+                teams:
+                - istio-hackers
             collab-gcp-identity:
               protect: true
               restrictions:


### PR DESCRIPTION
Fix branch protector configuration as collag-galley has [required tests](https://github.com/istio/test-infra/blob/master/prow/cluster/jobs/istio/istio/istio.istio.collab-galley.yaml), but is not protected.