### PR TITLE
Use the newly created mason image

### DIFF
--- a/boskos/configs.yaml
+++ b/boskos/configs.yaml
@@ -13,6 +13,9 @@ configs:
             networkpolicy:
               enabled: true
               provider: CALICO
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+            - https://www.googleapis.com/auth/trace.append
           - machinetype: n1-standard-2
             numnodes: 4
             version: 1.11
@@ -42,6 +45,9 @@ configs:
           - machinetype: n1-standard-4
             numnodes: 5
             version: 1.10
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+            - https://www.googleapis.com/auth/trace.append
           - machinetype: n1-standard-4
             numnodes: 5
             version: 1.10

--- a/boskos/mason-deployment.yaml
+++ b/boskos/mason-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-mason
-        image: gcr.io/istio-testing/mason:v20190307-bae43d943
+        image: gcr.io/istio-testing/mason:v20190417-87a1e7f
         args:
         - --config=/etc/config/configs.yaml
         - --service-account=/etc/service-account/service-account.json


### PR DESCRIPTION
Make sure all the clusters have SCOPE information and use the newly created mason image which uses test-infra from head.(https://github.com/istio/test-infra/issues/1183)
I have issued "make mason-deployment"