### PR TITLE
Remove @krzyzacy from owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-*                                    @clarketm @fejta @Katharine @krzyzacy @michelle192837
+*                                    @clarketm @fejta @Katharine @michelle192837
 /docker/                             @istio/wg-test-and-release-maintainers
-/prow/                               @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
+/prow/                               @clarketm @cjwagner @fejta @Katharine @michelle192837
 /prow/config/                        @istio/wg-test-and-release-maintainers
-/prow/config/jobs/test-infra.yaml    @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
-/prow/cluster/                       @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
+/prow/config/jobs/test-infra.yaml    @clarketm @cjwagner @fejta @Katharine @michelle192837
+/prow/cluster/                       @clarketm @cjwagner @fejta @Katharine @michelle192837
 /prow/cluster/jobs/                  @istio/wg-test-and-release-maintainers
-/prow/cluster/jobs/istio/test-infra/ @clarketm @cjwagner @fejta @Katharine @krzyzacy @michelle192837
+/prow/cluster/jobs/istio/test-infra/ @clarketm @cjwagner @fejta @Katharine @michelle192837


### PR DESCRIPTION
Users not in the org but in the codeowners can cause some problems. I asked @krzyzacy if they would join the org and they asked to just be removed instead