### PR TITLE
make release-test.sh optional in release-1.1 branch

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -222,6 +222,9 @@ presubmits:
       <<: *job_template
       always_run: true
       context: prow/release-test.sh
+      # TODO(https://github.com/istio/istio/issues/13823): The test is blocking check-ins. Once it is fixed, we can
+      # make it required again.
+      optional: true
       labels:
         preset-service-account: "true"
       max_concurrency: 5


### PR DESCRIPTION
https://github.com/istio/istio/issues/13823 It is blocking changes for 1.1 branch, for example https://github.com/istio/istio/pull/13671

Based on the error log, seems like it is because the script takes too long to run:
> {"component":"entrypoint","level":"error","msg":"Process did not finish before 2h0m0s timeout","time":"2019-05-08T18:58:12Z"}