### PR TITLE
add nogo vet with default analyzers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "nogo")
 
 buildifier(
     name = "buildifier",
@@ -24,4 +25,10 @@ platform(
       }
       {PARENT_REMOTE_EXECUTION_PROPERTIES}
     """,
+)
+
+nogo(
+    name = "nogo_vet",
+    vet = True,
+    visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,7 +59,10 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(go_version = "1.12.7")
+go_register_toolchains(
+    go_version = "1.12.7",
+    nogo="@//:nogo_vet",
+)
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 


### PR DESCRIPTION
This is in the effort towards modernization, #1396. 

Enable [nogo](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst) vet static analysis using the [*default*](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst#running-vet) analyzers. 

> **Note:** these checks are run alongside the compiler when building any Go target (e.g. go_library)