### PR TITLE
Change istio/pipeline into istio-releases/pipeline branch

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -157,7 +157,7 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
-  istio/pipeline:
+  istio-releases/pipeline:
   - name: needs-rebase
     events:
       - pull_request


### PR DESCRIPTION
istio/pipeline branch does not exist. Renaming it to the correct branch istio-releases/pipeline.