### PR TITLE
Switch circle requirement for prow requirement

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -64,8 +64,6 @@ presubmits:
     <<: *job_template
     context: prow/racetest.sh
     always_run: true
-    # TODO: make required once tests are stable
-    optional: true
     spec:
       containers:
       - <<: *istio_container
@@ -79,8 +77,6 @@ presubmits:
     <<: *job_template
     context: prow/shellcheck.sh
     always_run: true
-    # TODO: make required once tests are stable
-    optional: true
     spec:
       containers:
       - <<: *istio_container
@@ -94,8 +90,6 @@ presubmits:
     <<: *job_template
     context: prow/codecov.sh
     always_run: true
-    # TODO: make required once tests are stable
-    optional: true
     spec:
       containers:
       - <<: *istio_container

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -88,7 +88,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - "ci/circleci: build"
-            - "ci/circleci: test"
           branches:
             <<: *blocked_branches
             collab-galley:
@@ -107,7 +106,7 @@ branch-protection:
                 - "ci/circleci: codecov"
                 - "ci/circleci: shellcheck"
                 - "ci/circleci: lint"
-                - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
+                - "ci/circleci: test"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
                 - "merges-blocked-needs-admin"
             release-1.2:
@@ -117,17 +116,13 @@ branch-protection:
                 - "ci/circleci: codecov"
                 - "ci/circleci: shellcheck"
                 - "ci/circleci: lint"
-                - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
+                - "ci/circleci: test"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
                 - "merges-blocked-needs-admin"
             master:
               protect: true
               required_status_checks:
                 contexts:
-                - "ci/circleci: codecov"
-                - "ci/circleci: racetest"
-                - "ci/circleci: shellcheck"
-                - "ci/circleci: e2e-pilot-noauth-v1alpha3-v2"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
         proxy:
           protect: false


### PR DESCRIPTION
Make sure https://github.com/istio/istio/pull/15068 works fine, then we can turn these tests off as required for master and make the prow ones required.


The e2e-pilot-noauth-v1alpha3-v2 one is already covered by prow and we forgot to remove before