### PR TITLE
Add additional owners to prow/config

### DIFF
--- a/prow/config/OWNERS
+++ b/prow/config/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - howardjohn
+  - sdake
+  - geeknoid


### PR DESCRIPTION
Note - the owners are additive so top level owners are still owners here.

Most of the stuff here is not applicable to top level owners