### PR TITLE
Updating BOT PR description

### DIFF
--- a/toolbox/deps_update/main.go
+++ b/toolbox/deps_update/main.go
@@ -40,7 +40,7 @@ var (
 const (
 	istioDepsFile         = "istio.deps"
 	prTitlePrefix         = "[BOT PR] to update dependencies of "
-	prBody                = "This PR will be merged automatically once checks are successful."
+	prBody                = "This PR will NOT be merged automatically once checks are successful. NEEDS approval from OWNERS."
 	dependencyUpdateLabel = "dependency-update"
 
 	// CI Artifacts URLs


### PR DESCRIPTION
The PR created by BOT still needs APPROVAL from OWNERs.
Work is in progress for either creating a new BOT for run periodic jobs and/or running the job in a new cluster that is not shared with test cluster.