### PR TITLE
Swap prow for circle racetest

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -64,6 +64,8 @@ presubmits:
     <<: *job_template
     context: prow/racetest.sh
     always_run: true
+    # TODO(https://github.com/istio/istio/issues/15121) make required
+    optional: true
     spec:
       containers:
       - <<: *istio_container

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -122,6 +122,7 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                - "ci/circleci: racetest"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
         proxy:
           protect: false


### PR DESCRIPTION
Both will still run, just making circle the required one until prow
racetest is stable.