### PR TITLE
Get rid run after success for master releases

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -53,7 +53,6 @@ presubmits:
 
   - name: release-build-test-e2e-simpleTests
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-e2e-simpleTests
     max_concurrency: 5
@@ -70,7 +69,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-upgrade-tests-1.1.7
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-upgrade-tests-1.1.7
     max_concurrency: 5
@@ -87,7 +85,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-istio-unit-tests
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-istio-unit-tests
     max_concurrency: 5
@@ -104,7 +101,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-istioctl-tests
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-istioctl-tests
     max_concurrency: 5
@@ -121,7 +117,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-e2e-pilot-no_auth
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-e2e-pilot-no_auth
     max_concurrency: 5
@@ -138,7 +133,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-e2e-bookInfoTests
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-e2e-bookInfoTests
     max_concurrency: 5
@@ -155,7 +149,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-e2e-mixer-no_auth
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-e2e-mixer-no_auth
     max_concurrency: 5
@@ -172,7 +165,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-e2e-dashboard
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-e2e-dashboard
     max_concurrency: 5
@@ -189,7 +181,6 @@ presubmits:
         testing: test-pool
   - name: release-build-test-e2e-stackdriver
     <<: *job_template
-    optional: true
     always_run: true
     context: prow/release-build-test-e2e-stackdriver
     max_concurrency: 5
@@ -219,160 +210,6 @@ presubmits:
         - entrypoint
         - scripts/pipeline_runner.sh
         - release/gcb/run_build.sh
-    run_after_success:
-    - name: release-upgrade-tests-1.1.7
-      <<: *job_template
-      always_run: true
-      context: prow/release-upgrade-tests-1.1.7
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/upgrade-tests-1.1.7.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-unit-tests
-      <<: *job_template
-      always_run: true
-      context: prow/release-unit-tests
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/istio-unit-tests.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-istioctl-tests
-      <<: *job_template
-      always_run: true
-      context: prow/release-istioctl-tests
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/istioctl-tests.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-e2e-pilot-no_auth
-      <<: *job_template
-      always_run: true
-      context: prow/release-e2e-pilot-no_auth
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/e2e-pilot-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-e2e-bookinfoTests
-      <<: *job_template
-      always_run: true
-      context: prow/release-e2e-bookinfoTests
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-e2e-simpleTests
-      <<: *job_template
-      always_run: true
-      context: prow/release-e2e-simpleTests
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/e2e-simpleTests.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-e2e-mixer-no_auth
-      <<: *job_template
-      always_run: true
-      context: prow/release-e2e-mixer-no_auth
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/e2e-mixer-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-e2e-dashboard
-      <<: *job_template
-      always_run: true
-      context: prow/release-e2e-dashboard
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/e2e-dashboard.sh
-        nodeSelector:
-          testing: test-pool
-
-    - name: release-e2e-stackdriver
-      <<: *job_template
-      always_run: true
-      optional: true
-      context: prow/release-e2e-stackdriver
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - scripts/run-test.sh
-          - prow/e2e-stackdriver.sh
-        nodeSelector:
-          testing: test-pool
 
 postsubmits:
 


### PR DESCRIPTION
Let's try it out for master daily release for now. The release will take longer time because the presubmit will run for longer period of time since each test needs to build&push images before running the test.