### PR TITLE
Upgrade branchprotector to upstream and latest

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,8 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/istio-testing/branchprotector:v20181127-b0ca57e86
+            # TODO(fejta): migrate to trusted prowjob
+            image: gcr.io/k8s-prow/branchprotector:v20190628-ac9063df1
             args:
             - --config-path=/etc/config/config.yaml
             - --github-token-path=/etc/github/oauth


### PR DESCRIPTION
/assign @utka @sebastienvas @howardjohn

ref https://github.com/istio/test-infra/issues/1396

We now only mark jobs as required if they must run and pass. Tide will still block merges on conditionally triggered job failures, but we no longer mark them as required (and will eventually stop posting skipped status for them)

Will `kubectl apply` this once it merges.