### PR TITLE
Deploy postsubmit job cleanup / simplification

### DIFF
--- a/boskos/Makefile
+++ b/boskos/Makefile
@@ -1,14 +1,11 @@
+include ../prow/Makefile.gcloud.mk
+
 PROJECT ?= istio-prow-build
 ZONE ?= us-west1-a
 CLUSTER ?= prow
 NAMESPACE ?= boskos
 HUB ?= gcr.io/istio-testing
 TAG ?= $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
-
-activate-serviceaccount:
-ifdef GOOGLE_APPLICATION_CREDENTIALS
-	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
-endif
 
 mason-image:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cmd/mason/mason istio.io/test-infra/boskos/cmd/mason/
@@ -38,12 +35,9 @@ endif
 		-n $(NAMESPACE) --dry-run -o yaml \
 		| kubectl apply -f -
 
-get-cluster-credentials: activate-serviceaccount
-	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
-
 namespace: get-cluster-credentials
 	kubectl create namespace $(NAMESPACE)
 
 init: namespace create-serviceaccount
 
-.PHONY: mason-image mason-client deploy boskos-config activate-serviceaccount create-serviceaccount get-cluster-credentials namespace init
+.PHONY: mason-image mason-client deploy boskos-config create-serviceaccount namespace init

--- a/boskos/Makefile
+++ b/boskos/Makefile
@@ -5,6 +5,11 @@ NAMESPACE ?= boskos
 HUB ?= gcr.io/istio-testing
 TAG ?= $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
+activate-serviceaccount:
+ifdef GOOGLE_APPLICATION_CREDENTIALS
+	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
+endif
+
 mason-image:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cmd/mason/mason istio.io/test-infra/boskos/cmd/mason/
 	docker build --no-cache -t "$(HUB)/mason:$(TAG)" cmd/mason
@@ -33,7 +38,7 @@ endif
 		-n $(NAMESPACE) --dry-run -o yaml \
 		| kubectl apply -f -
 
-get-cluster-credentials:
+get-cluster-credentials: activate-serviceaccount
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 
 namespace: get-cluster-credentials
@@ -41,4 +46,4 @@ namespace: get-cluster-credentials
 
 init: namespace create-serviceaccount
 
-.PHONY: mason-image mason-client deploy boskos-config create-serviceaccount get-cluster-credentials namespace init
+.PHONY: mason-image mason-client deploy boskos-config activate-serviceaccount create-serviceaccount get-cluster-credentials namespace init

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,10 +21,15 @@ ifndef save
 	$(eval KUBECONFIG=$(shell mktemp))
 endif
 
-get-cluster-credentials: save-kubeconfig
+activate-serviceaccount:
+ifdef GOOGLE_APPLICATION_CREDENTIALS
+	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
+endif
+
+get-cluster-credentials: save-kubeconfig activate-serviceaccount
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 
-get-build-cluster-credentials: save-kubeconfig
+get-build-cluster-credentials: save-kubeconfig activate-serviceaccount
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT_BUILD)" --zone="$(ZONE)"
 
 update-config-dry-run: get-cluster-credentials
@@ -46,4 +51,4 @@ deploy: get-cluster-credentials
 deploy-build: get-build-cluster-credentials
 	kubectl apply -f ./cluster/build/
 
-.PHONY: deploy deploy-build update-config update-config-dry-run get-cluster-credentials get-build-cluster-credentials save-kubeconfig
+.PHONY: deploy deploy-build update-config update-config-dry-run get-cluster-credentials get-build-cluster-credentials save-kubeconfig activate-serviceaccount

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -3,34 +3,13 @@
 # Based off a similar file used to manage the k8s cluster
 # https://github.com/kubernetes/test-infra/blob/master/prow/Makefile
 
+include Makefile.gcloud.mk
+
 # GKE variables.
 PROJECT ?= istio-testing
 PROJECT_BUILD ?= istio-prow-build
 ZONE    ?= us-west1-a
 CLUSTER ?= prow
-
-export KUBECONFIG
-
-# https://github.com/istio/test-infra/issues/1636
-# This prevents the Kube current-context in the execution environment from being
-# overwritten unless the intention is made explicit w/ the `save` parameter.
-# e.g.
-#		make get-cluster-credentials save=true
-save-kubeconfig:
-ifndef save
-	$(eval KUBECONFIG=$(shell mktemp))
-endif
-
-activate-serviceaccount:
-ifdef GOOGLE_APPLICATION_CREDENTIALS
-	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
-endif
-
-get-cluster-credentials: save-kubeconfig activate-serviceaccount
-	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
-
-get-build-cluster-credentials: save-kubeconfig activate-serviceaccount
-	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT_BUILD)" --zone="$(ZONE)"
 
 update-config-dry-run: get-cluster-credentials
 	./recreate_prow_configmaps.py \
@@ -51,4 +30,4 @@ deploy: get-cluster-credentials
 deploy-build: get-build-cluster-credentials
 	kubectl apply -f ./cluster/build/
 
