### PR TITLE
Make lintmodern_cni required, and retire classic lint_cni.

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -36,34 +36,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: lint_cni_postsubmit
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - lint
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-cni-postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: install_cni_postsubmit
     path_alias: istio.io/cni
     spec:
@@ -223,33 +195,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: lint_cni
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - lint
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio-cni
-    branches:
-    - ^master$
-    decorate: true
     name: install_cni
     path_alias: istio.io/cni
     spec:
@@ -353,7 +298,6 @@ presubmits:
     - ^master$
     decorate: true
     name: lintmodern_cni
-    optional: true
     path_alias: istio.io/cni
     spec:
       containers:

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
@@ -36,34 +36,6 @@ postsubmits:
     branches:
     - ^release-1.3$
     decorate: true
-    name: lint_cni_release-1.3_postsubmit
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - lint
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-cni-postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^release-1.3$
-    decorate: true
     name: install_cni_release-1.3_postsubmit
     path_alias: istio.io/cni
     spec:
@@ -223,33 +195,6 @@ presubmits:
     branches:
     - ^release-1.3$
     decorate: true
-    name: lint_cni_release-1.3
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - lint
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio-cni
-    branches:
-    - ^release-1.3$
-    decorate: true
     name: install_cni_release-1.3
     path_alias: istio.io/cni
     spec:
@@ -353,7 +298,6 @@ presubmits:
     - ^release-1.3$
     decorate: true
     name: lintmodern_cni_release-1.3
-    optional: true
     path_alias: istio.io/cni
     spec:
       containers:

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -7,8 +7,6 @@ branches:
 jobs:
   - name: build
     command: [make, docker]
-  - name: lint
-    command: [make, lint]
   - name: install
     command: [make, docker, test]
   - name: e2e
@@ -26,4 +24,3 @@ jobs:
     command: [make, lint_modern]
     image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
     suppress_entrypoint: true
-    modifiers: [optional]


### PR DESCRIPTION
I'll eventually rename the job to drop "modern".