### PR TITLE
Migrate istio/test-infra to "build" cluster

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -7,6 +7,7 @@ presubmits:
       - ^release-1.*$
     always_run: true
     decorate: true
+    cluster: build
     path_alias: istio.io/test-infra
     spec:
       containers:
@@ -26,6 +27,7 @@ presubmits:
       - ^master$
       - ^release-1.*$
     decorate: true
+    cluster: build
     run_if_changed: '^prow/(config|plugins|cluster/jobs/.*)\.yaml$'
     spec:
       containers:
@@ -47,6 +49,7 @@ presubmits:
       - ^release-1.*$
     always_run: true
     decorate: true
+    cluster: build
     path_alias: istio.io/test-infra
     spec:
       containers:
@@ -74,6 +77,7 @@ presubmits:
       - ^release-1.*$
     always_run: true
     decorate: true
+    cluster: build
     path_alias: istio.io/test-infra
     spec:
       containers:
@@ -102,6 +106,7 @@ presubmits:
     run_if_changed: "flakeyTest/.*"
     optional: true
     decorate: true
+    cluster: build
     path_alias: istio.io/test-infra
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Attempt to validate *build* cluster is functional, #1670 and can run standard presubmits.