### PR TITLE
Update cmake of prow proxy builder image

### DIFF
--- a/docker/prowbazel/Dockerfile
+++ b/docker/prowbazel/Dockerfile
@@ -21,7 +21,7 @@ RUN /tmp/istio_tmp/scripts/linux-install-software \
 VOLUME /var/lib/docker
 EXPOSE 2375
 
-ENV PATH /usr/local/go/bin:/usr/lib/google-cloud-sdk/bin:/opt/go/bin:${PATH}
+ENV PATH /usr/local/go/bin:/usr/local/cmake/bin:/usr/lib/google-cloud-sdk/bin:/opt/go/bin:${PATH}
 
 # Create bootstrap user
 ENV HOME /home/bootstrap

--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION ?= 0.5.2
+VERSION ?= 0.5.3
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -47,3 +47,4 @@ Our dependency on this script is because it appropariately writes test job resul
 * 0.5.0: Update bazel to 0.22 and clang to 7
 * 0.5.1: Add lld and libc++
 * 0.5.2: Update gcc and g++ to 7.0
+* 0.5.3: Update cmake to 3.8.0

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.2
+  - image: gcr.io/istio-testing/prowbazel:0.5.3
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.2
+  - image: gcr.io/istio-testing/prowbazel:0.5.3
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.2
+  - image: gcr.io/istio-testing/prowbazel:0.5.3
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.2
+  - image: gcr.io/istio-testing/prowbazel:0.5.3
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/scripts/linux-install-software
+++ b/scripts/linux-install-software
@@ -11,6 +11,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # TOOLS
 . ${DIR}/tools/linux-install-bazel || error_exit "Cannot load Bazel install script"
 . ${DIR}/tools/linux-install-clang || error_exit "Cannot load Clang install script"
+. ${DIR}/tools/linux-install-cmake || error_exit "Cannot load cmake install script"
 . ${DIR}/tools/linux-install-docker || error_exit "Cannot load Docker install script"
 . ${DIR}/tools/linux-install-gcloud || error_exit "Cannot load gcloud install script"
 . ${DIR}/tools/linux-install-golang || error_exit "Cannot load golang install script"
@@ -31,7 +32,6 @@ function install_packages() {
     apt-transport-https \
     build-essential \
     ca-certificates \
-    cmake \
     curl \
     g++ \
     libtool \
@@ -92,6 +92,7 @@ update_bazel
 update_clang
 update_helm
 update_gcc
+install_cmake
 clear_apt
 
 echo "Software installation complete."

--- a/scripts/tools/linux-install-cmake
+++ b/scripts/tools/linux-install-cmake
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [[ "$(uname)" != "Linux" ]]; then
+  echo "Run on Linux only."
+  exit 1
+fi
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
+
+CMAKE_VERSION='3.8.0'
+CMAKE_BASE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}"
+CMAKE_ARCHIVE="cmake-${CMAKE_VERSION}-Linux-x86_64"
+CMAKE_URL="${CMAKE_BASE_URL}/${CMAKE_ARCHIVE}.tar.gz"
+CMAKE_DOWNLOAD_DIRECTORY="${TOOLS_DIR}/cmake"
+CMAKE_DIRECTORY="/usr/local/cmake"
+
+function install_cmake() {
+  if [[ -d "${CMAKE_DIRECTORY}" ]]; then
+    mkdir -p "${CMAKE_DIRECTORY}"
+  fi
+  if [[ -d "${CMAKE_DOWNLOAD_DIRECTORY}" ]]; then
+    mkdir -p "${CMAKE_DOWNLOAD_DIRECTORY}"
+  fi
+  
+  retry -n 3 wget -q -nc -P "${CMAKE_DIRECTORY}" "${CMAKE_URL}" \
+      || error_exit 'Could not download cmake.'
+  ${SUDO} tar -C ${CMAKE_DIRECTORY} -xzf "${CMAKE_DIRECTORY}/${CMAKE_ARCHIVE}.tar.gz" \
+      || error_exit 'Could not unpack cmake.'
+
+  sudo mv ${CMAKE_DIRECTORY}/${CMAKE_ARCHIVE}/* /usr/local/cmake/
+  echo 'CMAKE intalled.'
+}

--- a/scripts/tools/linux-install-gcc
+++ b/scripts/tools/linux-install-gcc
@@ -14,7 +14,7 @@ function update_gcc() {
   && sudo ln -s -f gcc-7 `which gcc` \
   && sudo ln -s -f g++-7 `which g++` \
   && echo 'gcc-7/g++-7 installed' \
-  && exit 0
+  && return 0
 
   echo 'failed to install gcc-7/g++-7'
   exit 1


### PR DESCRIPTION
Update prow proxy builder image to use cmake 3.8.0, which is required by envoy-wasm: https://github.com/istio/proxy/pull/2231