### PR TITLE
Update prow to v20190805-b43f41119

### DIFF
--- a/prow/bump.sh
+++ b/prow/bump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
           containers:
           - name: branchprotector
             # TODO(fejta): migrate to trusted prowjob
-            image: gcr.io/k8s-prow/branchprotector:v20190730-bfd5985df
+            image: gcr.io/k8s-prow/branchprotector:v20190805-b43f41119
             args:
             - --config-path=/etc/config/config.yaml
             - --confirm

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/cherrypicker:v20190805-b43f41119
         args:
         - --dry-run=false
         - --use-prow-assignments=false

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/deck:v20190805-b43f41119
         ports:
           - name: http
             containerPort: 8080

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/ghproxy:v20190805-b43f41119
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/hook:v20190805-b43f41119
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -14,7 +14,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/horologium:v20190805-b43f41119
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/needs-rebase:v20190805-b43f41119
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/plank:v20190805-b43f41119
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/sinker:v20190805-b43f41119
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20190730-bfd5985df
+          image: gcr.io/k8s-prow/status-reconciler:v20190805-b43f41119
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/tide:v20190805-b43f41119
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20190730-bfd5985df
+        image: gcr.io/k8s-prow/tot:v20190805-b43f41119
         args:
         - -storage=/store/tot.json
         - -fallback

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8,10 +8,10 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190730-bfd5985df"
-      initupload: "gcr.io/k8s-prow/initupload:v20190730-bfd5985df"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190730-bfd5985df"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190730-bfd5985df"
+      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190805-b43f41119"
+      initupload: "gcr.io/k8s-prow/initupload:v20190805-b43f41119"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190805-b43f41119"
+      sidecar: "gcr.io/k8s-prow/sidecar:v20190805-b43f41119"
     gcs_configuration:
       bucket: "istio-prow"
       path_strategy: "explicit"


### PR DESCRIPTION
In the future, this should be run on an interval as a periodic job (#1396). 

@cjwagner I know we spoke about this briefly - should creating a periodic for autobump be done *before* or *after* migrating to use a separate build cluster?