### PR TITLE
Update test image for 1.1/1.2

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "3000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "3000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   # Docker in Docker
   securityContext:
     privileged: true
@@ -36,7 +36,7 @@ istio_container: &istio_container
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190521-2f2d695
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   securityContext:
     privileged: true
   resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   # Docker in Docker
   securityContext:
     privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -5,7 +5,7 @@ job_template: &job_template
   path_alias: istio.io/istio
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+  image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
   # Docker in Docker
   securityContext:
     privileged: true


### PR DESCRIPTION
New envoy changes depend on a newer libc. Updating the image to the one
used in master should fix this. As far as I know there are no
incompatible changes in the newer image. I tested the unit tests locally
with this change.

fyi @ozevren 