### PR TITLE
Modernize operator-test-master

### DIFF
--- a/prow/cluster/jobs/istio/operator/istio.operator.master.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.yaml
@@ -48,15 +48,20 @@ presubmits:
         testing: build-pool
 
   - name: operator-test-master
-    <<: *job_template
-    context: prow/test.sh
+    path_alias: istio.io/operator
+    decorate: true
     always_run: true
     spec:
       containers:
-      - <<: *istio_container
+      - image: golang:1.12.7
         command:
-        - entrypoint
-        - prow/test.sh
+        - go
+        - test
+        - -race
+        - ./...
+        env:
+        - name: GO111MODULE
+          value: "on"
       nodeSelector:
         testing: test-pool
 postsubmits:


### PR DESCRIPTION
/assign @sdake @howardjohn @geeknoid @sbezverk 

Here's how I would recommend [converting istio/operator's circleci job](https://github.com/istio/operator/blob/1670827469a376fd755f8d7425dc333bc00d6a9c/.circleci/config.yml) to run on prow.

This job is clear, does everything it needs and should be approachable by general developers, aka it has an easy to understand image: (golang:1.12.7), a comprehensible command `go test -race ./...` and an environment variable (to force the use of go modules).

I would like to try and encourage this pattern rather than making CI testing appear to use and do things that are foreign to developers.

ref https://github.com/istio/test-infra/issues/1499

There's basically zero delta between what a developer will do normally, when running the presubmit locally and what the presubmit will do in prod.

```console
$ mkpj --job=operator-test-master --config-path=../istio-test-infra/prow/config.yaml --job-config-path ../istio-test-infra/prow/cluster/jobs --pull-number=91 | tee ~/job.yaml

$ phaino ~/job.yaml
?   	istio.io/operator/cmd	[no test files]
?   	istio.io/operator/cmd/iop	[no test files]
?   	istio.io/operator/cmd/manager	[no test files]
?   	istio.io/operator/pkg/apis	[no test files]
?   	istio.io/operator/pkg/apis/istio/v1alpha1	[no test files]
?   	istio.io/operator/pkg/apis/istio/v1alpha2	[no test files]
?   	istio.io/operator/pkg/component/component	[no test files]
ok  	istio.io/operator/pkg/component/controlplane	4.229s
?   	istio.io/operator/pkg/component/feature	[no test files]
?   	istio.io/operator/pkg/controller	[no test files]
?   	istio.io/operator/pkg/controller/istiocontrolplane	[no test files]
?   	istio.io/operator/pkg/helm	[no test files]
?   	istio.io/operator/pkg/helmreconciler	[no test files]
ok  	istio.io/operator/pkg/kubectlcmd	1.060s
ok  	istio.io/operator/pkg/manifest	1.280s
?   	istio.io/operator/pkg/name	[no test files]
ok  	istio.io/operator/pkg/patch	1.400s
ok  	istio.io/operator/pkg/translate	1.360s
ok  	istio.io/operator/pkg/util	1.205s
?   	istio.io/operator/pkg/util/fswatch	[no test files]
ok  	istio.io/operator/pkg/validate	1.242s
ok  	istio.io/operator/pkg/values	1.324s
?   	istio.io/operator/pkg/version	[no test files]
?   	istio.io/operator/pkg/vfsgen	[no test files]
ok  	istio.io/operator/tests/codecov	1.033s
?   	istio.io/operator/version	[no test files]
INFO[0080] PASS                                          duration=1m20.795601051s job=operator-test-master
INFO[0080] SUCCESS 
```