### PR TITLE
Turn on elide_skipped_contexts

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -8,6 +8,7 @@ triggers:
   - istio-ecosystem
   - istio-releases
   trusted_org: istio
+  elide_skipped_contexts: true
 
 config_updater:
   maps:


### PR DESCRIPTION
Current any context across all branches will show up as "Skipped". This
change makes it so only tests that are run will be posted.