### PR TITLE
Make circleci build nonrequired

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -85,9 +85,6 @@ branch-protection:
               protect: true
         istio:
           protect: false
-          required_status_checks:
-            contexts:
-            - "ci/circleci: build"
           branches:
             <<: *blocked_branches
             collab-galley:
@@ -107,6 +104,7 @@ branch-protection:
                 - "ci/circleci: shellcheck"
                 - "ci/circleci: lint"
                 - "ci/circleci: test"
+                - "ci/circleci: build"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
                 - "merges-blocked-needs-admin"
             release-1.2:
@@ -117,6 +115,7 @@ branch-protection:
                 - "ci/circleci: shellcheck"
                 - "ci/circleci: lint"
                 - "ci/circleci: test"
+                - "ci/circleci: build"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
                 - "merges-blocked-needs-admin"
             master:


### PR DESCRIPTION
I thought we needed build, but it can actually run fine on its own. See https://circleci.com/workflow-run/8df6e347-e4c0-4438-b559-db10e11d9220 where the one circle test works fine without the build step.

@icygalz can I remove
```
          required_status_checks:	
            contexts:
```
like I did or do I need to set contexts to an empty list?