### PR TITLE
Send webhooks to cherrypicker service.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -125,12 +125,17 @@ external_plugins:
   istio:
   - name: needs-rebase
     events:
-      - pull_request
+    - pull_request
   istio-releases/pipeline:
   - name: needs-rebase
     events:
-      - pull_request
+    - pull_request
   istio-ecosystem/authservice:
   - name: needs-rebase
     events:
-      - pull_request
+    - pull_request
+  istio/test-infra:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request


### PR DESCRIPTION
This will emit some errors in the Prow logs until the service is available, but we'll add that in a follow up after confirming it is working.
/assign @michelle192837 