### PR TITLE
Adding the new README.md

### DIFF
--- a/docker/istio_builders/README.md
+++ b/docker/istio_builders/README.md
@@ -1,0 +1,3 @@
+THIS DIRECTORY HAS BEEN DEPRECATED!
+
+Please take a look at [docker/istio](https://github.com/istio/test-infra/tree/master/docker/istio) directory instead.


### PR DESCRIPTION
docker/istio_builders directory has been deprecated and no longer used. I am adding a short documentation to reduce confusion.