### PR TITLE
Adding perf testing for daily releases

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -226,6 +226,20 @@ postsubmits:
         - scripts/pipeline_runner.sh
         - release/gcb/run_daily_release.sh
 
+  - name: perf-for-daily-release
+    <<: *job_template
+    run_if_changed: "daily/.*"
+    labels:
+      preset-release-pipeline: "true"
+    spec:
+      <<: *istio_rel_pipeline_spec
+      containers:
+      - <<: *istio_rel_pipeline_container
+        command:
+        - entrypoint
+        - scripts/get_tools_repo.sh
+        - prow/setup_perf_cluster_for_tests.sh
+
   - name: release-monthly
     <<: *job_template
     run_if_changed: "monthly/.*"


### PR DESCRIPTION
get tools was added in https://github.com/istio-releases/pipeline/pull/501
setup perf cluster was added in https://github.com/istio/istio/pull/13159
After this is tested, I will add servicegraph test to run for 10min