### PR TITLE
Add script to keep prow-staging in sync with master

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -1,3 +1,4 @@
+# Run update-prow-staging.sh to keep sync this with the master config
 job_template: &job_template
   branches:
   - "^prow-staging$"
@@ -5,27 +6,27 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190626-deb7c379
+  image: gcr.io/istio-testing/istio-builder:v20190628-31457b43
   # Docker in Docker
   securityContext:
     privileged: true
   resources:
     requests:
-      memory: "2Gi"
+      memory: "3Gi"
       cpu: "3000m"
     limits:
       memory: "24Gi"
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190607-32702dcd
+  image: gcr.io/istio-testing/istio-builder:v20190628-31457b43
   # Docker in Docker
   securityContext:
     privileged: true
   resources:
     requests:
       memory: "2Gi"
-      cpu: "2000m"
+      cpu: "3000m"
     limits:
       memory: "24Gi"
       cpu: "3000m"
@@ -34,7 +35,7 @@ presubmits:
 
   istio/istio:
 
-  - name: istio-unit-tests-master
+  - name: istio-unit-tests-prow-staging
     <<: *job_template
     context: prow/istio-unit-tests.sh
     always_run: true
@@ -45,22 +46,34 @@ presubmits:
         - entrypoint
         - prow/istio-unit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
-  - name: istio-lint-master
+  - name: istio-lint-prow-staging
     <<: *job_template
     context: prow/istio-lint.sh
     always_run: true
     spec:
       containers:
-      - <<: *istio_container
+      # Lint requires a large amount of memory
+      # See https://github.com/istio/istio/issues/14888 before lowering requests
+      - image: gcr.io/istio-testing/istio-builder:v20190628-31457b43
+        # Docker in Docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "3000m"
+          limits:
+            memory: "24Gi"
+            cpu: "3000m"
         command:
         - entrypoint
         - prow/istio-lint.sh
       nodeSelector:
         testing: test-pool
 
-  - name: istio-racetest-master
+  - name: istio-racetest-prow-staging
     <<: *job_template
     context: prow/racetest.sh
     always_run: true
@@ -73,7 +86,7 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: istio-shellcheck-master
+  - name: istio-shellcheck-prow-staging
     <<: *job_template
     context: prow/shellcheck.sh
     always_run: true
@@ -86,7 +99,7 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: istio-codecov-master
+  - name: istio-codecov-prow-staging
     <<: *job_template
     context: prow/codecov.sh
     always_run: true
@@ -99,7 +112,7 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-framework-local-presubmit-tests-master
+  - name: integ-framework-local-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-framework-local-presubmit-tests.sh
     always_run: true
@@ -108,11 +121,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-framework-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.framework.local.presubmit
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
-  - name: integ-galley-local-presubmit-tests-master
+  - name: integ-galley-local-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-galley-local-presubmit-tests.sh
     always_run: true
@@ -121,11 +135,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-galley-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.galley.local.presubmit
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
-  - name: integ-istioctl-local-presubmit-tests-master
+  - name: integ-istioctl-local-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-istioctl-local-presubmit-tests.sh
     always_run: true
@@ -135,11 +150,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-istioctl-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.istioctl.local.presubmit
       nodeSelector:
         testing: test-pool
 
-  - name: integ-mixer-local-presubmit-tests-master
+  - name: integ-mixer-local-presubmit-tests-prow-staging
     <<: *job_template
     optional: true
     context: prow/integ-mixer-local-presubmit-tests.sh
@@ -149,11 +165,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-mixer-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.mixer.local.presubmit
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
-  - name: integ-pilot-local-presubmit-tests-master
+  - name: integ-pilot-local-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-pilot-local-presubmit-tests.sh
     always_run: true
@@ -162,11 +179,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-pilot-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.pilot.local.presubmit
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
-  - name: integ-security-local-presubmit-tests-master
+  - name: integ-security-local-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-security-local-presubmit-tests.sh
     always_run: true
@@ -175,11 +193,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-security-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.security.local.presubmit
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
-  - name: integ-telemetry-local-presubmit-tests-master
+  - name: integ-telemetry-local-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-telemetry-local-presubmit-tests.sh
     always_run: true
@@ -189,11 +208,12 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-telemetry-local-presubmit-tests.sh
+            - prow/integ-suite-local.sh
+            - test.integration.telemetry.local.presubmit
       nodeSelector:
         testing: test-pool
-    
-  - name: integ-framework-k8s-presubmit-tests-master
+
+  - name: integ-framework-k8s-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-framework-k8s-presubmit-tests.sh
     max_concurrency: 5
