### PR TITLE
Update images to use Golang 1.12.5 and remove kind

### DIFF
--- a/docker/istio/shared/tools/install-golang.sh
+++ b/docker/istio/shared/tools/install-golang.sh
@@ -7,9 +7,6 @@ GO_BASE_URL="https://storage.googleapis.com/golang"
 GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"
 
-# Remove kind
-# KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
-
 export GOPATH=/opt/go
 mkdir -p ${GOPATH}/bin
 
@@ -22,7 +19,5 @@ go version
 go get github.com/github/hub
 go get github.com/golang/dep/cmd/dep
 go get github.com/jstemmer/go-junit-report
-# curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"
-# chmod u+x "${GOPATH}/bin/kind"
 
 rm -rf "${GO_ARCHIVE}"

--- a/docker/istio/shared/tools/install-golang.sh
+++ b/docker/istio/shared/tools/install-golang.sh
@@ -2,11 +2,13 @@
 
 set -eux
 
-GO_VERSION='1.12.4'
+GO_VERSION='1.12.5'
 GO_BASE_URL="https://storage.googleapis.com/golang"
 GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"
-KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
+
+# Remove kind
+# KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
 
 export GOPATH=/opt/go
 mkdir -p ${GOPATH}/bin
@@ -20,7 +22,7 @@ go version
 go get github.com/github/hub
 go get github.com/golang/dep/cmd/dep
 go get github.com/jstemmer/go-junit-report
-curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"	
-chmod u+x "${GOPATH}/bin/kind"
+# curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"
+# chmod u+x "${GOPATH}/bin/kind"
 
 rm -rf "${GO_ARCHIVE}"

--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION ?= 0.5.4
+VERSION ?= 0.5.5
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -49,4 +49,4 @@ Our dependency on this script is because it appropariately writes test job resul
 * 0.5.2: Update gcc and g++ to 7.0
 * 0.5.3: Update cmake to 3.8.0
 * 0.5.4: Update ninja to 1.9.0
-* 0.5.5: Update golang to 1.12.5
+* 0.5.5: Update golang to 1.12.5 and bazel to 0.26.0

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -49,3 +49,4 @@ Our dependency on this script is because it appropariately writes test job resul
 * 0.5.2: Update gcc and g++ to 7.0
 * 0.5.3: Update cmake to 3.8.0
 * 0.5.4: Update ninja to 1.9.0
+* 0.5.5: Update golang to 1.12.5

--- a/scripts/tools/linux-install-bazel
+++ b/scripts/tools/linux-install-bazel
@@ -8,7 +8,7 @@ fi
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
 
-BAZEL_VERSION='0.22.0'
+BAZEL_VERSION='0.26.0'
 BAZEL_BASE_URL='https://github.com/bazelbuild/bazel/releases/download'
 BAZEL_SH="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
 BAZEL_URL="${BAZEL_BASE_URL}/${BAZEL_VERSION}/${BAZEL_SH}"

--- a/scripts/tools/linux-install-golang
+++ b/scripts/tools/linux-install-golang
@@ -14,9 +14,6 @@ GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"
 GO_DIRECTORY="${TOOLS_DIR}/go"
 
-# Remove kind
-# KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
-
 export GOPATH=/opt/go
 mkdir -p ${GOPATH}/bin
 
@@ -24,7 +21,6 @@ function install_go_pkg() {
   go get github.com/github/hub
   go get github.com/golang/dep/cmd/dep
   go get github.com/jstemmer/go-junit-report
-#  curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"
 }
 
 function update_go() {

--- a/scripts/tools/linux-install-golang
+++ b/scripts/tools/linux-install-golang
@@ -8,13 +8,14 @@ fi
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
 
-GO_VERSION='1.11.4'
+GO_VERSION='1.12.5'
 GO_BASE_URL="https://storage.googleapis.com/golang"
 GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"
 GO_DIRECTORY="${TOOLS_DIR}/go"
 
-KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
+# Remove kind
+# KIND_RELEASE="https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64"
 
 export GOPATH=/opt/go
 mkdir -p ${GOPATH}/bin
@@ -23,7 +24,7 @@ function install_go_pkg() {
   go get github.com/github/hub
   go get github.com/golang/dep/cmd/dep
   go get github.com/jstemmer/go-junit-report
-  curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"
+#  curl -L "${KIND_RELEASE}" > "${GOPATH}/bin/kind"
 }
 
 function update_go() {


### PR DESCRIPTION
  - gcr.io/istio-testing/istio-builder:{date}

Also updated Bazel to 0.26.0

Once this is merged and the images built (also need date tag of version pushed), another PR can be merged to specify the new images in the yams files.