### PR TITLE
fix(tests): remove integ-telemetry-local* tests

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.collab-galley.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.collab-galley.yaml
@@ -127,20 +127,6 @@ presubmits:
         nodeSelector:
           testing: test-pool
 
-    - name: integ-telemetry-local-presubmit-tests
-      <<: *job_template
-      context: prow/integ-telemetry-local-presubmit-tests.sh
-      always_run: true
-      optional: true
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-telemetry-local-presubmit-tests.sh
-        nodeSelector:
-          testing: test-pool
-
     - name: integ-framework-k8s-presubmit-tests
       <<: *job_template
       context: prow/integ-framework-k8s-presubmit-tests.sh
@@ -509,18 +495,6 @@ postsubmits:
               - entrypoint
               - prow/integ-suite-local.sh
               - test.integration.security.local
-        nodeSelector:
-          testing: test-pool
-
-    - name: integ-telemetry-local-postsubmit-tests
-      <<: *job_template
-      spec:
-        containers:
-          - <<: *istio_container
-            command:
-              - entrypoint
-              - prow/integ-suite-local.sh
-              - test.integration.telemetry.local
         nodeSelector:
           testing: test-pool
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -186,20 +186,6 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-telemetry-local-presubmit-tests-master
-    <<: *job_template
-    always_run: true
-    optional: true
-    spec:
-      containers:
-        - <<: *istio_container
-          command:
-            - entrypoint
-            - prow/integ-suite-local.sh
-            - test.integration.telemetry.local.presubmit
-      nodeSelector:
-        testing: test-pool
-
   - name: integ-framework-k8s-presubmit-tests-master
     <<: *job_template
     always_run: true
@@ -721,18 +707,6 @@ postsubmits:
             - entrypoint
             - prow/integ-suite-local.sh
             - test.integration.security.local
-      nodeSelector:
-        testing: test-pool
-
-  - name: integ-telemetry-local-postsubmit-tests-master
-    <<: *job_template
-    spec:
-      containers:
-        - <<: *istio_container
-          command:
-            - entrypoint
-            - prow/integ-suite-local.sh
-            - test.integration.telemetry.local
       nodeSelector:
         testing: test-pool
 

--- a/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.prow-staging.yaml
@@ -198,21 +198,6 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: integ-telemetry-local-presubmit-tests-prow-staging
-    <<: *job_template
-    context: prow/integ-telemetry-local-presubmit-tests.sh
-    always_run: true
-    optional: true
-    spec:
-      containers:
-        - <<: *istio_container
-          command:
-            - entrypoint
-            - prow/integ-suite-local.sh
-            - test.integration.telemetry.local.presubmit
-      nodeSelector:
-        testing: test-pool
-
   - name: integ-framework-k8s-presubmit-tests-prow-staging
     <<: *job_template
     context: prow/integ-framework-k8s-presubmit-tests.sh
@@ -780,18 +765,6 @@ postsubmits:
             - entrypoint
             - prow/integ-suite-local.sh
             - test.integration.security.local
-      nodeSelector:
-        testing: test-pool
-
-  - name: integ-telemetry-local-postsubmit-tests-prow-staging
-    <<: *job_template
-    spec:
-      containers:
-        - <<: *istio_container
-          command:
-            - entrypoint
-            - prow/integ-suite-local.sh
-            - test.integration.telemetry.local
       nodeSelector:
         testing: test-pool
 


### PR DESCRIPTION
There are no local integration tests for telemetry currently. This PR removes the job config for those jobs.