@@ -205,10 +225,11 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-framework-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.framework.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: integ-galley-k8s-presubmit-tests-master
+  - name: integ-galley-k8s-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-galley-k8s-presubmit-tests.sh
     max_concurrency: 5
@@ -220,10 +241,11 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-galley-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.galley.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: integ-istioctl-k8s-presubmit-tests-master
+  - name: integ-istioctl-k8s-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-istioctl-k8s-presubmit-tests.sh
     optional: true
@@ -236,10 +258,11 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-istioctl-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.istioctl.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: integ-mixer-k8s-presubmit-tests-master
+  - name: integ-mixer-k8s-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-mixer-k8s-presubmit-tests.sh
     optional: true
@@ -252,10 +275,11 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-mixer-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.mixer.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: integ-pilot-k8s-presubmit-tests-master
+  - name: integ-pilot-k8s-presubmit-tests-prow-staging
     <<: *job_template
     optional: true
     context: prow/integ-pilot-k8s-presubmit-tests.sh
@@ -268,10 +292,11 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-pilot-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.pilot.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: integ-security-k8s-presubmit-tests-master
+  - name: integ-security-k8s-presubmit-tests-prow-staging
     <<: *job_template
     optional: true
     context: prow/integ-security-k8s-presubmit-tests.sh
@@ -284,10 +309,11 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-security-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.security.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: integ-telemetry-k8s-presubmit-tests-master
+  - name: integ-telemetry-k8s-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-telemetry-k8s-presubmit-tests.sh
     optional: true
@@ -300,10 +326,29 @@ presubmits:
         - <<: *istio_container
           command:
             - entrypoint
-            - prow/integ-telemetry-k8s-presubmit-tests.sh
+            - prow/integ-suite-k8s.sh
+            - test.integration.telemetry.kube.presubmit
       nodeSelector:
         testing: test-pool
-  - name: test-e2e-mixer-no_auth-master
+  - name: integ-new-install-k8s-presubmit-tests-prow-staging
+    <<: *job_template
+    context: prow/integ-new-installer-k8s-presubmit-tests.sh
+    optional: true
+    max_concurrency: 5
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-suite-k8s.sh
+            - test.integration.new.installer
+      nodeSelector:
+        testing: test-pool
+
+  - name: test-e2e-mixer-no_auth-prow-staging
     <<: *job_template
     optional: true
     skip_report: true
@@ -319,7 +364,7 @@ presubmits:
         - prow/test-e2e-mixer-no_auth.sh
       nodeSelector:
         testing: test-pool
-  - name: istio-pilot-e2e-envoyv2-v1alpha3-master
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-prow-staging
     <<: *job_template
     always_run: true
     context: prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
@@ -334,22 +379,7 @@ presubmits:
         - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       nodeSelector:
         testing: test-pool
-  - name: istio-e2e-pilot-cloudfoundry-v1alpha3-v2-master
-    <<: *job_template
-    always_run: true
-    context: prow/e2e-pilot-cloudfoundry-v1alpha3-v2.sh
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
-    spec:
-      containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/e2e-pilot-cloudfoundry-v1alpha3-v2.sh
-      nodeSelector:
-        testing: test-pool
-  - name: e2e-mixer-no_auth-master
+  - name: e2e-mixer-no_auth-prow-staging
     <<: *job_template
     always_run: true
     context: prow/e2e-mixer-no_auth.sh
@@ -364,7 +394,7 @@ presubmits:
         - prow/e2e-mixer-no_auth.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-dashboard-master
+  - name: e2e-dashboard-prow-staging
     <<: *job_template
     always_run: true
     context: prow/e2e-dashboard.sh
@@ -379,7 +409,7 @@ presubmits:
         - prow/e2e-dashboard.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-master
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-prow-staging
     <<: *job_template
     always_run: true
     context: prow/e2e-bookInfoTests-v1alpha3.sh
@@ -394,7 +424,7 @@ presubmits:
         - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-trustdomain-master
+  - name: e2e-bookInfoTests-trustdomain-prow-staging
     <<: *job_template
     always_run: true
     context: prow/e2e-bookInfoTests-trustdomain.sh
@@ -410,7 +440,7 @@ presubmits:
         - prow/e2e-bookInfoTests-trustdomain.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-simpleTests-master
+  - name: e2e-simpleTests-prow-staging
     <<: *job_template
     always_run: true
     context: prow/e2e-simpleTests.sh
@@ -425,7 +455,22 @@ presubmits:
         - prow/e2e-simpleTests.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-simpleTestsMinProfile-master
