### PR TITLE
Add postsubmit test for Kubernetes 1.16

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -1358,6 +1358,53 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-postsubmits-master
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-116-postsubmit-master
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
+        - test.integration.kube.presubmit
+        image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "3"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
 presubmits:
   istio/istio:
   - always_run: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
@@ -1358,6 +1358,53 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-postsubmits-release-1.3
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^release-1.3$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-116-postsubmit-release-1.3
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
+        - test.integration.kube.presubmit
+        image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "3"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
 presubmits:
   istio/istio:
   - always_run: true

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -214,6 +214,17 @@ jobs:
     - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
+  # TODO replace with official kindest/node image. Currently this is a custom built image of the beta
+  # As 1.16 has not been official released
+  - name: integ-k8s-116-postsubmit
+    type: postsubmit
+    command:
+    - prow/integ-suite-kind.sh
+    - --node-image
+    - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
+    - test.integration.kube.presubmit
+    requirements: [kind]
+    timeout: 4h
 
 resources:
   default:


### PR DESCRIPTION
Attempting to be a bit proactive with our testing here and start testing
this before our customers do. Unfortunately kind doesn't publish
prerelease images (or I couldn't find them), but it was pretty trivial
to build one myself for 1.16 beta 1.

I did manually test this on a few tests and things seem to work.

See https://github.com/istio/istio/issues/16632