### PR TITLE
Making sure only build image job are running on build-pool

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -45,7 +45,7 @@ presubmits:
         - entrypoint
         - prow/istio-unit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-framework-local-presubmit-tests-master
     <<: *job_template
@@ -58,7 +58,7 @@ presubmits:
             - entrypoint
             - prow/integ-framework-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-galley-local-presubmit-tests-master
     <<: *job_template
@@ -71,7 +71,7 @@ presubmits:
             - entrypoint
             - prow/integ-galley-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-istioctl-local-presubmit-tests-master
     <<: *job_template
@@ -99,7 +99,7 @@ presubmits:
             - entrypoint
             - prow/integ-mixer-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-pilot-local-presubmit-tests-master
     <<: *job_template
@@ -112,7 +112,7 @@ presubmits:
             - entrypoint
             - prow/integ-pilot-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-security-local-presubmit-tests-master
     <<: *job_template
@@ -125,7 +125,7 @@ presubmits:
             - entrypoint
             - prow/integ-security-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-telemetry-local-presubmit-tests-master
     <<: *job_template
@@ -548,7 +548,7 @@ postsubmits:
         - entrypoint
         - prow/e2e-kind-simpleTests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - name: istio-unit-tests-master
     <<: *job_template
     context: prow/istio-unit-tests.sh
@@ -560,7 +560,7 @@ postsubmits:
         - entrypoint
         - prow/istio-unit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - name: integ-framework-k8s-postsubmit-tests-master
     <<: *job_template
     labels:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -17,19 +17,6 @@ istio_container: &istio_container
       memory: "24Gi"
       cpu: "7000m"
 
-istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
-  # Docker in Docker
-  securityContext:
-    privileged: true
-  resources:
-    requests:
-      memory: "512Mi"
-      cpu: "500m"
-    limits:
-      memory: "24Gi"
-      cpu: "7000"
-
 presubmits:
 
   istio/istio:
@@ -45,7 +32,7 @@ presubmits:
         - entrypoint
         - prow/istio-unit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-framework-local-presubmit-tests-release-1.2
     <<: *job_template
@@ -58,7 +45,7 @@ presubmits:
             - entrypoint
             - prow/integ-framework-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-galley-local-presubmit-tests-release-1.2
     <<: *job_template
@@ -71,7 +58,7 @@ presubmits:
             - entrypoint
             - prow/integ-galley-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-mixer-local-presubmit-tests-release-1.2
     <<: *job_template
@@ -85,7 +72,7 @@ presubmits:
             - entrypoint
             - prow/integ-mixer-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-pilot-local-presubmit-tests-release-1.2
     <<: *job_template
@@ -98,7 +85,7 @@ presubmits:
             - entrypoint
             - prow/integ-pilot-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: integ-security-local-presubmit-tests-release-1.2
     <<: *job_template
@@ -111,7 +98,7 @@ presubmits:
             - entrypoint
             - prow/integ-security-local-presubmit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: istio-presubmit-release-1.2
     <<: *job_template
@@ -403,16 +390,6 @@ postsubmits:
         command:
         - entrypoint
         - prow/istio-integ-local-tests.sh
-      nodeSelector:
-        testing: test-pool
-  - name: istio-kind-simpleTest-release-1.2
-    <<: *job_template
-    spec:
-      containers:
-      - <<: *istio_container_with_kind
-        command:
-        - entrypoint
-        - prow/e2e-kind-simpleTests.sh
       nodeSelector:
         testing: test-pool
   - name: istio-postsubmit-release-1.2


### PR DESCRIPTION
Making sure only build image job are running on build-pool and taking out simpleTest-on-KinD from release-1.2 postsubmit tests. This test hasn't succeed yet.