### PR TITLE
Use nanosecond int64 value for timeout, grace period

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,8 +7,9 @@ plank:
   job_url_prefix: https://gubernator.k8s.io/build/
   pod_pending_timeout: 60m
   default_decoration_config:
-    timeout: 2h
-    grace_period: 15s
+    # TODO(fejta): use 2h, 15s instead
+    timeout: 7200000000000 # 2h
+    grace_period: 15000000000 # 15s
     utility_images:
       clonerefs: "gcr.io/k8s-prow/clonerefs:v20190628-eb4a10930"
       initupload: "gcr.io/k8s-prow/initupload:v20190628-eb4a10930"


### PR DESCRIPTION
/assign @utka @howardjohn 

fixes https://github.com/istio/test-infra/pull/1409

New prow supports 2h instead of 7200000000000000 but the code vendored in istio/test-infra still doesn't... 

Will pursue a better long term fix but this will unblock more merges.