### PR TITLE
Revert "Add lint test"

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -47,20 +47,6 @@ presubmits:
       nodeSelector:
         testing: build-pool
 
-  - name: istio-lint-master
-    <<: *job_template
-    context: prow/istio-lint.sh
-    always_run: true
-    optional: true
-    spec:
-      containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/istio-lint.sh
-      nodeSelector:
-        testing: test-pool
-
   - name: integ-framework-local-presubmit-tests-master
     <<: *job_template
     context: prow/integ-framework-local-presubmit-tests.sh


### PR DESCRIPTION
Reverts istio/test-infra#1316

linter isn't working, circleci is now so no immediate need. Let's revert for now to avoid disruption