### PR TITLE
update static ip for "boskos-metrics"

### DIFF
--- a/boskos/cluster/metrics-service.yaml
+++ b/boskos/cluster/metrics-service.yaml
@@ -12,4 +12,4 @@ spec:
     port: 80
     targetPort: 8080
   type: LoadBalancer
-  loadBalancerIP: 35.233.210.91
+  loadBalancerIP: 34.83.176.210


### PR DESCRIPTION
`Boskos` was migrated to the build cluster in a different region and a new static IP was reassigned.

/assign @sebastienvas @cjwagner @fejta 