### PR TITLE
Giving more resources for docker with kind images

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -27,8 +27,8 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "512Mi"
       cpu: "500m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "40Gi"
+      cpu: "8000m"
 
 presubmits:
 
@@ -417,7 +417,7 @@ postsubmits:
         - entrypoint
         - prow/e2e-kind-simpleTests.sh
       nodeSelector:
-        testing: test-pool
+        testing: build-pool
   - name: istio-unit-tests-master
     <<: *job_template
     context: prow/istio-unit-tests.sh


### PR DESCRIPTION
Giving bigger resources for docker with kind packages especially when the test needs to build their own images. Currently only build-pool nodes have the resources for the new resources needed for docker image with kind package.
i will update the test-pool nodes to have more resources if increasing the resources make the test pass.