### PR TITLE
install python 3.7 for benchmark testing

### DIFF
--- a/docker/istio/shared/tools/install-python.sh
+++ b/docker/istio/shared/tools/install-python.sh
@@ -16,6 +16,7 @@
 
 set -eux
 
+apt-get install python3.7
 apt-get -qqy install python3-pip
 pip3 install --upgrade pip
 pip install --user yamllint


### PR DESCRIPTION
istio benchmark testing required python 3.7