### PR TITLE
Use ghproxy for branchprotector

### DIFF
--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -18,9 +18,11 @@ spec:
             image: gcr.io/k8s-prow/branchprotector:v20190715-1dacc7e01
             args:
             - --config-path=/etc/config/config.yaml
+            - --confirm
+            - --github-endpoint=http://ghproxy # prefer ghproxy
+            - --github-endpoint=https://api.github.com
             - --github-token-path=/etc/github/oauth
             - --job-config-path=/etc/job-config
-            - --confirm
             volumeMounts:
             - name: oauth
               mountPath: /etc/github


### PR DESCRIPTION
/assign @cjwagner @geeknoid 

This should make the branchprotector job substantially faster by intelligently reusing cached values when they are still the latest value.

When this happens github does not charge us against our hourly token quota, and our throttler refunds the charge when this happens, allowing the app to safely perform faster.

ref https://github.com/istio/test-infra/issues/1511 https://github.com/istio/test-infra/issues/1396

https://github.com/kubernetes/test-infra/tree/master/ghproxy
https://github.com/kubernetes/test-infra/blob/b46a322dbb4a45f81ed13f1230a1bedb33aa93c1/prow/github/client.go#L345