### PR TITLE
Simplify how we update prow

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -10,6 +10,7 @@ CLUSTER ?= prow
 
 # ensures that kubectl has access to the prow cluster's config context
 get-cluster-credentials:
+	# TODO(fejta): https://github.com/istio/test-infra/issues/1636
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 
 update-config-dry-run: get-cluster-credentials
@@ -25,82 +26,7 @@ update-config: get-cluster-credentials
 		--plugins-config-path=plugins.yaml \
 		--wet
 
-# use to guarantee that on command completion all deployments see new configs
-update-configs: update-config update-plugins
+deploy: get-cluster-credentials
+	kubectl "--context=gke_$(PROJECT)_$(ZONE)_$(CLUSTER)" apply -f ./cluster/
 
-.PHONY: update-config update-plugins get-cluster-credentials update-configs
-
-branch-protector-cronjob: get-cluster-credentials
-	kubectl apply -f cluster/branchprotector_cronjob.yaml
-
-cherrypicker-deployment: get-cluster-credentials
-	kubectl apply -f cluster/cherrypicker_deployment.yaml
-
-deck-deployment: get-cluster-credentials
-	kubectl apply -f cluster/deck_deployment.yaml
-
-# This actually includes a deployment, service, and pvc, but it shouldn't matter.
-ghproxy-deployment: get-cluster-credentials
-	kubectl apply -f cluster/ghproxy.yaml
-
-hook-deployment: get-cluster-credentials
-	kubectl apply -f cluster/hook_deployment.yaml
-
-horologium-deployment: get-cluster-credentials
-	kubectl apply -f cluster/horologium_deployment.yaml
-
-needs-rebase-deployment: get-cluster-credentials
-	kubectl apply -f cluster/needs-rebase_deployment.yaml
-
-sinker-deployment: get-cluster-credentials
-	kubectl apply -f cluster/sinker_deployment.yaml
-
-plank-deployment: get-cluster-credentials
-	kubectl apply -f cluster/plank_deployment.yaml
-
-tide-deployment: get-cluster-credentials
-	kubectl apply -f cluster/tide_deployment.yaml
-
-tot-deployment: get-cluster-credentials
-	kubectl apply -f cluster/tot_deployment.yaml
-
-deployments: branch-protector-cronjob cherrypicker-deployment deck-deployment ghproxy-deployment hook-deployment horologium-deployment needs-rebase-deployment plank-deployment sinker-deployment tide-deployment tot-deployment statusreconciler-deployment
-
-.PHONY: branch-protector-cronjob deployments deck-deployment hook-deployment horologium-deployment needs-rebase-deployment plank-deployment sinker-deployment tide-deployment tot-deployment statusreconciler-deployment
-
-hook-rbac: get-cluster-credentials
-	kubectl apply -f cluster/hook_rbac.yaml
-
-deck-rbac: get-cluster-credentials
-	kubectl apply -f cluster/deck_rbac.yaml
-
-rbacs: hook-rbac deck-rbac
-
-.PHONY: rbacs hook-rbac deck-rbac
-
-cherrypicker-service: get-cluster-credentials
-	kubectl apply -f cluster/cherrypicker_service.yaml
-
-deck-service: get-cluster-credentials
-	kubectl apply -f cluster/deck_service.yaml
-
-hook-service: get-cluster-credentials
-	kubectl apply -f cluster/hook_service.yaml
-
-needs-rebase-service: get-cluster-credentials
-	kubectl apply -f cluster/needs-rebase_service.yaml
-
-tide-service: get-cluster-credentials
-	kubectl apply -f cluster/tide_service.yaml
-
-tot-service: get-cluster-credentials
-	kubectl apply -f cluster/tot_service.yaml
-
-statusreconciler-deployment: get-cluster-credentials
-	kubectl apply -f cluster/statusreconciler_deployment.yaml
-
-services: cherrypicker-service deck-service hook-service needs-rebase-service tide-service tot-service
-
-.PHONY: services deck-service hook-service needs-rebase-service tide-service tot-service
-
-deploy: deployments rbacs services
+.PHONY: deploy update-config update-config-dry-run get-cluster-credentials


### PR DESCRIPTION
/assign @michelle192837 @cjwagner 

* Ensure we target the correct context
* Drop all the redundant rules -- we don't want people updating prow this way, and using `apply -f cluster/foo_deployment.yaml` instead of just `apply -f cluster/` we're likely to cause issues by forgetting to add a new component