### PR TITLE
Re-add the k8s 1.12 test

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1198,6 +1198,53 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    name: integ-k8s-112-postsubmit_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - kindest/node:v1.12.10
+        - test.integration.kube.presubmit
+        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "3"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio-istio-postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     name: integ-k8s-113_istio_postsubmit
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -184,6 +184,15 @@ jobs:
     # The node image must be kept in sync with the kind version we use.
     # See docker/istio/shared/tools/install-golang.sh for the kind image
     # https://github.com/kubernetes-sigs/kind/releases for node corresponding node image
+  - name: integ-k8s-112-postsubmit
+    type: postsubmit
+    command:
+    - prow/integ-suite-kind.sh
+    - --node-image
+    - kindest/node:v1.12.10
+    - test.integration.kube.presubmit
+    requirements: [kind]
+    timeout: 4h
   - name: integ-k8s-113
     type: postsubmit
     command:


### PR DESCRIPTION
With https://github.com/istio/istio/pull/16912 merged we can turn this back on
