### PR TITLE
Fix KinD volume syntax

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -643,23 +643,25 @@ postsubmits:
         command:
         - entrypoint
         - prow/e2e-kind-simpleTests.sh
+        # Volumes needed to support KinD running in Kubernetes
+        # See https://github.com/kubernetes-sigs/kind/issues/303
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
       nodeSelector:
         testing: test-pool
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - hostPath:
-        path: /lib/modules
-        type: Directory
-      name: modules
-    - hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-      name: cgroup
 
   - name: istio-unit-tests-master
     <<: *job_template


### PR DESCRIPTION
https://github.com/istio/test-infra/issues/1415 would have caught this bug

Getting this KinD stuff to work is pretty frustrating because it only runs on postsubmit and there is no easy way to iterate on it locally. I tested this on my own prow cluster I spun up and it works though (https://github.com/howardjohn/istio/pull/4).

Note the test won't actually pass without https://github.com/istio/istio/pull/15308 but this PR isn't blocked by that one; both are needed for the test to pass 