### PR TITLE
Update resource count until mason client supports request ids

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -1,7 +1,8 @@
 resources:
 - type: gke-e2e-test-latest
   state: dirty
-  min-count: 1
+  # Set back to 1 when mason client supports request ids.
+  min-count: 5
   max-count: 5
   needs:
     gcp-project: 1
@@ -39,7 +40,8 @@ resources:
             - https://www.googleapis.com/auth/trace.append
 - type: gke-e2e-test
   state: dirty
-  min-count: 10
+  # Set back to 10 when mason client supports request ids.
+  min-count: 50
   max-count: 50
   needs:
     gcp-project: 1
@@ -72,7 +74,8 @@ resources:
 
 - type: gke-perf-preset
   state: dirty
-  min-count: 1
+  # Set back to 1 when mason client supports request ids.
+  min-count: 2
   max-count: 2
   needs:
     gcp-perf-test: 1


### PR DESCRIPTION
mason client does not yet support request priority therefore max count is not used yet.