### PR TITLE
Update Tide config to allow merge without approval for deps update BO…

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -213,6 +213,21 @@ branch-protection:
 tide:
   queries:
   - repos:
+    - istio/istio
+    - istio/proxy
+    labels:
+    - lgtm
+    - "cla: yes"
+    - dependency-update
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+    includedBranches:
+    - master
+  - repos:
     - istio/api
     - istio/test-infra
     - istio/istio


### PR DESCRIPTION
Update TIde config to allow merge without /approve for deps update BOT PR.