### PR TITLE
Filter test used in k8s version tests

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -1234,7 +1234,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.12.9
-        - test.integration.kube
+        - test.integration.kube.presubmit
         image: gcr.io/istio-testing/istio-builder:v20190819-7f5bc561
         name: ""
         resources:
@@ -1281,7 +1281,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.13.7
-        - test.integration.kube
+        - test.integration.kube.presubmit
         image: gcr.io/istio-testing/istio-builder:v20190819-7f5bc561
         name: ""
         resources:
@@ -1328,7 +1328,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.14.3
-        - test.integration.kube
+        - test.integration.kube.presubmit
         image: gcr.io/istio-testing/istio-builder:v20190819-7f5bc561
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
@@ -1234,7 +1234,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.12.9
-        - test.integration.kube
+        - test.integration.kube.presubmit
         image: gcr.io/istio-testing/istio-builder:v20190819-7f5bc561
         name: ""
         resources:
@@ -1281,7 +1281,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.13.7
-        - test.integration.kube
+        - test.integration.kube.presubmit
         image: gcr.io/istio-testing/istio-builder:v20190819-7f5bc561
         name: ""
         resources:
@@ -1328,7 +1328,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.14.3
-        - test.integration.kube
+        - test.integration.kube.presubmit
         image: gcr.io/istio-testing/istio-builder:v20190819-7f5bc561
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -197,7 +197,7 @@ jobs:
     - prow/integ-suite-kind.sh
     - --node-image
     - kindest/node:v1.12.9
-    - test.integration.kube
+    - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
   - name: integ-k8s-113-postsubmit
@@ -206,7 +206,7 @@ jobs:
     - prow/integ-suite-kind.sh
     - --node-image
     - kindest/node:v1.13.7
-    - test.integration.kube
+    - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
   - name: integ-k8s-114-postsubmit
@@ -215,7 +215,7 @@ jobs:
     - prow/integ-suite-kind.sh
     - --node-image
     - kindest/node:v1.14.3
-    - test.integration.kube
+    - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
 


### PR DESCRIPTION
Currently, these run all tests. This has basically a 100% failure rate,
giving us almost no signal. It will be more worthwhile to only run
nonflaky tests so that we can see when real breakages occur