### PR TITLE
Enable SSL redirect for Prow.

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -25,8 +25,9 @@ spec:
             containerPort: 8080
         args:
         - --config-path=/etc/config/config.yaml
-        - --hook-url=http://hook:8888/plugin-help
         - --job-config-path=/etc/job-config
+        - --redirect-http-to=prow.istio.io
+        - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/
         volumeMounts:
         - name: config


### PR DESCRIPTION
Currently http://prow.istio.io does not redirect to https://prow.istio.io
This will fix that.

/assign @fejta @utka