### PR TITLE
Support client certificate in kubeconfig

### DIFF
--- a/boskos/gcp/gke.go
+++ b/boskos/gcp/gke.go
@@ -37,14 +37,15 @@ const (
 )
 
 type clusterConfig struct {
-	Scopes                 []string                 `json:"scopes,omitempty"`
-	MachineType            string                   `json:"machinetype,omitempty"`
-	Version                string                   `json:"version,omitempty"`
-	Zone                   string                   `json:"zone,omitempty"`
-	NumNodes               int64                    `json:"numnodes,omitempty"`
-	NetworkPolicy          *container.NetworkPolicy `json:"networkpolicy,omitempty"`
-	EnableKubernetesAlpha  bool                     `json:"enablekubernetesalpha"`
-	EnableWorkloadIdentity bool                     `json:"enableworkloadidentity"`
+	Scopes                  []string                 `json:"scopes,omitempty"`
+	MachineType             string                   `json:"machinetype,omitempty"`
+	Version                 string                   `json:"version,omitempty"`
+	Zone                    string                   `json:"zone,omitempty"`
+	NumNodes                int64                    `json:"numnodes,omitempty"`
+	NetworkPolicy           *container.NetworkPolicy `json:"networkpolicy,omitempty"`
+	EnableKubernetesAlpha   bool                     `json:"enablekubernetesalpha"`
+	EnableWorkloadIdentity  bool                     `json:"enableworkloadidentity"`
+	EnableClientCertificate bool                     `json:"enableclientcertificate"`
 }
 
 type containerEngine struct {
@@ -152,6 +153,9 @@ func (cc *containerEngine) create(ctx context.Context, project string, config cl
 		clusterRequest.Cluster.WorkloadIdentityConfig = &container.WorkloadIdentityConfig{
 			IdentityNamespace: fmt.Sprintf("%s.svc.id.goog", project),
 		}
+	}
+	if config.EnableClientCertificate {
+		clusterRequest.Cluster.MasterAuth.ClientCertificateConfig.IssueClientCertificate = true
 	}
 
 	op, err := cc.service.Projects.Zones.Clusters.Create(project, config.Zone, clusterRequest).Context(ctx).Do()

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190816222004-e3a6b8045b0b
 	k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101
+	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/test-infra v0.0.0-20190914002441-ef4a69c12a20
 )


### PR DESCRIPTION
Added option to support creating a GKE cluster with client certificate enabled.
Support creating kubeconfig using client certificate if it is present.
