### PR TITLE
Deleting run_after_success for release-1.1

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -51,195 +51,193 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: istio-presubmit
+  - name: istio-pilot-e2e-envoyv2-v1alpha3
     <<: *job_template
-    context: prow/istio-presubmit.sh
     always_run: true
+    context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
     labels:
       preset-service-account: "true"
+    max_concurrency: 5
     spec:
       containers:
       - <<: *istio_container
         command:
         - entrypoint
-        - prow/istio-presubmit.sh
+        - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       nodeSelector:
-        testing: build-pool
-    run_after_success:
-    - name: istio-pilot-e2e-envoyv2-v1alpha3
-      <<: *job_template
-      always_run: true
-      context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-mixer-no_auth
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-mixer-no_auth.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-mixer-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-dashboard
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-dashboard.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-dashboard.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-envoyv2-v1alpha3
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-bookInfoTests-v1alpha3.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-trustdomain
-      <<: *job_template
-      always_run: true
-      optional: true
-      context: prow/e2e-bookInfoTests-trustdomain.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-trustdomain.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-simpleTests.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTestsMinProfile
-      <<: *job_template
-      optional: true
-      context: prow/e2e-simpleTests-minProfile.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-minProfile.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-pilot-multicluster-e2e
-      <<: *job_template
-      always_run: true
-      context: prow/istio-pilot-multicluster-e2e.sh
-      optional: true
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-multicluster-e2e.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests-cni
-      <<: *job_template
-      always_run: false
-      context: prow/e2e-simpleTests-cni.sh
-      optional: true
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-cni.sh
-        nodeSelector:
-    - name: istio_auth_sds_e2e
-      <<: *job_template
-      always_run: true
-      context: prow/e2e_pilotv2_auth_sds.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e_pilotv2_auth_sds.sh
-        nodeSelector:
-          testing: test-pool
-    - name: release-test
-      <<: *job_template
-      always_run: true
-      context: prow/release-test.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/release-test.sh
-        nodeSelector:
-          testing: test-pool
+        testing: test-pool
+  - name: e2e-mixer-no_auth
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-mixer-no_auth.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-mixer-no_auth.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-dashboard
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-dashboard.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-dashboard.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-bookInfoTests-v1alpha3.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-trustdomain
+    <<: *job_template
+    always_run: true
+    optional: true
+    context: prow/e2e-bookInfoTests-trustdomain.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-trustdomain.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-simpleTests.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTestsMinProfile
+    <<: *job_template
+    optional: true
+    context: prow/e2e-simpleTests-minProfile.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-minProfile.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-pilot-multicluster-e2e
+    <<: *job_template
+    always_run: true
+    context: prow/istio-pilot-multicluster-e2e.sh
+    optional: true
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-multicluster-e2e.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests-cni
+    <<: *job_template
+    always_run: false
+    context: prow/e2e-simpleTests-cni.sh
+    optional: true
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-cni.sh
+      nodeSelector:
+  - name: istio_auth_sds_e2e
+    <<: *job_template
+    always_run: true
+    context: prow/e2e_pilotv2_auth_sds.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e_pilotv2_auth_sds.sh
+      nodeSelector:
+        testing: test-pool
+  - name: release-test
+    <<: *job_template
+    always_run: true
+    context: prow/release-test.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/release-test.sh
+      nodeSelector:
+        testing: test-pool
 
 
 
 postsubmits:
 
   istio/istio:
-  - name: istio-postsubmit
+  - name: istio-unit-tests
+    <<: *job_template
+    context: prow/istio-unit-tests.sh
+    always_run: true
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-unit-tests.sh
+      nodeSelector:
+        testing: test-pool
+  
+  - name: e2e-simpleTests
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -248,132 +246,119 @@ postsubmits:
       - <<: *istio_container
         command:
         - entrypoint
-        - prow/istio-postsubmit.sh
+        - prow/e2e-simpleTests.sh
       nodeSelector:
         testing: test-pool
-    run_after_success:
-    - name: e2e-simpleTests
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTestsMinProfile
-      <<: *job_template
-      optional: true
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-minProfile.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests-non-mcp
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-non-mcp.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-envoyv2-v1alpha3
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-pilot-e2e-envoyv2-v1alpha3
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-mixer-no_auth
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-mixer-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-dashboard
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-dashboard.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio_auth_sds_e2e
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e_pilotv2_auth_sds.sh
-        nodeSelector:
-          testing: test-pool
+  - name: e2e-simpleTestsMinProfile
+    <<: *job_template
+    optional: true
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-minProfile.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests-non-mcp
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-non-mcp.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-pilot-e2e-envoyv2-v1alpha3
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-mixer-no_auth
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-mixer-no_auth.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-dashboard
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-dashboard.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio_auth_sds_e2e
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e_pilotv2_auth_sds.sh
+      nodeSelector:
+        testing: test-pool


### PR DESCRIPTION
Deleting run_after_success for release-1.0

/hold
only merge after https://github.com/istio/istio/pull/14954 is merged.