### PR TITLE
Use recommended review, /lgtm, /approve config

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -50,9 +50,11 @@ lgtm:
   - istio/test-infra
   - istio/proxy
   - istio-releases/pipeline
+  review_acts_as_lgtm: true
   trusted_team_for_sticky_lgtm: "Istio Hackers"
 - repos:
   - istio-ecosystem/authservice
+  review_acts_as_lgtm: true
 
 approve:
 - repos:
@@ -63,11 +65,9 @@ approve:
   - istio/proxy
   - istio-releases/pipeline
   implicit_self_approve: true
-  lgtm_acts_as_approve: true
 - repos:
   - istio-ecosystem/authservice
   implicit_self_approve: true
-  lgtm_acts_as_approve: true
 
 plugins:
   istio/istio:


### PR DESCRIPTION
* `/approve` adds the `approve` label
  - `/approve cancel` removes the `approve` label.
* `/lgtm` adds the `lgtm` label
  - `/lgtm cancel` removes the `lgtm` label
* Github approving review does the same thing as `/lgtm` + `/approve`
  - Github changes requested review does the same thing as `/lgtm cancel` `/approve cancel`

/assign @cjwagner @icygalz @utka 

Follow up to #1434 -- repos like `istio/test-infra` need this

ref https://github.com/istio/test-infra/pull/1434 https://github.com/istio/test-infra/issues/1433 #1396