### PR TITLE
Improve GOPROXY usage

### DIFF
--- a/prow/cluster/jobs/istio/operator/istio.operator.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.yaml
@@ -19,8 +19,6 @@ presubmits:
           value: "0"
         - name: USE_LOCAL_TOOLCHAIN
           value: "1"
-        - name: GO_PROXY
-          value: "https://proxy.golang.org"
       nodeSelector:
         testing: test-pool
 
@@ -41,8 +39,6 @@ presubmits:
           value: "0"
         - name: USE_LOCAL_TOOLCHAIN
           value: "1"
-        - name: GO_PROXY
-          value: "https://proxy.golang.org"
       nodeSelector:
         testing: build-pool
 
@@ -63,7 +59,5 @@ presubmits:
           value: "0"
         - name: USE_LOCAL_TOOLCHAIN
           value: "1"
-        - name: GO_PROXY
-          value: "https://proxy.golang.org"
       nodeSelector:
         testing: test-pool

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -15,8 +15,6 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-        - name: GOPROXY
-          value: "https://goproxy.io"
       nodeSelector:
         testing: build-pool
 
@@ -58,8 +56,6 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-        - name: GOPROXY
-          value: "https://goproxy.io"
       nodeSelector:
         testing: build-pool
 
@@ -83,8 +79,6 @@ presubmits:
           env:
           - name: GO111MODULE
             value: "on"
-          - name: GOPROXY
-            value: "https://goproxy.io"
       nodeSelector:
         testing: build-pool
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -366,3 +366,7 @@ presets:
   - name: rel-pipeline-github
     secret:
       secretName: rel-pipeline-github
+# Enable GOPROXY by default
+- env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"


### PR DESCRIPTION
Operator used the wrong variable name, test-infra used an unofficial
proxy.

We can set this globally and get it right this time, in one place. I
don't see any reason we would not want GOPROXY set, so global should be
safe - this is what kubernetes does.