### PR TITLE
Fix job url template.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,6 +1,6 @@
 ---
 plank:
-  job_url_template: 'https://prow.istio.io/view/gcs/istio-prow{{if eq .Spec.Type "presubmit"}}/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if .Spec.Type "batch"}}/pr-logs/pull/batch{{else}}/logs{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
+  job_url_template: 'https://prow.istio.io/view/gcs/istio-prow{{if eq .Spec.Type "presubmit"}}/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/pr-logs/pull/batch{{else}}/logs{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
   job_url_prefix: https://prow.istio.io/view/gcs/
   pod_pending_timeout: 60m
   default_decoration_config:


### PR DESCRIPTION
Fixes errors like:
```yaml
{
  component:  "plank"   
  file:  "prow/pjutil/pjutil.go:276"   
  func:  "k8s.io/test-infra/prow/pjutil.JobURL"   
  job:  "test-infra-cleanup-GKE"   
  level:  "error"   
  msg:  "error executing URL template: template: JobURL:1:192: executing "JobURL" at <.Spec.Type>: Type has arguments but cannot be invoked as function"   
  name:  "8623c03f-b486-11e9-8fd8-56293c9f2b73"   
  type:  "periodic"   
}
```