### PR TITLE
Postsubmit for deploying boskos and updating boskos config

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -29,6 +29,58 @@ postsubmits:
         secret:
           secretName: prow-deployer-service-account
 
+  - name: post-test-infra-update-boskos-config
+    cluster: test-infra-trusted
+    run_if_changed: '^boskos/resources.yaml$'
+    decorate: true
+    branches:
+      - master
+    annotations:
+      testgrid-create-test-group: "false"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+          command:
+            - bash
+          args:
+            - -c
+            - |
+              gcloud auth activate-service-account --key-file=/creds/service-account.json && \
+              make -C boskos boskos-config
+          volumeMounts:
+            - name: creds
+              mountPath: /creds
+      volumes:
+        - name: creds
+          secret:
+            secretName: prow-deployer-service-account
+
+  - name: post-test-infra-deploy-boskos
+    cluster: test-infra-trusted
+    run_if_changed: '^boskos/cluster/.*\.yaml$'
+    decorate: true
+    branches:
+      - master
+    annotations:
+      testgrid-create-test-group: "false"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+          command:
+            - bash
+          args:
+            - -c
+            - |
+              gcloud auth activate-service-account --key-file=/creds/service-account.json && \
+              make -C boskos deploy
+          volumeMounts:
+            - name: creds
+              mountPath: /creds
+      volumes:
+        - name: creds
+          secret:
+            secretName: prow-deployer-service-account
+
 
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -16,9 +16,6 @@ config_updater:
       name: config
     prow/plugins.yaml:
       name: plugins
-    boskos/resources.yaml:
-      name: boskos-config
-      namespace: boskos
     prow/cluster/jobs/**/*.yaml:
       name: job-config
 


### PR DESCRIPTION
Postsubmit(s) to deploy boskos and update boskos config.

/hold
> ~~`prow-deployer-service-account` needs to be updated **before** this can be merged.~~

**Update:**
`prow-deployer-service-account` updated with `container.admin` permissions.