-.PHONY: deploy deploy-build update-config update-config-dry-run get-cluster-credentials get-build-cluster-credentials save-kubeconfig activate-serviceaccount
+.PHONY: deploy deploy-build update-config update-config-dry-run

--- a/prow/Makefile.gcloud.mk
+++ b/prow/Makefile.gcloud.mk
@@ -1,0 +1,41 @@
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBECONFIG
+
+# https://github.com/istio/test-infra/issues/1636
+# This prevents the Kube current-context in the execution environment from being
+# overwritten unless the intention is made explicit w/ the `save` parameter.
+# e.g.
+#		make get-cluster-credentials save=true
+
+.PHONY: save-kubeconfig
+save-kubeconfig:
+ifndef save
+	$(eval KUBECONFIG=$(shell mktemp))
+endif
+
+.PHONY: activate-serviceaccount
+activate-serviceaccount:
+ifdef GOOGLE_APPLICATION_CREDENTIALS
+	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
+endif
+
+.PHONY: get-cluster-credentials
+get-cluster-credentials: save-kubeconfig activate-serviceaccount
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+.PHONY: get-build-cluster-credentials
+get-build-cluster-credentials: save-kubeconfig activate-serviceaccount
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT_BUILD)" --zone="$(ZONE)"

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -7,6 +7,8 @@ postsubmits:
     decorate: true
     branches:
     - master
+    labels:
+      preset-prow-deployer-service-account: "true"
     annotations:
       testgrid-create-test-group: "false"
     spec:
@@ -16,71 +18,45 @@ postsubmits:
         - bash
         args:
         - -c
-        - |
-          gcloud auth activate-service-account --key-file=/creds/service-account.json && \
-          cd prow && \
-          make deploy && \
-          make deploy-build
-        volumeMounts:
-        - name: creds
-          mountPath: /creds
-      volumes:
-      - name: creds
-        secret:
-          secretName: prow-deployer-service-account
+        - make -C prow deploy deploy-build
 
   - name: post-test-infra-update-boskos-config
     cluster: test-infra-trusted
     run_if_changed: '^boskos/resources.yaml$'
     decorate: true
     branches:
-      - master
+    - master
+    labels:
+      preset-prow-deployer-service-account: "true"
     annotations:
       testgrid-create-test-group: "false"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
-          command:
-            - bash
-          args:
-            - -c
-            - |
-              gcloud auth activate-service-account --key-file=/creds/service-account.json && \
-              make -C boskos boskos-config
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
-        - name: creds
-          secret:
-            secretName: prow-deployer-service-account
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+        command:
+        - bash
+        args:
+        - -c
+        - make -C boskos boskos-config
 
   - name: post-test-infra-deploy-boskos
     cluster: test-infra-trusted
     run_if_changed: '^boskos/cluster/.*\.yaml$'
     decorate: true
     branches:
-      - master
+    - master
+    labels:
+      preset-prow-deployer-service-account: "true"
     annotations:
       testgrid-create-test-group: "false"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
-          command:
-            - bash
-          args:
-            - -c
-            - |
-              gcloud auth activate-service-account --key-file=/creds/service-account.json && \
-              make -C boskos deploy
-          volumeMounts:
-            - name: creds
-              mountPath: /creds
-      volumes:
-        - name: creds
-          secret:
-            secretName: prow-deployer-service-account
-
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+        command:
+        - bash
+        args:
+        - -c
+        - make -C boskos deploy
 
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -15,10 +15,12 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
         command:
-        - bash
+        - make
         args:
-        - -c
-        - make -C prow deploy deploy-build
+        - -C
+        - prow
+        - deploy
+        - deploy-build
 
   - name: post-test-infra-update-boskos-config
     cluster: test-infra-trusted
@@ -34,10 +36,11 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
         command:
-        - bash
+        - make
         args:
-        - -c
-        - make -C boskos boskos-config
+        - -C
+        - boskos
+        - boskos-config
 
   - name: post-test-infra-deploy-boskos
     cluster: test-infra-trusted
@@ -53,10 +56,11 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
         command:
-        - bash
+        - make
         args:
-        - -c
-        - make -C boskos deploy
+        - -C
+        - boskos
+        - deploy
 
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -280,6 +280,19 @@ tide:
 
 presets:
 - labels:
+    preset-prow-deployer-service-account: "true"
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /creds/service-account.json
+  volumeMounts:
+  - name: creds
+    mountPath: /creds
+    readOnly: true
+  volumes:
+  - name: creds
+    secret:
+      secretName: prow-deployer-service-account
+- labels:
     preset-service-account: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Cleanup and simplification of *deploy* `postsubmit` jobs:
1. Add `preset-prow-deployer-service-account` preset since its contents are used in several places now.
2. Run `activate-service-account` in Makefile.
3. Extract common gcloud deployment operations into a separate Makefile (`Makefile.gcloud.mk`)

/assign @fejta @cjwagner 
