### PR TITLE
Only run prow on official branches in the tools repo.

### DIFF
--- a/prow/cluster/jobs/istio/tools/istio.tools.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.yaml
@@ -3,6 +3,9 @@ presubmits:
   istio/tools:
 
     - name: tools-lint
+      branches:
+        - ^master$
+        - ^release-1.*$
       path_alias: istio.io/tools
       decorate: true
       always_run: true
@@ -19,6 +22,9 @@ presubmits:
           testing: test-pool
 
     - name: tools-build
+      branches:
+        - ^master$
+        - ^release-1.*$
       path_alias: istio.io/tools
       decorate: true
       always_run: true
@@ -36,6 +42,9 @@ presubmits:
           testing: build-pool
 
     - name: tools-test
+      branches:
+        - ^master$
+        - ^release-1.*$
       path_alias: istio.io/tools
       decorate: true
       always_run: true
@@ -54,6 +63,9 @@ presubmits:
           testing: test-pool
 
     - name: tools-fmtpy
+      branches:
+        - ^master$
+        - ^release-1.*$
       path_alias: istio.io/tools
       decorate: true
       always_run: true


### PR DESCRIPTION
This fixes the next branchprotector failure as per #1639 