### PR TITLE
Upgrade to latest kubectl

### DIFF
--- a/docker/istio/istio/install.sh
+++ b/docker/istio/istio/install.sh
@@ -26,6 +26,7 @@ gem install --no-ri --no-rdoc fpm
 
 ./install-docker.sh
 ./install-gcloud.sh
+./install-kubectl.sh
 ./install-golang.sh
 ./install-helm.sh
 ./install-protoc.sh

--- a/docker/istio/shared/tools/install-gcloud.sh
+++ b/docker/istio/shared/tools/install-gcloud.sh
@@ -9,8 +9,8 @@ export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 export CLOUDSDK_INSTALL_DIR=/usr/lib/
 curl https://sdk.cloud.google.com | bash
 
-export PATH="/usr/lib/google-cloud-sdk/bin:${PATH}"
+export PATH="${PATH}:/usr/lib/google-cloud-sdk/bin"
 
 sed -i -e 's/true/false/' /usr/lib/google-cloud-sdk/lib/googlecloudsdk/core/config.json
-gcloud -q components update kubectl
+gcloud -q components update
 

--- a/docker/istio/shared/tools/install-kubectl.sh
+++ b/docker/istio/shared/tools/install-kubectl.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eux
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+mv ./kubectl /usr/local/bin/kubectl

--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190619-72a31e48
+  image: gcr.io/istio-testing/istio-builder:v20190625-86ce017a
   # Docker in Docker
   securityContext:
     privileged: true


### PR DESCRIPTION
https://github.com/istio/istio/pull/15138 will not work because we use an old kubectl version. This updates the image for prow staging only.

I tested the image correctly installs kubectl.

