### PR TITLE
Add a checkconfig presubmit to validate Prow config.

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -27,6 +27,23 @@ presubmits:
       # hostPath:
       #   path: /mnt/disks/ssd0/test-infra
 
+  - name: pull-test-infra-prow-checkconfig
+    decorate: true
+    run_if_changed: '^prow/(config|plugins|cluster/jobs/.*)\.yaml$'
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/checkconfig:v20190703-1f4d61631
+        command:
+        - /checkconfig
+        args:
+        - --config-path=prow/config.yaml
+        - --job-config-path=prow/cluster/jobs
+        - --plugin-config=prow/plugins.yaml
+        - --strict
+        - --exclude-warning=mismatched-tide
+        - --exclude-warning=unknown-fields
+        - --exclude-warning=non-decorated-jobs
+
   - name: lint-check
     context: "prow: lint-check"
     always_run: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -226,7 +226,6 @@ tide:
     - do-not-merge
     - do-not-merge/hold
     - do-not-merge/work-in-progress
-    - needs-ok-to-test
     - needs-rebase
   merge_method:
     istio/api: squash

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -78,6 +78,7 @@ plugins:
   - lifecycle
   - slackevents
   - trigger
+  - verify-owners
   - wip
 
   istio/api:
@@ -91,7 +92,11 @@ plugins:
   - lifecycle
   - slackevents
   - trigger
+  - verify-owners
   - wip
+
+  istio/installer:
+  - trigger
 
   istio/operator:
   - assign
@@ -111,6 +116,7 @@ plugins:
   - lifecycle
   - slackevents
   - trigger
+  - verify-owners
   - wip
 
   sebastienvas/core:
@@ -121,21 +127,22 @@ plugins:
   - trigger
 
   istio/test-infra:
-  - config-updater
-  - shrug
-  - skip
-  - yuks
   - approve
   - assign
   - blunderbuss
+  - config-updater
   - golint
   - help
   - hold
   - lgtm
   - lifecycle
+  - shrug
+  - skip
   - slackevents
   - trigger
+  - verify-owners
   - wip
+  - yuks
 
   istio-releases/pipeline:
   - lifecycle
@@ -153,6 +160,7 @@ plugins:
   - lifecycle
   - slackevents
   - trigger
+  - verify-owners
   - wip
 
 external_plugins:


### PR DESCRIPTION
This identified some existing problems with the config. The problems are fixed in the second commit.

Existing problems:
```
{"component":"checkconfig","file":"prow/cmd/checkconfig/main.go:71","func":"main.reportWarning","level":"warning","msg":"the tide query at position 1forbids the \"needs-ok-to-test\" label and requires the \"lgtm\" label, which is not recommended; see https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/maintainers.md#best-practices for more information","time":"2019-07-03T23:20:55Z"}
{"component":"checkconfig","file":"prow/cmd/checkconfig/main.go:71","func":"main.reportWarning","level":"warning","msg":"the following orgs or repos enable at least one plugin that uses OWNERS files (approve, blunderbuss, owners-label) but do not enable the verify-owners plugin to ensure validity of OWNERS files: [repo: istio-ecosystem/authservice repo: istio/api repo: istio/istio repo: istio/proxy repo: istio/test-infra]","time":"2019-07-03T23:20:55Z"}
{"component":"checkconfig","file":"prow/cmd/checkconfig/main.go:71","func":"main.reportWarning","level":"warning","msg":"the following repos have jobs configured but do not have the trigger plugin enabled: repo: istio/installer","time":"2019-07-03T23:20:55Z"}
```
- the tide query at position 1 forbids the \"needs-ok-to-test\" label and requires the \"lgtm\" label, which is not recommended; see https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/maintainers.md#best-practices for more information
- the following orgs or repos enable at least one plugin that uses OWNERS files (approve, blunderbuss, owners-label) but do not enable the verify-owners plugin to ensure validity of OWNERS files: [repo: istio-ecosystem/authservice repo: istio/api repo: istio/istio repo: istio/proxy repo: istio/test-infra]
- the following repos have jobs configured but do not have the trigger plugin enabled: repo: istio/installer


fixes #1415 

The first two errors aren't a big deal, but the last means the configured presubmit wasn't running on istio/installer.