### PR TITLE
Fixing docker resources for istio_container_with_kind

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -45,7 +45,7 @@ istio_container_with_kind: &istio_container_with_kind
       cpu: "500m"
     limits:
       memory: "24Gi"
-      cpu: "7000"
+      cpu: "7000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -28,7 +28,7 @@ istio_container_with_kind: &istio_container_with_kind
       cpu: "500m"
     limits:
       memory: "24Gi"
-      cpu: "7000"
+      cpu: "7000m"
 
 presubmits:
 


### PR DESCRIPTION
Missing "m" for the cpu  resources.