+  - name: e2e-simpleTests-distroless-prow-staging
+    <<: *job_template
+    optional: true
+    context: prow/e2e-simpleTests-distroless.sh
+    labels:
+      preset-service-account: "true"
+    max_concurrency: 5
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - prow/e2e-simpleTests-distroless.sh
+      nodeSelector:
+        testing: test-pool
+  - name: e2e-simpleTestsMinProfile-prow-staging
     <<: *job_template
     optional: true
     context: prow/e2e-simpleTests-minProfile.sh
@@ -441,7 +486,7 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: istio-pilot-multicluster-e2e-master
+  - name: istio-pilot-multicluster-e2e-prow-staging
     <<: *job_template
     always_run: true
     context: prow/istio-pilot-multicluster-e2e.sh
@@ -457,7 +502,7 @@ presubmits:
         - prow/istio-pilot-multicluster-e2e.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-simpleTests-cni-master
+  - name: e2e-simpleTests-cni-prow-staging
     <<: *job_template
     always_run: false
     context: prow/e2e-simpleTests-cni.sh
@@ -472,7 +517,7 @@ presubmits:
         - entrypoint
         - prow/e2e-simpleTests-cni.sh
       nodeSelector:
-  - name: istio_auth_sds_e2e-master
+  - name: istio_auth_sds_e2e-prow-staging
     <<: *job_template
     always_run: true
     context: prow/e2e_pilotv2_auth_sds.sh
@@ -487,13 +532,10 @@ presubmits:
         - prow/e2e_pilotv2_auth_sds.sh
       nodeSelector:
         testing: test-pool
-  - name: release-test-master
+  - name: release-test-prow-staging
     <<: *job_template
     always_run: true
     context: prow/release-test.sh
-    # TODO(https://github.com/istio/istio/issues/13823): The test is blocking check-ins. Once it is fixed, we can
-    # make it required again.
-    optional: true
     labels:
       preset-service-account: "true"
     max_concurrency: 5
@@ -510,7 +552,19 @@ presubmits:
 postsubmits:
 
   istio/istio:
-  - name: integ-framework-local-postsubmit-tests-master
+  - name: integ-conformance-local-postsubmit-tests-prow-staging
+    <<: *job_template
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-suite-local.sh
+            - test.integration.conformance.local
+      nodeSelector:
+        testing: test-pool
+
+  - name: integ-framework-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -522,7 +576,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-galley-local-postsubmit-tests-master
+  - name: integ-galley-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -534,7 +588,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-istioctl-local-postsubmit-tests-master
+  - name: integ-istioctl-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -546,7 +600,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-mixer-local-postsubmit-tests-master
+  - name: integ-mixer-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -558,7 +612,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-pilot-local-postsubmit-tests-master
+  - name: integ-pilot-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -570,7 +624,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-security-local-postsubmit-tests-master
+  - name: integ-security-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -582,7 +636,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-telemetry-local-postsubmit-tests-master
+  - name: integ-telemetry-local-postsubmit-tests-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -594,7 +648,7 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: istio-kind-simpleTest-master
+  - name: istio-kind-simpleTest-prow-staging
     <<: *job_template
     spec:
       containers:
@@ -602,9 +656,27 @@ postsubmits:
         command:
         - entrypoint
         - prow/e2e-kind-simpleTests.sh
+        # Volumes needed to support KinD running in Kubernetes
+        # See https://github.com/kubernetes-sigs/kind/issues/303
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
       nodeSelector:
-        testing: build-pool
-  - name: istio-unit-tests-master
+        testing: test-pool
+
+  - name: istio-unit-tests-prow-staging
     <<: *job_template
     context: prow/istio-unit-tests.sh
     always_run: true
@@ -615,21 +687,34 @@ postsubmits:
         - entrypoint
         - prow/istio-unit-tests.sh
       nodeSelector:
-        testing: build-pool
-  - name: integ-framework-k8s-postsubmit-tests-master
+        testing: test-pool
+  - name: integ-conformance-k8s-postsubmit-tests-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
     spec:
       containers:
-      - <<: *istio_container
-        command:
-        - entrypoint
-        - prow/integ-suite-k8s.sh
-        - test.integration.framework.kube
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-suite-k8s.sh
+            - test.integration.conformance.kube
       nodeSelector:
         testing: test-pool
-  - name: integ-galley-k8s-postsubmit-tests-master
+  - name: integ-framework-k8s-postsubmit-tests-prow-staging
+    <<: *job_template
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - <<: *istio_container
+          command:
+            - entrypoint
+            - prow/integ-suite-k8s.sh
+            - test.integration.framework.kube
+      nodeSelector:
+        testing: test-pool
+  - name: integ-galley-k8s-postsubmit-tests-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -642,7 +727,7 @@ postsubmits:
         - test.integration.galley.kube
       nodeSelector:
         testing: test-pool
