### PR TITLE
Revert "Update to golang 1.13 (#1788)"

### DIFF
--- a/docker/istio/shared/tools/install-golang.sh
+++ b/docker/istio/shared/tools/install-golang.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION='1.13'
+GO_VERSION='1.12.9'
 GO_BASE_URL="https://storage.googleapis.com/golang"
 GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 GO_URL="${GO_BASE_URL}/${GO_ARCHIVE}"

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.master.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+  image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "3000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+  image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
   # Docker in Docker
   securityContext:
     privileged: true
@@ -36,7 +36,7 @@ istio_container: &istio_container
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+  image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
   securityContext:
     privileged: true
   resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         - localTestEnv
         - test
         - binaries-test
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -52,7 +52,7 @@ postsubmits:
         - T=-v
         - localTestEnv
         - racetest
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -80,7 +80,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -139,7 +139,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -228,7 +228,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/e2e-dashboard.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -257,7 +257,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -301,7 +301,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -346,7 +346,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -393,7 +393,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -442,7 +442,7 @@ postsubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -492,7 +492,7 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -543,7 +543,7 @@ postsubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -591,7 +591,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -636,7 +636,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -664,7 +664,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -692,7 +692,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -720,7 +720,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -748,7 +748,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.mixer.local
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -776,7 +776,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -804,7 +804,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -832,7 +832,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -859,7 +859,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-integ-race-native-tests.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -887,7 +887,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -930,7 +930,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -973,7 +973,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1016,7 +1016,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1059,7 +1059,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1102,7 +1102,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1145,7 +1145,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1188,7 +1188,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1235,7 +1235,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.13.10
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1282,7 +1282,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1329,7 +1329,7 @@ postsubmits:
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1378,7 +1378,7 @@ presubmits:
         - localTestEnv
         - test
         - binaries-test
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1405,7 +1405,7 @@ presubmits:
         - entrypoint
         - make
         - lint
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1435,7 +1435,7 @@ presubmits:
         - T=-v
         - localTestEnv
         - racetest
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1462,7 +1462,7 @@ presubmits:
         - entrypoint
         - make
         - shellcheck
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1489,7 +1489,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1518,7 +1518,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1545,7 +1545,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1572,7 +1572,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1599,7 +1599,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.mixer.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1626,7 +1626,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1653,7 +1653,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1680,7 +1680,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1722,7 +1722,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1764,7 +1764,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1807,7 +1807,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1849,7 +1849,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1891,7 +1891,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1933,7 +1933,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -1976,7 +1976,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2019,7 +2019,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2062,7 +2062,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2106,7 +2106,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/e2e-dashboard.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2134,7 +2134,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2177,7 +2177,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2223,7 +2223,7 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2271,7 +2271,7 @@ presubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2320,7 +2320,7 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2371,7 +2371,7 @@ presubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2416,7 +2416,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:
@@ -2443,7 +2443,7 @@ presubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: istio
-image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
 branches:
   - master
 


### PR DESCRIPTION
This reverts commit f52db8161d2374403089c601df6bf7ee414c6304.

This broke some tests

This could have been avoided with https://github.com/istio/test-infra/issues/1734