### PR TITLE
The "build" cluster is now the implicit default.

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -7,7 +7,6 @@ presubmits:
       - ^release-1.*$
     always_run: true
     decorate: true
-    cluster: build
     path_alias: istio.io/test-infra
     spec:
       containers:
@@ -27,7 +26,6 @@ presubmits:
       - ^master$
       - ^release-1.*$
     decorate: true
-    cluster: build
     run_if_changed: '^prow/(config|plugins|cluster/jobs/.*)\.yaml$'
     spec:
       containers:
@@ -49,7 +47,6 @@ presubmits:
       - ^release-1.*$
     always_run: true
     decorate: true
-    cluster: build
     path_alias: istio.io/test-infra
     spec:
       containers:
@@ -77,7 +74,6 @@ presubmits:
       - ^release-1.*$
     always_run: true
     decorate: true
-    cluster: build
     path_alias: istio.io/test-infra
     spec:
       containers:
@@ -106,7 +102,6 @@ presubmits:
     run_if_changed: "flakeyTest/.*"
     optional: true
     decorate: true
-    cluster: build
     path_alias: istio.io/test-infra
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
The "build" cluster is now the implicit default. Removing redundant `cluster` key.

/assign @cjwagner 