### PR TITLE
Disable --rerun-creates-job until we add a cookie-secret.

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -30,7 +30,6 @@ spec:
         - --redirect-http-to=prow.istio.io
         - --spyglass
         - --tide-url=http://tide/
-        - --rerun-creates-job
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
We need to set up GitHub oauth before we can enable this.
/assign @howardjohn 