### PR TITLE
Removing Integration tests from Release-1.1

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -238,6 +238,7 @@ presubmits:
 
 postsubmits:
 
+  istio/istio:
   - name: istio-postsubmit
     <<: *job_template
     labels:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -34,35 +34,6 @@ presubmits:
       nodeSelector:
         testing: build-pool
 
-  - name: istio-integ-local-tests
-    <<: *job_template
-    context: prow/istio-integ-local-tests.sh
-    always_run: true
-    spec:
-      containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/istio-integ-local-tests.sh
-      nodeSelector:
-        testing: build-pool
-
-  - name: istio-integ-k8s-tests
-    <<: *job_template
-    context: prow/istio-integ-k8s-tests.sh
-    optional: true
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/istio-integ-k8s-tests.sh
-      nodeSelector:
-        testing: build-pool
-
   - name: test-e2e-mixer-no_auth
     <<: *job_template
     optional: true
@@ -267,29 +238,6 @@ presubmits:
 
 postsubmits:
 
-  istio/istio:
-  - name: istio-integ-local-tests
-    <<: *job_template
-    spec:
-      containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/istio-integ-local-tests.sh
-      nodeSelector:
-        testing: test-pool
-  - name: istio-integ-k8s-tests
-    <<: *job_template
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/istio-integ-k8s-tests.sh
-      nodeSelector:
-        testing: test-pool
   - name: istio-postsubmit
     <<: *job_template
     labels:


### PR DESCRIPTION
The Integration tests in Release-1.1 are not stable. It is not providing any good signals for quality, and causing spurious errors/flake detection in testgrid.