### PR TITLE
Go module testing

### DIFF
--- a/docker/istio/istio/Dockerfile
+++ b/docker/istio/istio/Dockerfile
@@ -21,4 +21,7 @@ RUN chmod +rx /usr/local/bin/entrypoint
 # if running in the continuous integration environment.
 ENV CI prow
 
+# Set GO module variable to use Go modules even though we are on the GOPATH
+ENV GO111MODULE on
+
 ENTRYPOINT ["entrypoint"]


### PR DESCRIPTION
  - Set GO111MODULE on

This PR is for modifying the `gcr.io/istio-testing/istio-builder` used to build the Istio images specifically to test using Golang modules. Currently, the Istio build used Golang 1.12.5 but the Istio code being built in on the GOPATH so modules is not being used (the underlying _vendor_ directory is).

The images created using this PR will be used against the _prow-staging_ branch to do some initial testing.