### PR TITLE
Deleting run_after_success for release-1.2

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -100,10 +100,90 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: istio-presubmit-release-1.2
+  - name: integ-framework-k8s-presubmit-tests-release-1.2
     <<: *job_template
-    context: prow/istio-presubmit.sh
+    context: prow/integ-framework-k8s-presubmit-tests.sh
+    max_concurrency: 5
     always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-framework-k8s-presubmit-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: integ-galley-k8s-presubmit-tests-release-1.2
+    <<: *job_template
+    context: prow/integ-galley-k8s-presubmit-tests.sh
+    max_concurrency: 5
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-galley-k8s-presubmit-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: integ-mixer-k8s-presubmit-tests-release-1.2
+    <<: *job_template
+    context: prow/integ-mixer-k8s-presubmit-tests.sh
+    optional: true
+    max_concurrency: 5
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-mixer-k8s-presubmit-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: integ-pilot-k8s-presubmit-tests-release-1.2
+    <<: *job_template
+    optional: true
+    context: prow/integ-pilot-k8s-presubmit-tests.sh
+    max_concurrency: 5
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-pilot-k8s-presubmit-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: integ-security-k8s-presubmit-tests-release-1.2
+    <<: *job_template
+    optional: true
+    context: prow/integ-security-k8s-presubmit-tests.sh
+    max_concurrency: 5
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-security-k8s-presubmit-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: test-e2e-mixer-no_auth-release-1.2
+    <<: *job_template
+    optional: true
+    skip_report: true
+    context: "prow: test-e2e-mixer-no_auth"
+    max_concurrency: 5
     labels:
       preset-service-account: "true"
     spec:
@@ -111,272 +191,177 @@ presubmits:
       - <<: *istio_container
         command:
         - entrypoint
-        - prow/istio-presubmit.sh
+        - prow/test-e2e-mixer-no_auth.sh
       nodeSelector:
-        testing: build-pool
-    run_after_success:
-    - name: integ-framework-k8s-presubmit-tests-release-1.2
-      <<: *job_template
-      context: prow/integ-framework-k8s-presubmit-tests.sh
-      max_concurrency: 5
-      always_run: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-framework-k8s-presubmit-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: integ-galley-k8s-presubmit-tests-release-1.2
-      <<: *job_template
-      context: prow/integ-galley-k8s-presubmit-tests.sh
-      max_concurrency: 5
-      always_run: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-galley-k8s-presubmit-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: integ-mixer-k8s-presubmit-tests-release-1.2
-      <<: *job_template
-      context: prow/integ-mixer-k8s-presubmit-tests.sh
-      optional: true
-      max_concurrency: 5
-      always_run: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-mixer-k8s-presubmit-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: integ-pilot-k8s-presubmit-tests-release-1.2
-      <<: *job_template
-      optional: true
-      context: prow/integ-pilot-k8s-presubmit-tests.sh
-      max_concurrency: 5
-      always_run: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-pilot-k8s-presubmit-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: integ-security-k8s-presubmit-tests-release-1.2
-      <<: *job_template
-      optional: true
-      context: prow/integ-security-k8s-presubmit-tests.sh
-      max_concurrency: 5
-      always_run: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-security-k8s-presubmit-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: test-e2e-mixer-no_auth-release-1.2
-      <<: *job_template
-      optional: true
-      skip_report: true
-      context: "prow: test-e2e-mixer-no_auth"
-      max_concurrency: 5
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/test-e2e-mixer-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-pilot-e2e-envoyv2-v1alpha3-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-mixer-no_auth-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-mixer-no_auth.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-mixer-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-dashboard-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-dashboard.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-dashboard.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-envoyv2-v1alpha3-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-bookInfoTests-v1alpha3.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-trustdomain-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-bookInfoTests-trustdomain.sh
-      optional: true
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-trustdomain.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/e2e-simpleTests.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTestsMinProfile-release-1.2
-      <<: *job_template
-      optional: true
-      context: prow/e2e-simpleTests-minProfile.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-minProfile.sh
-        nodeSelector:
-          testing: test-pool
+        testing: test-pool
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-mixer-no_auth-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-mixer-no_auth.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-mixer-no_auth.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-dashboard-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-dashboard.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-dashboard.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-bookInfoTests-v1alpha3.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-trustdomain-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-bookInfoTests-trustdomain.sh
+    optional: true
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-trustdomain.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/e2e-simpleTests.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTestsMinProfile-release-1.2
+    <<: *job_template
+    optional: true
+    context: prow/e2e-simpleTests-minProfile.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-minProfile.sh
+      nodeSelector:
+        testing: test-pool
 
