### PR TITLE
Fix API repo builds.

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.yaml
@@ -10,7 +10,7 @@ presubmits:
       always_run: true
       spec:
         containers:
-          - image: gcr.io/istio-testing/build-tools:2019-08-22T16-27-38
+          - image: gcr.io/istio-testing/build-tools:2019-08-16
             command:
               - make
               - presubmit


### PR DESCRIPTION
The latest build-tools container image are having problems building some protos.
So revert back to a known good version until the container image can be fixed.