### PR TITLE
Remove k8s 1.12 tests

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.yaml
@@ -1226,53 +1226,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-112-postsubmit-master
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --node-image
-        - kindest/node:v1.12.10
-        - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-postsubmits-master
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
     name: integ-k8s-113-postsubmit-master
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.yaml
@@ -1226,53 +1226,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-112-postsubmit-release-1.3
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --node-image
-        - kindest/node:v1.12.10
-        - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-postsubmits-release-1.3
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^release-1.3$
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
     name: integ-k8s-113-postsubmit-release-1.3
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -187,15 +187,6 @@ jobs:
     # The node image must be kept in sync with the kind version we use.
     # See docker/istio/shared/tools/install-golang.sh for the kind image
     # https://github.com/kubernetes-sigs/kind/releases for node corresponding node image
-  - name: integ-k8s-112-postsubmit
-    type: postsubmit
-    command:
-    - prow/integ-suite-kind.sh
-    - --node-image
-    - kindest/node:v1.12.10
-    - test.integration.kube.presubmit
-    requirements: [kind]
-    timeout: 4h
   - name: integ-k8s-113-postsubmit
     type: postsubmit
     command:


### PR DESCRIPTION
Support for this version has both been dropped and broken by
https://github.com/istio/istio/pull/16666. We can re-enable this if we
get back support for 1.12 (note - this is not officially supported
version, so low priority) or disable just the test that is broken.

See https://github.com/istio/istio/issues/16754