### PR TITLE
Remove GO1111MODULE=on (revert to using vendor dir)

### DIFF
--- a/docker/istio/istio/Dockerfile
+++ b/docker/istio/istio/Dockerfile
@@ -21,7 +21,4 @@ RUN chmod +rx /usr/local/bin/entrypoint
 # if running in the continuous integration environment.
 ENV CI prow
 
-# Set GO module variable to use Go modules even though we are on the GOPATH
-ENV GO111MODULE on
-
 ENTRYPOINT ["entrypoint"]


### PR DESCRIPTION
I want to remove the setting to prevent it from being in an image that might make it further than staging (for now).

Thanks.