### PR TITLE
Reducing max pod age to 6h

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -19,7 +19,7 @@ plank:
 sinker:
   resync_period: 1h
   max_prowjob_age: 168h
-  max_pod_age: 12h
+  max_pod_age: 6h
 
 deck:
   tide_update_period: 1s


### PR DESCRIPTION
From testgrid eng:
"TestGrid stops looking back after finding X unchanged results (like 100), and tests time out after 24 hours if they're left running like that.So the recent runs are finishing quickly enough that we hit 100 unchanged runs and stop looking back further than that, leaving the older pending runs alone"

This can be alleviate with making the old job die faster. Reducing the max age pod will help but issue might resurface depending how fast the presubmit moves. This is the current testgrid's limitation.