### PR TITLE
Update prow-staging to use prow image with Golang 1.12 and kind

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true
@@ -18,7 +18,7 @@ istio_container: &istio_container
       cpu: "7000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true


### PR DESCRIPTION
Should I remove the kind container `istio_container_with_kind`, moving the CPU size up to `istio_container` and update the jobs to use `istio_container` as well?