### PR TITLE
Create a new istio-builder image with KinD package included

### DIFF
--- a/docker/istio/shared/tools/install-golang.sh
+++ b/docker/istio/shared/tools/install-golang.sh
@@ -6,6 +6,7 @@ GO_VERSION='1.12.4'
 GO_BASE_URL="https://storage.googleapis.com/golang"
 GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"
+KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
 
 export GOPATH=/opt/go
 mkdir -p ${GOPATH}/bin
@@ -19,5 +20,7 @@ go version
 go get github.com/github/hub
 go get github.com/golang/dep/cmd/dep
 go get github.com/jstemmer/go-junit-report
+curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"	
+chmod u+x "${GOPATH}/bin/kind"
 
 rm -rf "${GO_ARCHIVE}"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -17,6 +17,19 @@ istio_container: &istio_container
       memory: "24Gi"
       cpu: "7000m"
 
+istio_container_with_kind: &istio_container_with_kind
+  image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
+  # Docker in Docker
+  securityContext:
+    privileged: true
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "24Gi"
+      cpu: "7000"
+
 presubmits:
 
   istio/istio:
@@ -399,7 +412,7 @@ postsubmits:
     <<: *job_template
     spec:
       containers:
-      - <<: *istio_container
+      - <<: *istio_container_with_kind
         command:
         - entrypoint
         - prow/e2e-kind-simpleTests.sh


### PR DESCRIPTION
I made sure my git clone is clean with only KinD packages addition before creating and pushing new istio-builder images. I enabled the new image only for e2e-kind-simpleTest postsubmit test.
I will monitor the test and once e2e-kind-simpleTest is passing, i will enable the new image for master's postsubmit tests and monitor it before enabling it for presubmit tests.