### PR TITLE
Remove merges-blocked-needs-admin from release-1.3

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -82,7 +82,7 @@ blocked_branches: &blocked_branches
       teams:
       - release-managers-1-2
   release-1.3: &release13
-    <<: *blocking_merge
+    protect: true
     restrictions:
       teams:
       - release-managers-1-3
@@ -187,9 +187,6 @@ branch-protection:
                 - "merges-blocked-needs-admin"
             release-1.3:
               <<: *release13
-              required_status_checks:
-                contexts:
-                - "merges-blocked-needs-admin"
         proxy:
           required_pull_request_reviews: *tide_withcodeowners_reviews
           restrictions: *tide_withcodeowners_restrictions

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -117,13 +117,10 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name:   "istio 1.3 requires  admin merges",
+			name:   "istio 1.3 protected",
 			org:    "istio",
 			repo:   "istio",
 			branch: "release-1.3",
-			expectedContexts: []string{
-				"merges-blocked-needs-admin",
-			},
 		},
 		{
 			name:   "collab-galley restricted to hackers",


### PR DESCRIPTION
Instead of having a context that never passes, we will instead change
the owners to be just the release managers, so we can properly utilize
tide instead of force merging changes.