### PR TITLE
Revert "Swap prow for circle racetest"

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -64,8 +64,6 @@ presubmits:
     <<: *job_template
     context: prow/racetest.sh
     always_run: true
-    # TODO(https://github.com/istio/istio/issues/15121) make required
-    optional: true
     spec:
       containers:
       - <<: *istio_container

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -122,7 +122,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                - "ci/circleci: racetest"
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
         proxy:
           protect: false


### PR DESCRIPTION
Reverts istio/test-infra#1376

https://prow.istio.io/?job=istio-racetest-master is working now (well, as much as any other prow test). This is blocking https://github.com/istio/istio/pull/15068