### PR TITLE
Temporarily disable mandiff

### DIFF
--- a/prow/cluster/jobs/istio/operator/istio.operator.master.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.yaml
@@ -53,18 +53,3 @@ presubmits:
       nodeSelector:
         testing: test-pool
 
-  - name: operator-mandiff-master
-    path_alias: istio.io/operator
-    decorate: true
-    always_run: true
-    spec:
-      containers:
-      - image: gcr.io/istio-testing/istio-builder:v20190624-478286dc
-        command:
-        - make
-        - mandiff
-        env:
-        - name: GO111MODULE
-          value: "on"
-      nodeSelector:
-        testing: test-pool


### PR DESCRIPTION
This is necessary because the iop is being restructured. The mandiff test which uses it must be modified accordingly. 