### PR TITLE
Add optional jobs for CNI

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -36,33 +36,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: shellcheck_cni_postsubmit
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - bin/check_shell_scripts.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-cni-postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: lint_cni_postsubmit
     path_alias: istio.io/cni
     spec:
@@ -161,6 +134,60 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-cni-postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: buildmodern_cni_postsubmit
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - docker
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-cni-postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: lintmodern_cni_postsubmit
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - lint_modern
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/cni:
   - always_run: true
@@ -177,32 +204,6 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio-cni
-    branches:
-    - ^master$
-    decorate: true
-    name: shellcheck_cni
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - bin/check_shell_scripts.sh
         image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
@@ -318,3 +319,57 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-cni
+    branches:
+    - ^master$
+    decorate: true
+    name: buildmodern_cni
+    optional: true
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - docker
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-cni
+    branches:
+    - ^master$
+    decorate: true
+    name: lintmodern_cni
+    optional: true
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - lint_modern
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
@@ -36,33 +36,6 @@ postsubmits:
     branches:
     - ^release-1.3$
     decorate: true
-    name: shellcheck_cni_release-1.3_postsubmit
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - bin/check_shell_scripts.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-cni-postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^release-1.3$
-    decorate: true
     name: lint_cni_release-1.3_postsubmit
     path_alias: istio.io/cni
     spec:
@@ -161,6 +134,60 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-cni-postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^release-1.3$
+    decorate: true
+    name: buildmodern_cni_release-1.3_postsubmit
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - docker
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-cni-postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^release-1.3$
+    decorate: true
+    name: lintmodern_cni_release-1.3_postsubmit
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - lint_modern
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/cni:
   - always_run: true
@@ -177,32 +204,6 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio-cni
-    branches:
-    - ^release-1.3$
-    decorate: true
-    name: shellcheck_cni_release-1.3
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - bin/check_shell_scripts.sh
         image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
@@ -318,3 +319,57 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-cni
+    branches:
+    - ^release-1.3$
+    decorate: true
+    name: buildmodern_cni_release-1.3
+    optional: true
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - docker
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-cni
+    branches:
+    - ^release-1.3$
+    decorate: true
+    name: lintmodern_cni_release-1.3
+    optional: true
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - lint_modern
+        image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -124,7 +124,6 @@ branch-protection:
           branches: *blocked_branches
           required_status_checks:
             contexts:
-              - "ci/circleci: build"
               - "ci/circleci: install-demo"
               - "ci/circleci: integration-old-kind"
               - "ci/circleci: integration-presubmit-isolated-namespaces-kind"

--- a/prow/config/cmd/generate.go
+++ b/prow/config/cmd/generate.go
@@ -27,9 +27,9 @@ const ConfigOutput = "../../cluster/jobs"
 
 func exit(err error, context string) {
 	if context == "" {
-		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v", err))
+		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v\n", err))
 	} else {
-		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v: %v", context, err))
+		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v: %v\n", context, err))
 	}
 	os.Exit(1)
 }

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -32,9 +32,9 @@ import (
 
 func exit(err error, context string) {
 	if context == "" {
-		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v", err))
+		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v\n", err))
 	} else {
-		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v: %v", context, err))
+		_, _ = fmt.Fprint(os.Stderr, fmt.Sprintf("%v: %v\n", context, err))
 	}
 	os.Exit(1)
 }
@@ -76,17 +76,18 @@ type JobConfig struct {
 }
 
 type Job struct {
-	Name           string            `json:"name"`
-	PostsubmitName string            `json:"postsubmit"`
-	Command        []string          `json:"command"`
-	Env            []v1.EnvVar       `json:"env"`
-	Resources      string            `json:"resources"`
-	Modifiers      []string          `json:"modifiers"`
-	Requirements   []string          `json:"requirements"`
-	Type           string            `json:"type"`
-	Timeout        *prowjob.Duration `json:"timeout"`
-	Repos          []string          `json:"repos"`
-	Image          string            `json:"image"`
+	Name               string            `json:"name"`
+	PostsubmitName     string            `json:"postsubmit"`
+	Command            []string          `json:"command"`
+	Env                []v1.EnvVar       `json:"env"`
+	Resources          string            `json:"resources"`
+	Modifiers          []string          `json:"modifiers"`
+	Requirements       []string          `json:"requirements"`
+	Type               string            `json:"type"`
+	Timeout            *prowjob.Duration `json:"timeout"`
+	Repos              []string          `json:"repos"`
+	Image              string            `json:"image"`
+	SuppressEntrypoint bool              `json:"suppress_entrypoint"`
 }
 
 // Reads the job yaml
@@ -170,7 +171,7 @@ func ConvertJobConfig(jobConfig JobConfig, branch string) config.JobConfig {
 		}
 		// Commands are run with the entrypoint wrapper which will start up prereqs
 
-		if !jobConfig.SuppressEntrypoint {
+		if !job.SuppressEntrypoint && !jobConfig.SuppressEntrypoint {
 			job.Command = append([]string{"entrypoint"}, job.Command...)
 		}
 

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -7,8 +7,6 @@ branches:
 jobs:
   - name: build
     command: [make, docker]
-  - name: shellcheck
-    command: [bin/check_shell_scripts.sh]
   - name: lint
     command: [make, lint]
   - name: install
@@ -17,3 +15,15 @@ jobs:
     command: [make, prow-e2e]
     requirements: [kind]
     repos: [istio/istio]
+
+  - name: buildmodern
+    command: [make, docker]
+    image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+    suppress_entrypoint: true
+    modifiers: [optional]
+
+  - name: lintmodern
+    command: [make, lint_modern]
+    image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
+    suppress_entrypoint: true
+    modifiers: [optional]

--- a/prow/config/jobs/installer.yaml
+++ b/prow/config/jobs/installer.yaml
@@ -8,4 +8,3 @@ branches:
 jobs:
   - name: build
     command: [make, run-build]
-    modifier: optional


### PR DESCRIPTION
- Add a couple optional CNI jobs using the build-tools container. If
these work, I'll make those non-optional and retire the old equivalent jobs.

- Make the CircleCI-bssed instsller build job optional, since the prow-based
job works.