### PR TITLE
Add KinD to istio builder

### DIFF
--- a/scripts/tools/linux-install-golang
+++ b/scripts/tools/linux-install-golang
@@ -14,6 +14,8 @@ GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"
 GO_DIRECTORY="${TOOLS_DIR}/go"
 
+KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
+
 export GOPATH=/opt/go
 mkdir -p ${GOPATH}/bin
 
@@ -21,6 +23,7 @@ function install_go_pkg() {
   go get github.com/github/hub
   go get github.com/golang/dep/cmd/dep
   go get github.com/jstemmer/go-junit-report
+  curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"
 }
 
 function update_go() {


### PR DESCRIPTION
From KinD:
>Building kind now requires go modules (using any upstream supported go version)
or using the new Makefile. Pre-built binaries for all platforms are included with
this release. Please consider using one of the binaries in your CI setups, or
at least pinning to a tagged release.

So using the binary is preferred, and easier than dealing with go modules stuff...

I built the image locally and tried running kind, but for some reason docker says
`* Starting Docker: docker `
but doesn't actual start. Not sure why or how this image is intended used... Presumably if docker works now it will work with this change though