### PR TITLE
Improve CODEOWNERS rules for Prow oncall.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,7 @@
-*                                   @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
-/prow/config/                       @clarketm @cjwagner @fejta @geeknoid @howardjohn @sdake
+*                                   @clarketm @fejta @Katharine @krzyzacy @michelle192837
+/prow/                              @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
+/prow/config/                       @clarketm @fejta @geeknoid @howardjohn @sdake
+/prow/cluster/                      @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
 /prow/cluster/jobs/                 @howardjohn @sdake @geeknoid @duderino @linsun
 /prow/cluster/jobs/istio/bots/      @howardjohn @sdake @geeknoid @duderino @linsun @ozevren
 /prow/cluster/jobs/istio/community/ @howardjohn @sdake @geeknoid @duderino @linsun


### PR DESCRIPTION
This PR:
1) adds oncall members as owners of `/prow/` and `/prow/cluster/`
1) removes @cjwagner from `*` and `/prow/config/`