### PR TITLE
Remove specialized prow runner scripts from istio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE ?= on
+
 lint:
 	@scripts/run_golangci.sh
 	@scripts/check_license.sh

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -14,7 +14,13 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - prow/istio-unit-tests.sh
+        - make
+        - -e
+        - T=-v
+        - build
+        - localTestEnv
+        - test
+        - binaries-test
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -41,7 +47,11 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - prow/racetest.sh
+        - make
+        - -e
+        - T=-v
+        - localTestEnv
+        - racetest
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -68,7 +78,8 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - prow/codecov.sh
+        - make
+        - coverage-diff
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1370,7 +1381,13 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/istio-unit-tests.sh
+        - make
+        - -e
+        - T=-v
+        - build
+        - localTestEnv
+        - test
+        - binaries-test
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1396,7 +1413,8 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/istio-lint.sh
+        - make
+        - lint
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1422,7 +1440,11 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/racetest.sh
+        - make
+        - -e
+        - T=-v
+        - localTestEnv
+        - racetest
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1448,7 +1470,8 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/shellcheck.sh
+        - make
+        - shellcheck
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
@@ -1474,7 +1497,8 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/codecov.sh
+        - make
+        - coverage-diff
         image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -5,18 +5,18 @@ branches:
 
 jobs:
   - name: istio-unit-tests
-    command: [prow/istio-unit-tests.sh]
+    command: [make, -e, "T=-v", build, localTestEnv, test, binaries-test]
   - name: istio-lint
     type: presubmit
     resources: lint
-    command: [prow/istio-lint.sh]
+    command: [make, lint]
   - name: istio-racetest
-    command: [prow/racetest.sh]
+    command: [make,  -e, "T=-v", localTestEnv, racetest]
   - name: istio-shellcheck
     type: presubmit
-    command: [prow/shellcheck.sh]
+    command: [make, shellcheck]
   - name: istio-codecov
-    command: [prow/codecov.sh]
+    command: [make, coverage-diff]
 
   - name: release-test
     command: [prow/release-test.sh]


### PR DESCRIPTION
Right now we have some scripts that are mostly just very light wrappers
around make. It makes (no pun intended) more sense to just directly call
make and clean up these scripts.