### PR TITLE
Mount /var/lib/docker as emptyDir for kind

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -95,6 +95,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -106,6 +108,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_cni_postsubmit
@@ -260,6 +264,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -271,6 +277,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e(?: .*?)?$'
   - always_run: true
     annotations:

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
@@ -95,6 +95,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -106,6 +108,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_cni_postsubmit
@@ -258,6 +262,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -269,6 +275,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e(?: .*?)?$'
   - always_run: true
     annotations:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -156,6 +156,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -167,6 +169,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -200,6 +204,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -211,6 +217,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -274,6 +282,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -285,6 +295,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -318,6 +330,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -329,6 +343,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -363,6 +379,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -374,6 +392,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -410,6 +430,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -421,6 +443,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -459,6 +483,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -470,6 +496,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -509,6 +537,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -520,6 +550,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -559,6 +591,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -570,6 +604,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -607,6 +643,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -618,6 +656,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -876,6 +916,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -887,6 +929,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -919,6 +963,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -930,6 +976,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -962,6 +1010,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -973,6 +1023,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1005,6 +1057,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1016,6 +1070,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1048,6 +1104,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1059,6 +1117,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1091,6 +1151,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1102,6 +1164,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1134,6 +1198,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1145,6 +1211,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1177,6 +1245,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1188,6 +1258,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1224,6 +1296,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1235,6 +1309,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1271,6 +1347,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1282,6 +1360,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1318,6 +1398,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1329,6 +1411,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1365,6 +1449,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1376,6 +1462,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1708,6 +1796,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1719,6 +1809,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-framework-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1752,6 +1844,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1763,6 +1857,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-istioctl-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1796,6 +1892,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1807,6 +1905,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-galley-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1841,6 +1941,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1852,6 +1954,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-mixer-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1885,6 +1989,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1896,6 +2002,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-pilot-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1929,6 +2037,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1940,6 +2050,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-security-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1973,6 +2085,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1984,6 +2098,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-telemetry-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2018,6 +2134,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2029,6 +2147,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-new-install-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2063,6 +2183,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2074,6 +2196,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-mixer-no_auth(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2108,6 +2232,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2119,6 +2245,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?pilot-e2e-envoyv2-v1alpha3(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2184,6 +2312,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2195,6 +2325,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-bookInfoTests-envoyv2-v1alpha3(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2229,6 +2361,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2240,6 +2374,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-bookInfoTests-trustdomain(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2277,6 +2413,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2288,6 +2426,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2327,6 +2467,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2338,6 +2480,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTests-distroless(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2378,6 +2522,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2389,6 +2535,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTestsMinProfile(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2429,6 +2577,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2440,6 +2590,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTests-cni(?: .*?)?$'
   - always_run: true
     annotations:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
@@ -156,6 +156,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -167,6 +169,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -200,6 +204,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -211,6 +217,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -274,6 +282,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -285,6 +295,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -318,6 +330,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -329,6 +343,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -363,6 +379,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -374,6 +392,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -410,6 +430,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -421,6 +443,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -459,6 +483,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -470,6 +496,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -509,6 +537,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -520,6 +550,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -559,6 +591,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -570,6 +604,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -607,6 +643,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -618,6 +656,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -903,6 +943,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -914,6 +956,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -946,6 +990,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -957,6 +1003,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -989,6 +1037,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1000,6 +1050,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1032,6 +1084,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1043,6 +1097,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1075,6 +1131,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1086,6 +1144,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1118,6 +1178,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1129,6 +1191,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1161,6 +1225,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1172,6 +1238,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1204,6 +1272,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1215,6 +1285,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1251,6 +1323,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1262,6 +1336,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1298,6 +1374,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1309,6 +1387,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.3_istio_postsubmit
@@ -1345,6 +1425,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1356,6 +1438,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio/istio:
   - always_run: true
@@ -1719,6 +1803,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1730,6 +1816,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-framework-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1763,6 +1851,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1774,6 +1864,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-istioctl-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1807,6 +1899,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1818,6 +1912,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-galley-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1852,6 +1948,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1863,6 +1961,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-mixer-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1896,6 +1996,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1907,6 +2009,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-pilot-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1940,6 +2044,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1951,6 +2057,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-security-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -1984,6 +2092,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1995,6 +2105,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-telemetry-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2029,6 +2141,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2040,6 +2154,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?integ-new-install-k8s-tests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2074,6 +2190,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2085,6 +2203,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-mixer-no_auth(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2119,6 +2239,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2130,6 +2252,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?pilot-e2e-envoyv2-v1alpha3(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2195,6 +2319,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2206,6 +2332,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-bookInfoTests-envoyv2-v1alpha3(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2240,6 +2368,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2251,6 +2381,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-bookInfoTests-trustdomain(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2288,6 +2420,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2299,6 +2433,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTests(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2338,6 +2474,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2349,6 +2487,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTests-distroless(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2389,6 +2529,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2400,6 +2542,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTestsMinProfile(?: .*?)?$'
   - always_run: true
     annotations:
@@ -2440,6 +2584,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2451,6 +2597,8 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?e2e-simpleTests-cni(?: .*?)?$'
   - always_run: true
     annotations:

--- a/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
@@ -141,6 +141,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -152,6 +154,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio/operator:
   - always_run: true
@@ -299,6 +303,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -310,4 +316,6 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?manifest-apply(?: .*?)?$'

--- a/prow/cluster/jobs/istio/operator/istio.operator.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.release-1.3.gen.yaml
@@ -141,6 +141,8 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -152,6 +154,8 @@ postsubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio/operator:
   - always_run: true
@@ -299,6 +303,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -310,4 +316,6 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?manifest-apply(?: .*?)?$'

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -469,6 +469,12 @@ func applyRequirements(job *config.JobBase, requirements []string) {
 						},
 					},
 				},
+				v1.Volume{
+					Name: "docker-root",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
 			)
 			job.Spec.Containers[0].VolumeMounts = append(job.Spec.Containers[0].VolumeMounts,
 				v1.VolumeMount{
@@ -479,6 +485,10 @@ func applyRequirements(job *config.JobBase, requirements []string) {
 				v1.VolumeMount{
 					MountPath: "/sys/fs/cgroup",
 					Name:      "cgroup",
+				},
+				v1.VolumeMount{
+					MountPath: "/var/lib/docker",
+					Name:      "docker-root",
 				},
 			)
 		}

--- a/prow/config/testdata/simple.gen.yaml
+++ b/prow/config/testdata/simple.gen.yaml
@@ -91,6 +91,8 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
@@ -102,4 +104,6 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - emptyDir: {}
+        name: docker-root
     trigger: '(?m)^/test (?:.*? )?presubmit-kind(?: .*?)?$'


### PR DESCRIPTION
This is recommended best practice from KinD and it makes the new build tools work -- likely because the folder ` /var/lib/docker` does not exist in the build tools image. Another fix could be to add ` /var/lib/docker ` to build tools, but since this is best practice we can just do this.