### PR TITLE
update istio/proxy to use prowbazel 0.5.2 with gcc-7/g++-7

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.1
+  - image: gcr.io/istio-testing/prowbazel:0.5.2
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.1
+  - image: gcr.io/istio-testing/prowbazel:0.5.2
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.1
+  - image: gcr.io/istio-testing/prowbazel:0.5.2
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.1
+  - image: gcr.io/istio-testing/prowbazel:0.5.2
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"


### PR DESCRIPTION
For istio/proxy#2179

/assign @icygalz
I only updated the prowbazel for istio/proxy in `master` and `wasm` branch, not including 1.1 and other periodic jobs. I assume only the istio/proxy in `master` and `wasm` branch will need to compile with the latest istio/proxy code, right?