-  - name: integ-istioctl-k8s-postsubmit-tests-master
+  - name: integ-istioctl-k8s-postsubmit-tests-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -655,8 +740,10 @@ postsubmits:
         - test.integration.istioctl.kube
       nodeSelector:
         testing: test-pool
-  - name: integ-mixer-k8s-postsubmit-tests-master
+  - name: integ-mixer-k8s-postsubmit-tests-prow-staging
     <<: *job_template
+    labels:
+      preset-service-account: "true"
     spec:
       containers:
       - <<: *istio_container
@@ -666,8 +753,10 @@ postsubmits:
         - test.integration.mixer.kube
       nodeSelector:
         testing: test-pool
-  - name: integ-pilot-k8s-postsubmit-tests-master
+  - name: integ-pilot-k8s-postsubmit-tests-prow-staging
     <<: *job_template
+    labels:
+      preset-service-account: "true"
     spec:
       containers:
       - <<: *istio_container
@@ -678,8 +767,10 @@ postsubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-security-k8s-postsubmit-tests-master
+  - name: integ-security-k8s-postsubmit-tests-prow-staging
     <<: *job_template
+    labels:
+      preset-service-account: "true"
     spec:
       containers:
       - <<: *istio_container
@@ -689,8 +780,10 @@ postsubmits:
         - test.integration.security.kube
       nodeSelector:
         testing: test-pool
-  - name: integ-telemetry-k8s-postsubmit-tests-master
+  - name: integ-telemetry-k8s-postsubmit-tests-prow-staging
     <<: *job_template
+    labels:
+      preset-service-account: "true"
     spec:
       containers:
       - <<: *istio_container
@@ -700,7 +793,7 @@ postsubmits:
         - test.integration.telemetry.kube
       nodeSelector:
         testing: test-pool
-  - name: e2e-simpleTestsMinProfile-master
+  - name: e2e-simpleTestsMinProfile-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -713,7 +806,7 @@ postsubmits:
         - prow/e2e-simpleTests-minProfile.sh
       nodeSelector:
         testing: test-pool
-  - name: istio-integ-race-native-tests-master
+  - name: istio-integ-race-native-tests-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -725,7 +818,7 @@ postsubmits:
         - prow/istio-integ-race-native-tests.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-simpleTests-master
+  - name: e2e-simpleTests-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -737,7 +830,7 @@ postsubmits:
         - prow/e2e-simpleTests.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-simpleTests-non-mcp-master
+  - name: e2e-simpleTests-non-mcp-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -750,7 +843,7 @@ postsubmits:
         - prow/e2e-simpleTests-non-mcp.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-master
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -762,7 +855,7 @@ postsubmits:
         - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
       nodeSelector:
         testing: test-pool
-  - name: istio-pilot-e2e-envoyv2-v1alpha3-master
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -774,7 +867,7 @@ postsubmits:
         - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
       nodeSelector:
         testing: test-pool
-  - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest-master
+  - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -786,7 +879,7 @@ postsubmits:
         - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp-master
+  - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -799,7 +892,7 @@ postsubmits:
         - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-mixer-no_auth-master
+  - name: e2e-mixer-no_auth-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -811,7 +904,7 @@ postsubmits:
         - prow/e2e-mixer-no_auth.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-dashboard-master
+  - name: e2e-dashboard-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"
@@ -823,7 +916,7 @@ postsubmits:
         - prow/e2e-dashboard.sh
       nodeSelector:
         testing: test-pool
-  - name: istio_auth_sds_e2e-master
+  - name: istio_auth_sds_e2e-prow-staging
     <<: *job_template
     labels:
       preset-service-account: "true"

--- a/prow/cluster/jobs/istio/istio/update-prow-staging.sh
+++ b/prow/cluster/jobs/istio/istio/update-prow-staging.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "# Run update-prow-staging.sh to keep sync this with the master config" > istio.istio.prow-staging.yaml
+cat istio.istio.master.yaml >> istio.istio.prow-staging.yaml
+sed -i 's/-master/-prow-staging/g' istio.istio.prow-staging.yaml
+sed -i 's/\^master/\^prow-staging/g' istio.istio.prow-staging.yaml


### PR DESCRIPTION
Additionally, run this script. This also will fix the issue of the test
names being duplicated.

@fejta we have been using this branch as a means to test experimental changes to the prow config, originally inspired by large changes like upgrading our builder image to go 1.12. If there is a better way to do this would be happy to hear it. We could make prowjobs and apply manually but only admins can do that