### PR TITLE
Use the DIND image recently built

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -16,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -45,7 +45,7 @@ postsubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -78,7 +78,7 @@ postsubmits:
         - entrypoint
         - make
         - prow-e2e
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -118,9 +118,10 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -145,9 +146,10 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - make
         - lint_modern
-        image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -177,7 +179,7 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -207,7 +209,7 @@ presubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -241,7 +243,7 @@ presubmits:
         - entrypoint
         - make
         - prow-e2e
-        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -277,15 +279,15 @@ presubmits:
     - ^master$
     decorate: true
     name: buildmodern_cni
-    optional: true
     path_alias: istio.io/cni
     rerun_command: /test buildmodern
     spec:
       containers:
       - command:
+        - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:
@@ -311,9 +313,10 @@ presubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - make
         - lint_modern
-        image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
+        image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -1,14 +1,16 @@
 org: istio
 repo: cni
-image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
+image: gcr.io/istio-testing/build-tools:2019-09-26T01-36-18
 branches:
   - master
 
 jobs:
   - name: build
     command: [make, docker]
+
   - name: install
     command: [make, docker, test]
+
   - name: e2e
     command: [make, prow-e2e]
     requirements: [kind]
@@ -16,11 +18,6 @@ jobs:
 
   - name: buildmodern
     command: [make, docker]
-    image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
-    suppress_entrypoint: true
-    modifiers: [optional]
 
   - name: lintmodern
     command: [make, lint_modern]
-    image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
-    suppress_entrypoint: true


### PR DESCRIPTION
DIND was added to the build-tools image. This should work well,
although it can be easily reverted if the CNI repository is negatively
impacted.

The DIND PR: https://github.com/istio/tools/pull/373