### PR TITLE
Re-enable CNI tests in master and release-1.3

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -529,7 +529,6 @@ postsubmits:
     decorate: true
     name: e2e-simpleTests-cni_istio_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -2375,9 +2374,7 @@ presubmits:
     - ^master$
     decorate: true
     name: e2e-simpleTests-cni_istio
-    optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
@@ -529,7 +529,6 @@ postsubmits:
     decorate: true
     name: e2e-simpleTests-cni_istio_release-1.3_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -2355,9 +2354,7 @@ presubmits:
     - ^release-1.3$
     decorate: true
     name: e2e-simpleTests-cni_istio_release-1.3
-    optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio.1.3.yaml
+++ b/prow/config/jobs/istio.1.3.yaml
@@ -110,7 +110,6 @@ jobs:
   - name: e2e-simpleTests-cni
     command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple]
     requirements: [kind]
-    modifiers: [optional, hidden]
     env:
       - name: ENABLE_ISTIO_CNI
         value: true

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -110,7 +110,6 @@ jobs:
   - name: e2e-simpleTests-cni
     command: [prow/e2e-kind-suite.sh, --auth_enable, --single_test, e2e_simple]
     requirements: [kind]
-    modifiers: [optional, hidden]
     env:
     - name: ENABLE_ISTIO_CNI
       value: true


### PR DESCRIPTION
Re-enable the CNI tests which were failing due to daily build Helm charts having invalid versions.
This must be merged only after https://github.com/istio/istio/pull/17063 (`master`) and https://github.com/istio/istio/pull/17067 (`release-1.3`) which fix the chart versions. 
Cf. #1709.
