### PR TITLE
Remove superfluous jobs for istio/api release-1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/hashicorp/go-multierror v0.0.0-20171204182908-b7773ae21874
 	github.com/kr/pretty v0.1.0
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v0.9.4
 	github.com/satori/go.uuid v1.2.0 // indirect


### PR DESCRIPTION
- I added these this morning, but it turns out they're redundant. There
are already jobs for release-1.3