### PR TITLE
Make removed circle tests non-required

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -88,7 +88,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - "ci/circleci: build"
-            - "ci/circleci: e2e-simple"
             - "ci/circleci: lint"
             - "ci/circleci: test"
           branches:
@@ -113,10 +112,7 @@ branch-protection:
                 contexts:
                 - "ci/circleci: codecov"
                 - "ci/circleci: shellcheck"
-                - "ci/circleci: e2e-galley"
-                - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
-                - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
                 - "merges-blocked-needs-admin"
             release-1.2:
@@ -125,10 +121,7 @@ branch-protection:
                 contexts:
                 - "ci/circleci: codecov"
                 - "ci/circleci: shellcheck"
-                - "ci/circleci: e2e-galley"
-                - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
-                - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
                 - "merges-blocked-needs-admin"
             authz-v2:
@@ -137,10 +130,7 @@ branch-protection:
                 contexts:
                 - "ci/circleci: codecov"
                 - "ci/circleci: shellcheck"
-                - "ci/circleci: e2e-galley"
-                - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
-                - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
             master:
               protect: true
@@ -149,9 +139,7 @@ branch-protection:
                 - "ci/circleci: codecov"
                 - "ci/circleci: racetest"
                 - "ci/circleci: shellcheck"
-                - "ci/circleci: e2e-pilot-auth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
-                - "ci/circleci: e2e-mixer-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
         proxy:
           protect: false


### PR DESCRIPTION
These tests no longer exist, so github waits on them forever