### PR TITLE
Add owners to prow jobs

### DIFF
--- a/prow/cluster/jobs/OWNERS
+++ b/prow/cluster/jobs/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - geeknoid
+  - howardjohn
+  - duderino
+  - linsun
+  - sdake


### PR DESCRIPTION
individual repos can override this with their own owners