### PR TITLE
Delete istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -1192,36 +1192,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
-    max_concurrency: 5
-    name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest-master
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
-        image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-postsubmits-master
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     decoration_config:
       timeout: 4h0m0s
     name: integ-k8s-112-postsubmit-master

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -182,12 +182,6 @@ jobs:
     command: [prow/integ-suite-kind.sh, test.integration.conformance.kube]
     requirements: [kind]
 
-  - name: istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest
-    type: postsubmit
-    command: [prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh]
-    requirements: [gcp]
-
-
     # The node image must be kept in sync with the kind version we use.
     # See docker/istio/shared/tools/install-golang.sh for the kind image
     # https://github.com/kubernetes-sigs/kind/releases for node corresponding node image


### PR DESCRIPTION
This test is completely irrelevant now. It seems the intent was to
rerun an existing test with the "latest kubernetes", with the latest
meaning 1.11. The normal test now actually runs on kubernetes latest
(1.15), and we have explicit tests to test all supported versions.
Therefor, it seems this test provides no additional coverage.