### PR TITLE
Update master prow jobs to use new Golang 1.12 and bazel 0.26.0 updates

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "7000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.4
+  - image: gcr.io/istio-testing/prowbazel:0.5.5
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.4
+  - image: gcr.io/istio-testing/prowbazel:0.5.5
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.4
+  - image: gcr.io/istio-testing/prowbazel:0.5.5
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.4
+  - image: gcr.io/istio-testing/prowbazel:0.5.5
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -1,5 +1,5 @@
 test_infra_container: &test_infra_container
-  image: gcr.io/istio-testing/test-infra-builder:v20190118-90fecc84
+  image: gcr.io/istio-testing/test-infra-builder:v20190531-6fbeace
   # Bazel needs privileged mode in order to sandbox builds.
   securityContext:
     privileged: true


### PR DESCRIPTION
Will pick up release-1.2 in another PR after verifying `master` works.