### PR TITLE
Revert "Apply plugin config per-repo rather than on all repos."

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -56,33 +56,7 @@ approve:
   lgtm_acts_as_approve: true
 
 plugins:
-  istio/istio:
-  - approve
-  - assign
-  - blunderbuss
-  - golint
-  - help
-  - hold
-  - lgtm
-  - lifecycle
-  - slackevents
-  - trigger
-  - wip
-
-  istio/api:
-  - approve
-  - assign
-  - blunderbuss
-  - golint
-  - help
-  - hold
-  - lgtm
-  - lifecycle
-  - slackevents
-  - trigger
-  - wip
-
-  istio/proxy:
+  istio:
   - approve
   - assign
   - blunderbuss
@@ -107,17 +81,6 @@ plugins:
   - shrug
   - skip
   - yuks
-  - approve
-  - assign
-  - blunderbuss
-  - golint
-  - help
-  - hold
-  - lgtm
-  - lifecycle
-  - slackevents
-  - trigger
-  - wip
 
   istio-releases/pipeline:
   - lifecycle


### PR DESCRIPTION
Reverts istio/test-infra#1229
Looks like it removed ability for istio-testing to add labels automatically.