### PR TITLE
Remove superfluous prod=prow node selector

### DIFF
--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -41,5 +41,3 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -65,5 +65,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -84,5 +84,3 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -34,5 +34,3 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -56,5 +56,3 @@ spec:
       - name: plugins
         configMap:
           name: plugins
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -49,5 +49,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -40,5 +40,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -52,5 +52,3 @@ spec:
       - name: service-account
         secret:
           secretName: prow-service-account
-      nodeSelector:
-        prod: prow

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -57,5 +57,3 @@ spec:
         - name: tot-volume
           persistentVolumeClaim:
             claimName: tot-storage
-      nodeSelector:
-        prod: prow

--- a/toolbox/metrics/cmd/deployment.yaml
+++ b/toolbox/metrics/cmd/deployment.yaml
@@ -40,5 +40,3 @@ spec:
       - name: service-account
         secret:
           secretName: metrics-service-account
-      nodeSelector:
-        prod: prow


### PR DESCRIPTION
The service cluster now only contains a single node pool and is dedicated to service components, thus `prod=prow` node selector is obsolete.