### PR TITLE
After RTD, properly configure prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -123,11 +123,6 @@ branch-protection:
               required_status_checks:
                 contexts:
                 - "ci/circleci: e2e-pilot-cloudfoundry-v1alpha3-v2"
-        operator:
-          protect: false
-          branches:
-            master:
-              protect: false
         proxy:
           protect: false
           required_status_checks:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -94,14 +94,8 @@ plugins:
   - wip
 
   istio/operator:
-  - approve
   - assign
-  - blunderbuss
-  - golint
-  - help
   - hold
-  - lgtm
-  - lifecycle
   - slackevents
   - trigger
   - wip


### PR DESCRIPTION
turn off tide entirely (conflicts with mergify)
turn on trigger plugin (runs jobs for the PR)
turn on assign plugin (allows assignment of a PR)
turn on hold (allows holding a PR)
turn on wip (allows markiing WIPing a PR)