### PR TITLE
Revert "Revert "Move more tests to using kind (#1604)""

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -119,16 +119,15 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-mixer-no_auth-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-mixer-no_auth.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_mixer
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -140,8 +139,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -149,16 +163,15 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: istio-pilot-e2e-envoyv2-v1alpha3-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_pilotv2_v1alpha3
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -170,8 +183,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -209,16 +237,15 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-bookInfoTests-envoyv2-v1alpha3-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_bookinfo_envoyv2_v1alpha3
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -230,8 +257,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -284,16 +326,16 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
+        - prow/e2e-kind-suite.sh
+        - --use_mcp=false
+        - --single_test
+        - e2e_bookinfo_envoyv2_v1alpha3
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -305,8 +347,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -314,16 +371,18 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTests-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests.sh
+        - ./prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --single_test
+        - e2e_simple
+        - --installer
+        - helm
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -335,8 +394,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -393,9 +467,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTestsMinProfile-master
     path_alias: istio.io/istio
     spec:
@@ -422,8 +493,23 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio-postsubmits-master
@@ -461,43 +547,19 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTests-non-mcp-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests-non-mcp.sh
-        image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-postsubmits-master
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
-    name: istio-kind-simpleTest-master
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/e2e-kind-simpleTests.sh
+        - ./prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --use_mcp=false
+        - --single_test
+        - e2e_simple
+        - --installer
+        - helm
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1935,16 +1997,15 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-mixer-no_auth-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-mixer-no_auth.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_mixer
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1956,24 +2017,38 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: istio-pilot-e2e-envoyv2-v1alpha3-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_pilotv2_v1alpha3
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1985,8 +2060,23 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master
@@ -2022,16 +2112,15 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-bookInfoTests-envoyv2-v1alpha3-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh
+        - prow/e2e-kind-suite.sh
+        - --single_test
+        - e2e_bookinfo_envoyv2_v1alpha3
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -2043,8 +2132,23 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master
@@ -2096,16 +2200,18 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTests-master
     path_alias: istio.io/istio
     spec:
       containers:
       - command:
         - entrypoint
-        - prow/e2e-simpleTests.sh
+        - ./prow/e2e-kind-suite.sh
+        - --auth_enable
+        - --single_test
+        - e2e_simple
+        - --installer
+        - helm
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -2117,8 +2223,23 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master
@@ -2174,9 +2295,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-simpleTestsMinProfile-master
     optional: true
     path_alias: istio.io/istio
@@ -2204,8 +2322,23 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
       nodeSelector:
         testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     annotations:
       testgrid-dashboards: istio-presubmits-master

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -75,39 +75,40 @@ jobs:
     modifiers: [optional]
 
   - name: e2e-mixer-no_auth
-    command: [prow/e2e-mixer-no_auth.sh]
-    requirements: [gcp]
+    command: [prow/e2e-kind-suite.sh, --single_test, e2e_mixer]
+    requirements: [kind]
 
   - name: istio-pilot-e2e-envoyv2-v1alpha3
-    command: [prow/istio-pilot-e2e-envoyv2-v1alpha3.sh]
-    requirements: [gcp]
+    command: [prow/e2e-kind-suite.sh, --single_test, e2e_pilotv2_v1alpha3]
+    requirements: [kind]
 
+  # TODO migrate to kind once we have metric server in kind
   - name: e2e-dashboard
     command: [prow/e2e-dashboard.sh]
     requirements: [gcp]
 
   - name: e2e-bookInfoTests-envoyv2-v1alpha3
-    command: [prow/e2e-bookInfoTests-envoyv2-v1alpha3.sh]
-    requirements: [gcp]
+    command: [prow/e2e-kind-suite.sh, --single_test, e2e_bookinfo_envoyv2_v1alpha3]
+    requirements: [kind]
   - name: e2e-bookInfoTests-trustdomain
     command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple]
     requirements: [kind]
     modifiers: [optional]
   - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp
     type: postsubmit
-    command: [prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh]
-    requirements: [gcp]
+    command: [prow/e2e-kind-suite.sh, --use_mcp=false, --single_test, e2e_bookinfo_envoyv2_v1alpha3]
+    requirements: [kind]
 
   - name: e2e-simpleTests
-    command: [prow/e2e-simpleTests.sh]
-    requirements: [gcp]
+    command: [./prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple, --installer, helm]
+    requirements: [kind]
   - name: e2e-simpleTests-distroless
     command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple, --installer, helm, --variant, distroless]
     requirements: [kind]
     modifiers: [optional]
   - name: e2e-simpleTestsMinProfile
     command: [prow/e2e-kind-suite.sh, --single_test, e2e_simple_noauth, --installer, helm, --valueFile, values-istio-minimal.yaml, --helmSetValueList, "gateways.enabled=true,galley.enabled=false,global.useMCP=false"]
-    requirements: [gcp]
+    requirements: [kind]
     modifiers: [optional]
   - name: e2e-simpleTests-cni
     command: [prow/e2e-simpleTests-cni.sh]
@@ -115,11 +116,7 @@ jobs:
     modifiers: [optional]
   - name: e2e-simpleTests-non-mcp
     type: postsubmit
-    command: [prow/e2e-simpleTests-non-mcp.sh]
-    requirements: [gcp]
-  - name: istio-kind-simpleTest
-    type: postsubmit
-    command: [prow/e2e-kind-simpleTests.sh]
+    command: [./prow/e2e-kind-suite.sh, --auth_enable, --use_mcp=false, --single_test, e2e_simple, --installer, helm]
     requirements: [kind]
 
   - name: istio-pilot-multicluster-e2e


### PR DESCRIPTION
Reverts istio/test-infra#1621

I attempted to fix this in #1618, then decided it didn't work and instead reverted. Turns out, it did work and the test I was looking at didn't pick up the change. 

See this test result, which shows the simpleTest passing with KinD: https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/16066/e2e-simpleTests-master/5148.
