### PR TITLE
Change integ-security-k8s-presubmit-tests-master to requried

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -297,7 +297,6 @@ presubmits:
         testing: test-pool
   - name: integ-security-k8s-presubmit-tests-master
     <<: *job_template
-    optional: true
     context: prow/integ-security-k8s-presubmit-tests.sh
     max_concurrency: 5
     always_run: true


### PR DESCRIPTION
It has been passing for more than a week. Note it failed a few times around 07/03 because it actually catches a bug in a PR. The PR still got merged due to the test is not required.

See https://k8s-testgrid.appspot.com/istio-presubmits-master#integ-security-k8s-presubmit-tests&width=20