### PR TITLE
enforce sds test

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -207,7 +207,6 @@ presubmits:
       <<: *job_template
       always_run: true
       context: prow/e2e_pilotv2_auth_sds.sh
-      optional: true
       labels:
         preset-service-account: "true"
       max_concurrency: 5

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -220,7 +220,6 @@ presubmits:
       <<: *job_template
       always_run: true
       context: prow/e2e_pilotv2_auth_sds.sh
-      optional: true
       labels:
         preset-service-account: "true"
       max_concurrency: 5


### PR DESCRIPTION
With recent fixes to istio_auth_sds_e2e, it is as stable as istio-pilot-e2e-envoyv2-v1alpha3. The flaky tests are not caused by SDS. It is safe to enforce istio_auth_sds_e2e to be required in presubmit.
https://k8s-gubernator.appspot.com/builds/istio-prow/pr-logs/directory/istio-pilot-e2e-envoyv2-v1alpha3?
https://k8s-gubernator.appspot.com/builds/istio-prow/pr-logs/directory/istio_auth_sds_e2e