### PR TITLE
Pipeline infra

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -51,12 +51,29 @@ presubmits:
 
   istio-releases/pipeline:
 
+  - name: release-build-test-e2e-simpleTests
+    <<: *job_template
+    optional: true
+    always_run: true
+    context: prow/release-e2e-simpleTests
+    max_concurrency: 5
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - scripts/build_test_presubmit.sh
+        - prow/e2e-simpleTests.sh
+      nodeSelector:
+        testing: test-pool
   - name: release-build
     <<: *job_template
     always_run: true
     optional: false
     context: prow/release-build
-    labels:
+    labels: 
       preset-release-pipeline: "true"
     spec:
       <<: *istio_rel_pipeline_spec

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -73,7 +73,7 @@ presubmits:
     always_run: true
     optional: false
     context: prow/release-build
-    labels: 
+    labels:
       preset-release-pipeline: "true"
     spec:
       <<: *istio_rel_pipeline_spec

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -130,6 +130,7 @@ plugins:
   istio-releases/pipeline:
   - lifecycle
   - trigger
+  - hold
 
   istio-ecosystem/authservice:
   - approve


### PR DESCRIPTION
Adding a non-blocking build and test simpleTest for release. This is part 1 of getting rid run_after_success mechanism in istio-releases/pipeline.