### PR TITLE
Increase memory request 2 -> 3gb

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -11,7 +11,7 @@ istio_container: &istio_container
     privileged: true
   resources:
     requests:
-      memory: "2Gi"
+      memory: "3Gi"
       cpu: "3000m"
     limits:
       memory: "24Gi"


### PR DESCRIPTION
codecov, racetest, and unit test are using up to 3gb in the tests,
causing them to get frequently OOMKilled.

Fixes https://github.com/istio/test-infra/issues/1413