### PR TITLE
Skip report on installer until stable

### DIFF
--- a/prow/cluster/jobs/istio/installer/istio.installer.master.yaml
+++ b/prow/cluster/jobs/istio/installer/istio.installer.master.yaml
@@ -26,6 +26,7 @@ presubmits:
     context: prow/istio-lint.sh
     always_run: true
     optional: true
+    skip_report: true
     spec:
       containers:
       - <<: *istio_container


### PR DESCRIPTION
The code needed for this is not in installer yet and the code we have doesn't work yet, will be a bit cleaner to not report this

See https://github.com/istio/installer/pull/258