### PR TITLE
Added tide to istio-releases/pipeline

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -206,6 +206,14 @@ branch-protection:
 tide:
   queries:
   - repos:
+    - istio-releases/pipeline
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+  - repos:
     - istio/api
     - istio/test-infra
     - istio/istio


### PR DESCRIPTION
It seems a PR deleted tide config for istio-releases/pipeline but I couldn't find the culprit PR. Adding tide config for istio-releases/pipeline.