### PR TITLE
Remove sds-enabled tests on old e2e framework

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -182,36 +182,6 @@ postsubmits:
     labels:
       preset-service-account: "true"
     max_concurrency: 5
-    name: istio_auth_sds_e2e-master
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/e2e_pilotv2_auth_sds.sh
-        image: gcr.io/istio-testing/istio-builder:v20190709-959ee177
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-postsubmits-master
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-dashboard-master
     path_alias: istio.io/istio
     spec:
@@ -1915,35 +1885,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
-        image: gcr.io/istio-testing/istio-builder:v20190709-959ee177
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio-presubmits-master
-    branches:
-    - ^master$
-    decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
-    name: istio_auth_sds_e2e-master
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/e2e_pilotv2_auth_sds.sh
         image: gcr.io/istio-testing/istio-builder:v20190709-959ee177
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -82,10 +82,6 @@ jobs:
     command: [prow/istio-pilot-e2e-envoyv2-v1alpha3.sh]
     requirements: [gcp]
 
-  - name: istio_auth_sds_e2e
-    command: [prow/e2e_pilotv2_auth_sds.sh]
-    requirements: [gcp]
-
   - name: e2e-dashboard
     command: [prow/e2e-dashboard.sh]
     requirements: [gcp]


### PR DESCRIPTION
Istio with SDS won't support k8s 1.11, which is the version that e2e tests are running on. 