### PR TITLE
Fix a couple bugs.

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -2,6 +2,9 @@ presubmits:
   istio/test-infra:
 
   - name: build-test
+    branches:
+      - ^master$
+      - ^release-1.*$
     always_run: true
     decorate: true
     path_alias: istio.io/test-infra
@@ -19,6 +22,9 @@ presubmits:
         testing: build-pool
 
   - name: pull-test-infra-prow-checkconfig
+    branches:
+      - ^master$
+      - ^release-1.*$
     decorate: true
     run_if_changed: '^prow/(config|plugins|cluster/jobs/.*)\.yaml$'
     spec:
@@ -36,6 +42,9 @@ presubmits:
         - --exclude-warning=non-decorated-jobs
 
   - name: lint-check
+    branches:
+      - ^master$
+      - ^release-1.*$
     always_run: true
     decorate: true
     path_alias: istio.io/test-infra
@@ -60,6 +69,9 @@ presubmits:
         testing: build-pool
 
   - name: generate-check
+    branches:
+      - ^master$
+      - ^release-1.*$
     always_run: true
     decorate: true
     path_alias: istio.io/test-infra
@@ -83,6 +95,9 @@ presubmits:
         testing: build-pool
 
   - name: flakey-run
+    branches:
+      - ^master$
+      - ^release-1.*$
     context: "prow: flakey-run"
     run_if_changed: "flakeyTest/.*"
     optional: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -257,6 +257,7 @@ tide:
     - istio/community
     - istio/istio.io
     - istio/gogo-genproto
+    - istio/test-infra
     labels:
     - "cla: yes"
     missingLabels:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -39,7 +39,6 @@ lgtm:
   - istio
   review_acts_as_lgtm: true
 - repos:
-  - istio/test-infra
   - istio-releases/pipeline
   review_acts_as_lgtm: true
   trusted_team_for_sticky_lgtm: "Istio Hackers"
@@ -49,7 +48,6 @@ lgtm:
 
 approve:
 - repos:
-  - istio/test-infra
   - istio-releases/pipeline
   implicit_self_approve: true
 - repos:
@@ -77,7 +75,6 @@ plugins:
   - config-updater
   - golint
   - hold
-  - lgtm
   - lifecycle
   - skip
   - slackevents


### PR DESCRIPTION
- Enable tide on test-infra. Somehow, that got dropped.

- Remove test-infra from some of the old-school plugins so it works
cleanly with CODEOWNERS.

- Only run prow jobs for official branches in the test-infra repo. This will
fix the branch protector.

Combined with enabling write permission for istio developers on the test-infra repo, like all our other repos, should get  everything working normally on this repo.