### PR TITLE
Turn off service account for istioctl test

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -925,8 +925,6 @@ postsubmits:
         testing: test-pool
   - name: integ-istioctl-k8s-postsubmit-tests-master
     <<: *job_template
-    labels:
-      preset-service-account: "true"
     spec:
       containers:
       - <<: *istio_container


### PR DESCRIPTION
I am pretty sure this is not needed as the test runs fully locally now
with kind, so it doesnt need boskos or gcr. The istioctl test is already
failing (https://github.com/istio/istio/issues/15500) so this will
reduce risk if this doesn't work as expected. Once this works others can
be removed as well