### PR TITLE
Add cherrypicker service and deployment.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -33,6 +33,9 @@ update-configs: update-config update-plugins
 branch-protector-cronjob: get-cluster-credentials
 	kubectl apply -f cluster/branchprotector_cronjob.yaml
 
+cherrypicker-deployment: get-cluster-credentials
+	kubectl apply -f cluster/cherrypicker_deployment.yaml
+
 deck-deployment: get-cluster-credentials
 	kubectl apply -f cluster/deck_deployment.yaml
 
@@ -61,9 +64,12 @@ tide-deployment: get-cluster-credentials
 tot-deployment: get-cluster-credentials
 	kubectl apply -f cluster/tot_deployment.yaml
 
-deployments: branch-protector-cronjob deck-deployment ghproxy-deployment hook-deployment horologium-deployment needs-rebase-deployment plank-deployment sinker-deployment tide-deployment tot-deployment statusreconciler-deployment
+deployments: branch-protector-cronjob cherrypicker-deployment deck-deployment ghproxy-deployment hook-deployment horologium-deployment needs-rebase-deployment plank-deployment sinker-deployment tide-deployment tot-deployment statusreconciler-deployment
 
 .PHONY: branch-protector-cronjob deployments deck-deployment hook-deployment horologium-deployment needs-rebase-deployment plank-deployment sinker-deployment tide-deployment tot-deployment statusreconciler-deployment
+
+cherrypicker-service: get-cluster-credentials
+	kubectl apply -f cluster/cherrypicker_service.yaml
 
 deck-service: get-cluster-credentials
 	kubectl apply -f cluster/deck_service.yaml
@@ -83,7 +89,7 @@ tot-service: get-cluster-credentials
 statusreconciler-deployment: get-cluster-credentials
 	kubectl apply -f cluster/statusreconciler_deployment.yaml
 
-services: deck-service hook-service needs-rebase-service tide-service tot-service
+services: cherrypicker-service deck-service hook-service needs-rebase-service tide-service tot-service
 
 .PHONY: services deck-service hook-service needs-rebase-service tide-service tot-service
 

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: cherrypicker
+  labels:
+    app: cherrypicker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cherrypicker
+  template:
+    metadata:
+      labels:
+        app: cherrypicker
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: cherrypicker
+        image: gcr.io/k8s-prow/cherrypicker:v20190729-0247813d7
+        args:
+        - --dry-run=false
+        - --use-prow-assignments=false
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      nodeSelector:
+        prod: prow

--- a/prow/cluster/cherrypicker_service.yaml
+++ b/prow/cluster/cherrypicker_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cherrypicker
+  namespace: default
+  name: cherrypicker
+spec:
+  selector:
+    app: cherrypicker
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  type: ClusterIP


### PR DESCRIPTION
Seems to be receiving webhooks and was able to make a [fork](https://github.com/istio-testing/test-infra).
Please change [`plugins.yaml`](https://github.com/istio/test-infra/blob/a61b87c6fae107bccff746674eea9b653f9f8b8a/prow/plugins.yaml#L138-L141) to enable the tool on a repo that requires cherrypicks and allows users to changes labels so that we can test the new behavior.
/assign @michelle192837 @geeknoid 