### PR TITLE
Set BUILD_WITH_CONTAINER to 0 for all jobs.

### DIFF
--- a/prow/cluster/jobs/istio/operator/istio.operator.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.yaml
@@ -18,10 +18,6 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        - name: USE_LOCAL_TOOLCHAIN
-          value: "1"
       nodeSelector:
         testing: test-pool
 
@@ -41,10 +37,6 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        - name: USE_LOCAL_TOOLCHAIN
-          value: "1"
       nodeSelector:
         testing: build-pool
 
@@ -64,9 +56,5 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        - name: USE_LOCAL_TOOLCHAIN
-          value: "1"
       nodeSelector:
         testing: test-pool

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -349,3 +349,5 @@ presets:
 - env:
   - name: GOPROXY
     value: "https://proxy.golang.org"
+  - name: BUILD_WITH_CONTAINER
+    value: "0"


### PR DESCRIPTION
By default, we want humans building Istio stuff to be building through a
container. But the CI system already cranks up jobs within said container,
so we never want to have the CI's call to 'make' to induce a dind call
to the container. So we set BUILD_WITH_CONTAINER to 0 for all CI jobs.