-    - name: istio-pilot-multicluster-e2e-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/istio-pilot-multicluster-e2e.sh
-      optional: true
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-multicluster-e2e.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests-cni-release-1.2
-      <<: *job_template
-      always_run: false
-      context: prow/e2e-simpleTests-cni.sh
-      optional: true
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-cni.sh
-        nodeSelector:
-    - name: istio_auth_sds_e2e-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/e2e_pilotv2_auth_sds.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e_pilotv2_auth_sds.sh
-        nodeSelector:
-          testing: test-pool
-    - name: release-test-release-1.2
-      <<: *job_template
-      always_run: true
-      context: prow/release-test.sh
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/release-test.sh
-        nodeSelector:
-          testing: test-pool
+  - name: istio-pilot-multicluster-e2e-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/istio-pilot-multicluster-e2e.sh
+    optional: true
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-multicluster-e2e.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests-cni-release-1.2
+    <<: *job_template
+    always_run: false
+    context: prow/e2e-simpleTests-cni.sh
+    optional: true
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-cni.sh
+      nodeSelector:
+  - name: istio_auth_sds_e2e-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/e2e_pilotv2_auth_sds.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e_pilotv2_auth_sds.sh
+      nodeSelector:
+        testing: test-pool
+  - name: release-test-release-1.2
+    <<: *job_template
+    always_run: true
+    context: prow/release-test.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/release-test.sh
+      nodeSelector:
+        testing: test-pool
 
 
 postsubmits:
@@ -392,7 +377,20 @@ postsubmits:
         - prow/istio-integ-local-tests.sh
       nodeSelector:
         testing: test-pool
-  - name: istio-postsubmit-release-1.2
+  - name: istio-unit-tests-postsubmit-release-1.2
+    <<: *job_template
+    context: prow/istio-unit-tests.sh
+    always_run: true
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-unit-tests.sh
+      nodeSelector:
+        testing: test-pool
+
+  - name: istio-integ-k8s-tests-release-1.2
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -401,155 +399,142 @@ postsubmits:
       - <<: *istio_container
         command:
         - entrypoint
-        - prow/istio-postsubmit.sh
+        - prow/istio-integ-k8s-tests.sh
       nodeSelector:
         testing: test-pool
-    run_after_success:
-    - name: istio-integ-k8s-tests-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-integ-k8s-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTestsMinProfile-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-minProfile.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-integ-race-native-tests-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-integ-race-native-tests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-simpleTests-non-mcp-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-simpleTests-non-mcp.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-envoyv2-v1alpha3-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-pilot-e2e-envoyv2-v1alpha3-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-mixer-no_auth-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-mixer-no_auth.sh
-        nodeSelector:
-          testing: test-pool
-    - name: e2e-dashboard-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e-dashboard.sh
-        nodeSelector:
-          testing: test-pool
-    - name: istio_auth_sds_e2e-release-1.2
-      <<: *job_template
-      labels:
-        preset-service-account: "true"
-      max_concurrency: 5
-      spec:
-        containers:
-        - <<: *istio_container
-          command:
-          - entrypoint
-          - prow/e2e_pilotv2_auth_sds.sh
-        nodeSelector:
-          testing: test-pool
+  - name: e2e-simpleTestsMinProfile-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-minProfile.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-integ-race-native-tests-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-integ-race-native-tests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTests-non-mcp-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-non-mcp.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-mixer-no_auth-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-mixer-no_auth.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-dashboard-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-dashboard.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio_auth_sds_e2e-release-1.2
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e_pilotv2_auth_sds.sh
+      nodeSelector:
+        testing: test-pool


### PR DESCRIPTION
Deleting run_after_success for release-1.2

/hold
only merge, after https://github.com/istio/istio/pull/14957 is merged.