### PR TITLE
Remove the old E2E Galley test from required gates.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -145,7 +145,6 @@ branch-protection:
                 - "ci/circleci: codecov"
                 - "ci/circleci: racetest"
                 - "ci/circleci: shellcheck"
-                - "ci/circleci: e2e-galley"
                 - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"


### PR DESCRIPTION
It is subsumed by the Integration test.