### PR TITLE
Enable size, trigger and wip across all istio orgs

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -5,10 +5,9 @@
 triggers:
 - repos:
   - istio
-  - istio-releases/pipeline
+  - istio-ecosystem
+  - istio-releases
   trusted_org: istio
-- repos:
-  - istio-ecosystem/authservice
 
 config_updater:
   maps:
@@ -66,6 +65,16 @@ plugins:
   - trigger
   - wip
 
+  istio-ecosystem:
+  - size
+  - trigger
+  - wip
+
+  istio-releases:
+  - size
+  - trigger
+  - wip
+
   istio/istio:
   - approve
   - assign
@@ -97,7 +106,6 @@ plugins:
 
   istio-releases/pipeline:
   - lifecycle
-  - trigger
   - hold
 
   istio-ecosystem/authservice:
@@ -110,9 +118,7 @@ plugins:
   - lgtm
   - lifecycle
   - slackevents
-  - trigger
   - verify-owners
-  - wip
 
 external_plugins:
   istio:


### PR DESCRIPTION
/assign @geeknoid @cjwagner @howardjohn @utka 

Configure a base set plugins the same way throughout istio, istio-releases, istio-ecosystem

* size auto-manages the `size/L` or whatever label to PR, which helps gubernator.k8s.io/pr sorting
* wip auto-manages the work-in-progress label based on draft status and/or title
* trigger causes any presubmit/postsubmit prow jobs defined for the repo to run as configured
  - does nothing until these jobs are added