### PR TITLE
use modern job_url_prefix_config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,7 +1,8 @@
 ---
 plank:
   job_url_template: 'https://prow.istio.io/view/gcs/istio-prow{{if eq .Spec.Type "presubmit"}}/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/pr-logs/pull/batch{{else}}/logs{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
-  job_url_prefix: https://prow.istio.io/view/gcs/
+  job_url_prefix_config:
+    '*': https://prow.istio.io/view/gcs/
   pod_pending_timeout: 60m
   default_decoration_config:
     # TODO(fejta): use 2h, 15s instead


### PR DESCRIPTION
`job_url_prefix` doesn't do anything any more.

To my mild surprise, this being removed doesn't seem to have broken anything obvious here, but updating this in the name of sanity and in case I missed anything.