### PR TITLE
Make gen check optional

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1500,6 +1500,7 @@ postsubmits:
     decorate: true
     name: gencheck_istio_postsubmit
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:
@@ -2658,7 +2659,9 @@ presubmits:
     - ^master$
     decorate: true
     name: gencheck_istio
+    optional: true
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -229,6 +229,7 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    modifiers: [optional, hidden]
     image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
     suppress_entrypoint: true
 


### PR DESCRIPTION
Tests are expected to be left optional for ~1 week before being marked as required. This test is not stable so should not be required: https://prow.istio.io/job-history/istio-prow/pr-logs/directory/gencheck_istio