### PR TITLE
Transfer tide state across pods

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -17,21 +17,27 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
-        - --job-config-path=/etc/job-config
+        - --gcs-credentials-file=/etc/service-account/service-account.json
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --history-uri=gs://istio-prow/tide-history.json
+        - --job-config-path=/etc/job-config
+        - --status-path=gs://istio-prow/tide-status-checkpoint.yaml
         ports:
           - name: http
             containerPort: 8888
         volumeMounts:
-        - name: oauth
-          mountPath: /etc/github
-          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: service-account
+          mountPath: /etc/service-account
           readOnly: true
       volumes:
       - name: oauth
@@ -43,5 +49,8 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: service-account
+        secret:
+          secretName: prow-service-account
       nodeSelector:
         prod: prow


### PR DESCRIPTION
/assign @Katharine @michelle192837 @clarketm 


Added the `prow-service-account` secret

Similar to https://github.com/kubernetes/test-infra/blob/0a2e51dc8afa02adebff7c2a5e899a316e042893/prow/cluster/tide_deployment.yaml#L44-L46