### PR TITLE
Remove required tests check for gce-collab-identity

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -133,17 +133,6 @@ branch-protection:
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
-            collab-gce-identity:
-              protect: true
-              required_status_checks:
-                contexts:
-                  - "ci/circleci: codecov"
-                  - "ci/circleci: shellcheck"
-                  - "ci/circleci: e2e-galley"
-                  - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
-                  - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
-                  - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
-                  - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
         proxy:
           protect: false
           required_status_checks:


### PR DESCRIPTION
Remove required tests check for `gce-collab-identity` branch to reduce the burden of syncing with `master` to pick up patches for tests.

Will review test failures manually to make sure new PRs will not break anything. 

We will cherry-pick changes to `master` later.