### PR TITLE
Temporarily disable CNI test

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -530,6 +530,7 @@ postsubmits:
     decorate: true
     name: e2e-simpleTests-cni-master
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:
@@ -2356,7 +2357,9 @@ presubmits:
     - ^master$
     decorate: true
     name: e2e-simpleTests-cni-master
+    optional: true
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
@@ -530,6 +530,7 @@ postsubmits:
     decorate: true
     name: e2e-simpleTests-cni-release-1.3
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:
@@ -2356,7 +2357,9 @@ presubmits:
     - ^release-1.3$
     decorate: true
     name: e2e-simpleTests-cni-release-1.3
+    optional: true
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -110,6 +110,7 @@ jobs:
   - name: e2e-simpleTests-cni
     command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple]
     requirements: [kind]
+    modifiers: [optional, hidden]
     env:
     - name: ENABLE_ISTIO_CNI
       value: true


### PR DESCRIPTION
The CNI tests were accidentally broken in a manner that is likely not
fixable in a day (partly because they depend on nightly builds which are
only built once a day - this is another problem..., partly because I
don't know the best fix). We just made this test required, so I don't
think its too harmful to make it optional again and unblock PRs.

Tracking in https://github.com/istio/istio/issues/16508