### PR TITLE
Add self to CODEOWNERS for top-level infra

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-*                                   @chxchx @cjwagner @fejta
-/prow/config/                       @chxchx @cjwagner @fejta @howardjohn @sdake @geeknoid
+*                                   @chxchx @cjwagner @fejta @clarketm
+/prow/config/                       @chxchx @cjwagner @fejta @clarketm @howardjohn @sdake @geeknoid
 /prow/cluster/jobs/                 @howardjohn @sdake @geeknoid @duderino @linsun
 /prow/cluster/jobs/istio/bots/      @howardjohn @sdake @geeknoid @duderino @linsun @ozevren
 /prow/cluster/jobs/istio/community/ @howardjohn @sdake @geeknoid @duderino @linsun


### PR DESCRIPTION
Adding myself to top-level `CODEOWNERS` to be able to approve version bumps #1650, configuration, and general infrastructure features.