### PR TITLE
test-infra oncall should own test-infra and trusted jobs.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,5 @@
 /prow/cluster/jobs/istio/operator/  @howardjohn @sdake @geeknoid @duderino @linsun @ayj @costinm @Laci21 @martonsereg @matyix @ostromart @rcernich @waynz0r
 /prow/cluster/jobs/istio/pkg/       @howardjohn @sdake @geeknoid @duderino @linsun @ozevren
 /prow/cluster/jobs/istio/proxy/     @howardjohn @sdake @geeknoid @duderino @linsun @mandarjog @PiotrSikora
+/prow/cluster/jobs/istio/test-infra @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
 /prow/cluster/jobs/istio/tools/     @howardjohn @sdake @geeknoid @duderino @linsun @mandarjog


### PR DESCRIPTION
Adding `test-infra` oncall members as owners of test-infra and trusted jobs.