### PR TITLE
add yamllint 1.15 into image

### DIFF
--- a/docker/istio/istio/install.sh
+++ b/docker/istio/istio/install.sh
@@ -29,6 +29,7 @@ gem install --no-ri --no-rdoc fpm
 ./install-golang.sh
 ./install-helm.sh
 ./install-protoc.sh
+./install-yamllint.sh
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/docker/istio/shared/tools/install-yamllint.sh
+++ b/docker/istio/shared/tools/install-yamllint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eux
+
+
+YAMLLINTL_BASE_URL='http://launchpadlibrarian.net/411563953/yamllint_1.15.0-1_all.deb'
+YAMLLINTL_DEB="yamllint_1.15.0-1_all.deb"
+
+wget -q -nc "${YAMLLINTL_BASE_URL}"
+chmod +x "${YAMLLINTL_DEB}"
+apt-get update
+apt-get -qqy install python3-pkg-resources python3-yaml python3-pathspec 
+dpkg -i "${YAMLLINTL_DEB}"
+


### PR DESCRIPTION
the default yamllint with ubuntu:xenial is only 1.2, we need to use newer one.