### PR TITLE
Update prow images for master to Golang 1.12.5 with kind v0.30.0

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "7000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true
@@ -36,7 +36,7 @@ istio_container: &istio_container
       cpu: "7000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190603-0df7dcf1
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   securityContext:
     privileged: true
   resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190531-aba3be6
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true
@@ -18,7 +18,7 @@ istio_container: &istio_container
       cpu: "7000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
+  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.5
+  - image: gcr.io/istio-testing/prowbazel:0.5.6
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.5
+  - image: gcr.io/istio-testing/prowbazel:0.5.6
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.wasm.yaml
@@ -1,7 +1,7 @@
 
 bazel_postsubmit_spec: &bazel_postsubmit_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.5
+  - image: gcr.io/istio-testing/prowbazel:0.5.6
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"
@@ -21,7 +21,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
 
 bazel_spec: &bazel_spec
   containers:
-  - image: gcr.io/istio-testing/prowbazel:0.5.5 
+  - image: gcr.io/istio-testing/prowbazel:0.5.6
     args:
     - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
     - "--clean"

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -1,5 +1,5 @@
 test_infra_container: &test_infra_container
-  image: gcr.io/istio-testing/test-infra-builder:v20190531-6fbeace
+  image: gcr.io/istio-testing/test-infra-builder:v20190607-32702dcd
   # Bazel needs privileged mode in order to sandbox builds.
   securityContext:
     privileged: true


### PR DESCRIPTION
The base prow image was tested in `prow-staging` in https://github.com/istio/istio/pull/14757.

This PR moves that and associated images to `master`. 

Note: When this is merged, it would be beneficial if someone is available for a bit to possibly revert things in case tests start to fail in `master`. The PR above for `prow-staging` provided feedback that things should work, but want to be safe.

If the approver can check with me on Slack before merging, I can be around to help watch as well.