### PR TITLE
Use KinD for optional E2E tests

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -239,16 +239,16 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-bookInfoTests-trustdomain-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-bookInfoTests-trustdomain.sh
+        - prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --single_test
+        - e2e_simple
         image: gcr.io/istio-testing/istio-builder:v20190805-b1d72b4d
         name: ""
         resources:
@@ -260,8 +260,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -329,16 +344,20 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTests-distroless-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests-distroless.sh
+        - prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --single_test
+        - e2e_simple
+        - --installer
+        - helm
+        - --variant
+        - distroless
         image: gcr.io/istio-testing/istio-builder:v20190805-b1d72b4d
         name: ""
         resources:
@@ -350,8 +369,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -368,7 +402,15 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests-minProfile.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_simple_noauth
+        - --installer
+        - helm
+        - --valueFile
+        - values-istio-minimal.yaml
+        - --helmSetValueList
+        - gateways.enabled=true,galley.enabled=false,global.useMCP=false
         image: gcr.io/istio-testing/istio-builder:v20190805-b1d72b4d
         name: ""
         resources:
@@ -2009,9 +2051,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-bookInfoTests-trustdomain-master
     optional: true
     path_alias: istio.io/istio
@@ -2019,7 +2058,10 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-bookInfoTests-trustdomain.sh
+        - prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --single_test
+        - e2e_simple
         image: gcr.io/istio-testing/istio-builder:v20190805-b1d72b4d
         name: ""
         resources:
@@ -2031,8 +2073,23 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master
@@ -2068,9 +2125,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTests-distroless-master
     optional: true
     path_alias: istio.io/istio
@@ -2078,7 +2132,14 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests-distroless.sh
+        - prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --single_test
+        - e2e_simple
+        - --installer
+        - helm
+        - --variant
+        - distroless
         image: gcr.io/istio-testing/istio-builder:v20190805-b1d72b4d
         name: ""
         resources:
@@ -2090,8 +2151,23 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master
@@ -2108,7 +2184,15 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests-minProfile.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_simple_noauth
+        - --installer
+        - helm
+        - --valueFile
+        - values-istio-minimal.yaml
+        - --helmSetValueList
+        - gateways.enabled=true,galley.enabled=false,global.useMCP=false
         image: gcr.io/istio-testing/istio-builder:v20190805-b1d72b4d
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -90,8 +90,8 @@ jobs:
     command: [prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh]
     requirements: [gcp]
   - name: e2e-bookInfoTests-trustdomain
-    command: [prow/e2e-bookInfoTests-trustdomain.sh]
-    requirements: [gcp]
+    command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple]
+    requirements: [kind]
     modifiers: [optional]
   - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp
     type: postsubmit
@@ -102,11 +102,11 @@ jobs:
     command: [prow/e2e-simpleTests.sh]
     requirements: [gcp]
   - name: e2e-simpleTests-distroless
-    command: [prow/e2e-simpleTests-distroless.sh]
-    requirements: [gcp]
+    command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple, --installer, helm, --variant, distroless]
+    requirements: [kind]
     modifiers: [optional]
   - name: e2e-simpleTestsMinProfile
-    command: [prow/e2e-simpleTests-minProfile.sh]
+    command: [prow/e2e-kind-suite.sh, --single_test, e2e_simple_noauth, --installer, helm, --valueFile, values-istio-minimal.yaml, --helmSetValueList, "gateways.enabled=true,galley.enabled=false,global.useMCP=false"]
     requirements: [gcp]
     modifiers: [optional]
   - name: e2e-simpleTests-cni


### PR DESCRIPTION
Migrate these tests over to using KinD instead of boskos. This will make
them much cheaper and more reproducible locally.

Currently only doing the optional tests as a canary, once these are
stable more will be migrated over.

Blocked by https://github.com/istio/istio/pull/16062