### PR TITLE
Experimenting with upper resource limit

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -19,7 +19,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container: &istio_container
@@ -32,7 +32,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
@@ -44,7 +44,7 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -17,10 +17,10 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container: &istio_container
   image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
@@ -30,10 +30,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
   image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
@@ -42,10 +42,10 @@ istio_container_with_kind: &istio_container_with_kind
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
@@ -17,10 +17,10 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container: &istio_container
   image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
@@ -30,10 +30,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
@@ -19,7 +19,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container: &istio_container
@@ -32,7 +32,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
@@ -19,7 +19,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container: &istio_container
@@ -32,7 +32,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
@@ -44,7 +44,7 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
@@ -17,10 +17,10 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container: &istio_container
   image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
@@ -30,10 +30,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
   image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
@@ -42,10 +42,10 @@ istio_container_with_kind: &istio_container_with_kind
   resources:
     requests:
       memory: "2Gi"
-      cpu: "4000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -12,10 +12,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "2000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
   image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
@@ -25,10 +25,10 @@ istio_container_with_kind: &istio_container_with_kind
   resources:
     requests:
       memory: "2Gi"
-      cpu: "2000m"
+      cpu: "3000m"
     limits:
-      memory: "40Gi"
-      cpu: "8000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -14,7 +14,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
@@ -27,7 +27,7 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -14,7 +14,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
@@ -27,7 +27,7 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "2Gi"
       cpu: "2000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -12,10 +12,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "2000m"
+      cpu: "3000m"
     limits:
-      memory: "2Gi"
-      cpu: "2000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
   image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
@@ -27,8 +27,8 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "2Gi"
       cpu: "2000m"
     limits:
-      memory: "2Gi"
-      cpu: "2000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -14,8 +14,8 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "2000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "2Gi"
+      cpu: "2000m"
 
 istio_container_with_kind: &istio_container_with_kind
   image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
@@ -27,8 +27,8 @@ istio_container_with_kind: &istio_container_with_kind
       memory: "2Gi"
       cpu: "2000m"
     limits:
-      memory: "40Gi"
-      cpu: "8000m"
+      memory: "2Gi"
+      cpu: "2000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -14,7 +14,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -12,10 +12,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "2000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -14,7 +14,7 @@ istio_container: &istio_container
       memory: "2Gi"
       cpu: "3000m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "3000m"
 
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -12,10 +12,10 @@ istio_container: &istio_container
   resources:
     requests:
       memory: "2Gi"
-      cpu: "2000m"
+      cpu: "3000m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "3000m"
 
 presubmits:
 

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -8,8 +8,8 @@ test_infra_container: &test_infra_container
       memory: "512Mi"
       cpu: "500m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "1000m"
 
 test_infra_container: &test_flakey_container
   image: gcr.io/istio-testing/test-flakey-builder:v20190611-65b6bb45
@@ -21,8 +21,8 @@ test_infra_container: &test_flakey_container
       memory: "512Mi"
       cpu: "500m"
     limits:
-      memory: "24Gi"
-      cpu: "7000m"
+      memory: "10Gi"
+      cpu: "1000m"
 
 
 branch_spec: &branch_spec

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -8,7 +8,7 @@ test_infra_container: &test_infra_container
       memory: "512Mi"
       cpu: "500m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "1000m"
 
 test_infra_container: &test_flakey_container
@@ -21,7 +21,7 @@ test_infra_container: &test_flakey_container
       memory: "512Mi"
       cpu: "500m"
     limits:
-      memory: "10Gi"
+      memory: "24Gi"
       cpu: "1000m"
 
 


### PR DESCRIPTION
The flakiness is caused by pods being able to take up higher resources and we couldn't control when the pod takes more resources. By limiting the upper-bound and fit the node's quota, we can avoid the nodes going on CPU contention.

Cons:  the pods will get throttled and test might be slower.