### PR TITLE
Temporarily restore /lgtm == /approve

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -50,10 +50,12 @@ lgtm:
   - istio/test-infra
   - istio/proxy
   - istio-releases/pipeline
+  lgtm_acts_as_approve: true # TODO(fejta): delete https://github.com/istio/test-infra/issues/1433
   review_acts_as_lgtm: true
   trusted_team_for_sticky_lgtm: "Istio Hackers"
 - repos:
   - istio-ecosystem/authservice
+  lgtm_acts_as_approve: true # TODO(fejta): delete https://github.com/istio/test-infra/issues/1433
   review_acts_as_lgtm: true
 
 approve:


### PR DESCRIPTION
/assign @howardjohn 

ref https://github.com/istio/test-infra/issues/1433

People are used to `/lgtm` adding the `approve` label, let's give them time to adjust to using github reviews instead.