### PR TITLE
update sinker, plank, deck deployments with "kubeconfig" secret

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -30,12 +30,16 @@ spec:
         - --redirect-http-to=prow.istio.io
         - --spyglass
         - --tide-url=http://tide/
+        - --kubeconfig=/etc/kubeconfig/istio-config
         volumeMounts:
         - name: config
           mountPath: /etc/config
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
+          readOnly: true
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
           readOnly: true
       volumes:
       - name: config
@@ -44,5 +48,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
       nodeSelector:
         prod: prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -21,6 +21,7 @@ spec:
         - --tot-url=http://tot
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --kubeconfig=/etc/kubeconfig/istio-config
         volumeMounts:
         - name: oauth
           mountPath: /etc/github
@@ -30,6 +31,9 @@ spec:
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
+          readOnly: true
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
           readOnly: true
       volumes:
       - name: oauth
@@ -41,5 +45,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
       nodeSelector:
         prod: prow

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,12 +18,16 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/istio-config
         volumeMounts:
         - name: config
           mountPath: /etc/config
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
+          readOnly: true
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
           readOnly: true
       volumes:
       - name: config
@@ -32,5 +36,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
       nodeSelector:
         prod: prow


### PR DESCRIPTION
This is the required configuration for multi-cluster builds/tests, #1670. Currently, this is a **noop**, as the *default* build/test cluster will remain the same (i.e. current service cluster). An announcement will be made when (and how) the auxiliary build can be used - when it is properly vetted.