### PR TITLE
Add job to test that gcsweb is alive

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -231,3 +231,16 @@ periodics:
       command:
       - entrypoint
       - scripts/trigger_daily_release.sh
+- interval: 5m
+  name: monitoring-verify-gcsweb
+  decorate: true
+  spec:
+    containers:
+      - image: alpine:3.10.1
+        command:
+        - wget
+        args:
+        - --spider
+        - https://gcsweb.istio.io/gcs/istio-release/
+    nodeSelector:
+      testing: test-pool


### PR DESCRIPTION
This job just tries fetching gcsweb with TLS verification enabled, and fails if it can't. We can hook it up to testgrid to get emails when it fails, creating a basic but functional monitoring system.

gcsweb going down can cause end-user issues (e.g. istio/istio#15699) as well as upstream developer issues, so it is particularly worthwhile having monitoring on this.