### PR TITLE
Allow github reviews to add/remove LGTM

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -41,6 +41,9 @@ slack:
 
 lgtm:
 - repos:
+  - istio
+  review_acts_as_lgtm: true
+- repos:
   - istio/api
   - istio/istio
   - istio/operator


### PR DESCRIPTION
/hold

What channels should we go through for this sort of proposal?
/cc @howardjohn @cjwagner @utka 

ref https://github.com/istio/test-infra/issues/1433

NOTE: you can still `/lgtm` or `/approve` whenever you want to just lgtm or approve, respectively (aka current behavior remains the same).

These plugins did not behave this way initially because they predate github's review functionality.