### PR TITLE
Remove broken Jenkins deployment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ are defined. Only once tests are passing and after review approval can a PR be m
 exists for that module, a new fastForward branch (based on HEAD of master) will be created and a PR will be automatically
 created for the stable branch. This will trigger qualification jobs.
 
-More details [here](doc/deployment.md).
-
 ## Tests Types ##
 
 * Unit tests: Should be done in specific modules for features implemented in a module. (PR to master)


### PR DESCRIPTION
It's possible that as of [this commit](8b71c74d64a669d84d9da4ad1ce07b9c59ebe80b), we can either remove that whole Test Infrastructure paragraph or update it. Happy to just remove the link.