### PR TITLE
[WIP] Update 1.2 prow jobs to use new Golang 1.12 and bazel 0.26.0 updates

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "7000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "7000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true
@@ -36,7 +36,7 @@ istio_container: &istio_container
       cpu: "7000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   securityContext:
     privileged: true
   resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.2.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.5
+  - image: gcr.io/istio-testing/prowbazel:0.5.6
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.5
+  - image: gcr.io/istio-testing/prowbazel:0.5.6
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.2.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.2
+  - image: gcr.io/istio-testing/prowbazel:0.5.5
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.2
+  - image: gcr.io/istio-testing/prowbazel:0.5.5
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"


### PR DESCRIPTION
Wait to verify these changes in `master` before merging for `release1.2`