### PR TITLE
Use the old builder image for publish test

### DIFF
--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -72,7 +72,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
+        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
         name: ""
         resources:
           limits:
@@ -156,7 +156,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
+        image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -16,3 +16,4 @@ jobs:
     command: [entrypoint, test/publish.sh]
     modifiers: [optional]
     requirements: [gcp]
+    image: gcr.io/istio-testing/istio-builder:v20190909-ca3fb8ed


### PR DESCRIPTION
Using this for two reasons:

* This is meant to test istio/istio, which is using the old image
* This does not yet work on the new image, need some extra dependencies