### PR TITLE
Add cloudfoundry test

### DIFF
--- a/docker/istio/istio/install.sh
+++ b/docker/istio/istio/install.sh
@@ -20,7 +20,8 @@ apt-get -qqy --no-install-recommends install \
   unzip \
   wget \
   zip \
-  jq
+  jq \
+  iptables
 
 gem install --no-ri --no-rdoc fpm
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -548,6 +548,7 @@ presubmits:
   - name: istio_e2e_cloudfoundry-master
     <<: *job_template
     always_run: true
+    optional: true
     spec:
       containers:
       - <<: *istio_container
@@ -941,6 +942,7 @@ postsubmits:
   - name: istio_e2e_cloudfoundry-master
     <<: *job_template
     always_run: true
+    optional: true
     spec:
       containers:
       - <<: *istio_container

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190628-31457b43
+  image: gcr.io/istio-testing/istio-builder:v20190709-959ee177
   # Docker in Docker
   securityContext:
     privileged: true
@@ -18,7 +18,7 @@ istio_container: &istio_container
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190628-31457b43
+  image: gcr.io/istio-testing/istio-builder:v20190709-959ee177
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -545,7 +545,18 @@ presubmits:
         - prow/release-test.sh
       nodeSelector:
         testing: test-pool
-
+  - name: istio_e2e_cloudfoundry-master
+    <<: *job_template
+    always_run: true
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - make
+        - e2e_cloudfoundry
+      nodeSelector:
+        testing: test-pool
 
 postsubmits:
 
@@ -925,5 +936,17 @@ postsubmits:
         command:
         - entrypoint
         - prow/e2e_pilotv2_auth_sds.sh
+      nodeSelector:
+        testing: test-pool
+  - name: istio_e2e_cloudfoundry-master
+    <<: *job_template
+    always_run: true
+    spec:
+      containers:
+      - <<: *istio_container
+        command:
+        - entrypoint
+        - make
+        - e2e_cloudfoundry
       nodeSelector:
         testing: test-pool


### PR DESCRIPTION
This is the last test running on circleci in istio/istio repo (in presubmit).

This change
* Adds iptables to builder
* Builds and updates the image
* Adds the cloudfoundry tests

Do not merge until https://github.com/istio/istio/pull/15404 is approved or test will fail (but it is optional for now anyways)