### PR TITLE
Add plugins back to istio, proxy and test-infra

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -70,16 +70,24 @@ plugins:
   - approve
   - assign
   - blunderbuss
+  - golint
+  - help
+  - hold
   - lgtm
   - lifecycle
+  - slackevents
   - verify-owners
 
   istio/proxy:
   - approve
   - assign
   - blunderbuss
+  - golint
+  - help
+  - hold
   - lgtm
   - lifecycle
+  - slackevents
   - verify-owners
 
   istio/test-infra:
@@ -88,12 +96,15 @@ plugins:
   - blunderbuss
   - config-updater
   - golint
+  - help
   - hold
   - lgtm
   - lifecycle
+  - shrug
   - skip
   - slackevents
   - verify-owners
+  - yuks
 
   istio-releases/pipeline:
   - lifecycle


### PR DESCRIPTION
/assign @utka @cjwagner @geeknoid @howardjohn 

Add back plugins removed in https://github.com/istio/test-infra/pull/1468 

Not necessary if we can reach agreement on https://github.com/istio/test-infra/pull/1490 (which I would personally prefer)