### PR TITLE
Fix workload identity deployment

### DIFF
--- a/boskos/gcp/gke.go
+++ b/boskos/gcp/gke.go
@@ -149,8 +149,9 @@ func (cc *containerEngine) create(ctx context.Context, project string, config cl
 	// Since Boskos can pick any project in the pool, we need to make sure the identity namespace ties
 	// to the correct project id.
 	if config.EnableWorkloadIdentity {
-		clusterRequest.Cluster.WorkloadIdentityConfig.IdentityNamespace =
-			fmt.Sprintf("%s.svc.id.goog", project)
+		clusterRequest.Cluster.WorkloadIdentityConfig = &container.WorkloadIdentityConfig{
+			IdentityNamespace: fmt.Sprintf("%s.svc.id.goog", project),
+		}
 	}
 
 	op, err := cc.service.Projects.Zones.Clusters.Create(project, config.Zone, clusterRequest).Context(ctx).Do()


### PR DESCRIPTION
Without this, it will segfault because `clusterRequest.Cluster.WorkloadIdentityConfig` is a null pointer. 

This can be tested with a GKE project: https://gist.github.com/pitlv2109/28ecf3d05a6529fe98b154c1e0ced031