### PR TITLE
add yamllint 1.16 and it's dependencies

### DIFF
--- a/docker/istio/istio/Dockerfile
+++ b/docker/istio/istio/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=koalaman/shellcheck-alpine:v0.6.0 /bin/shellcheck /bin/shellcheck
 VOLUME /var/lib/docker
 EXPOSE 2375
 
-ENV PATH /usr/local/go/bin:/opt/go/bin:/usr/lib/google-cloud-sdk/bin:${PATH}
+ENV PATH /usr/local/go/bin:/opt/go/bin:/usr/lib/google-cloud-sdk/bin:/root/.local/bin:${PATH}
 
 # Add entrypoint to start docker
 ADD shared/prow-runner.sh /usr/local/bin/entrypoint

--- a/docker/istio/istio/install.sh
+++ b/docker/istio/istio/install.sh
@@ -20,7 +20,6 @@ apt-get -qqy --no-install-recommends install \
   unzip \
   wget \
   zip \
-  yamllint \
   jq
 
 gem install --no-ri --no-rdoc fpm
@@ -30,6 +29,7 @@ gem install --no-ri --no-rdoc fpm
 ./install-golang.sh
 ./install-helm.sh
 ./install-protoc.sh
+./install-yamllint.sh
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/docker/istio/shared/tools/install-yamllint.sh
+++ b/docker/istio/shared/tools/install-yamllint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+
+
+apt-get -qqy install python3-pip  
+pip3 install --upgrade pip
+pip install --user yamllint 
+export PATH=${PATH}:/root/.local/bin


### PR DESCRIPTION
- Using PIP to install yamllint 1.16 and it's dependency into our image(ubuntu 16.04) 

- remove `apt-get yamllint` from install.sh as the default yamllint version with ubuntu 16.04 is only 1.2 and lacks all the dependencies.

