### PR TITLE
Remove required status check for e2e-dind-IPV6

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -118,10 +118,6 @@ branch-protection:
             - deploy/netlify
         cni:
           branches: *blocked_branches
-          required_status_checks:
-            contexts:
-              # TODO(howardjohn): migrate fully to prow
-              - "ci/circleci: e2e-dind-ipv6"
         installer:
           branches: *blocked_branches
           required_status_checks:


### PR DESCRIPTION
CNI repository is blocked because of this job. Not sure when
this job had a regression, however, I submitted 3 separate PRs
to master (that changed the README.md) and they all failed.

See: https://github.com/istio/cni/pull/182#issuecomment-535043839