### PR TITLE
Make Istio proxy presubmit priviledged

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -26,6 +26,8 @@ presubmits:
       - image: gcr.io/istio-testing/prowbazel:0.5.8
         command:
         - ./prow/proxy-presubmit.sh
+        securityContext:
+          privileged: true
         resources:
           requests:
             memory: "8Gi"


### PR DESCRIPTION
istio/proxy has some go tests that uses go mod and needs to be privileged to create directory for go mod.