### PR TITLE
Adding privileged back to postsubmit

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -115,6 +115,8 @@ postsubmits:
       - image: gcr.io/istio-testing/prowbazel:0.5.8
         command:
         - ./prow/proxy-postsubmit.sh
+        securityContext:
+          privileged: true
         resources:
           requests:
             memory: "8Gi"


### PR DESCRIPTION
Privileged gives several benefits for this particular test, like ability to create symlinks outside of build context. I was able to walk around this particular symlink issue, but the test still fails to copy data to the bucket, it fails with insufficient permissions. We did not change bucket permissions, so I want to test if privileged going to help with this or not. 