### PR TITLE
Delete integration race test

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -852,33 +852,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-race-native-tests_istio_postsubmit
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/istio-integ-race-native-tests.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 24Gi
-          requests:
-            cpu: "3"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio-istio-postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: integ-framework-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -147,9 +147,6 @@ jobs:
   - name: integ-conformance-local-tests
     type: postsubmit
     command: [prow/integ-suite-local.sh, test.integration.conformance.local]
-  - name: integ-race-native-tests
-    type: postsubmit
-    command: [prow/istio-integ-race-native-tests.sh]
 
   - name: integ-framework-k8s-tests
     type: postsubmit


### PR DESCRIPTION
Note: this is not dropping test coverage at all. This target is a
duplicate now since we already run with -race on the normal tests.