### PR TITLE
Unify on build-tools for istio.io - removing one redundant image

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.yaml
@@ -11,7 +11,7 @@ presubmits:
       always_run: true
       spec:
         containers:
-          - image: gcr.io/istio-testing/website-tools:2019-07-25
+          - image: gcr.io/istio-testing/build-tools:2019-08-15
             command:
               - make
               - prow


### PR DESCRIPTION
The website-tools image has been consolidated into the build-tools
image. As a result, lets remove the usage of this image in the istio.io
documentation repo.

Depends-On: https://github.com/istio/common-files/pull/28
Depends-On: https://github.com/istio/tools/pull/272