### PR TITLE
Raise job CPU limits

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -15,7 +15,7 @@ istio_container: &istio_container
       cpu: "3000m"
     limits:
       memory: "24Gi"
-      cpu: "3000m"
+      cpu: "5000m"
 
 istio_container_with_kind: &istio_container_with_kind
   image: gcr.io/istio-testing/istio-builder:v20190709-959ee177
@@ -63,7 +63,7 @@ presubmits:
             cpu: "3000m"
           limits:
             memory: "24Gi"
-            cpu: "3000m"
+            cpu: "5000m"
         command:
         - entrypoint
         - prow/istio-lint.sh


### PR DESCRIPTION
The CPU limits were set to a low number in an attempt to fix
infrastructure flakes we attributed to CPU being overloaded. When we
made this change, we did not detect any noticable differences, and it
appears moving to SSDs has fixed the issue. Right now our tests get
heavily throttled. Hopefully this should help.