### PR TITLE
`install` misnamed - should be `test`

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -36,14 +36,13 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: install_cni_postsubmit
+    name: test_cni_postsubmit
     path_alias: istio.io/cni
     spec:
       containers:
       - command:
         - entrypoint
         - make
-        - docker
         - test
         image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
         name: ""
@@ -173,14 +172,13 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: install_cni
+    name: test_cni
     path_alias: istio.io/cni
     spec:
       containers:
       - command:
         - entrypoint
         - make
-        - docker
         - test
         image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
         name: ""

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -9,8 +9,8 @@ jobs:
   - name: build
     command: [make, docker]
 
-  - name: install
-    command: [make, docker, test]
+  - name: test
+    command: [make, test]
 
   - name: e2e
     command: [make, e2e]


### PR DESCRIPTION
The install operation does what `make test` does in the makefile target.
As such, rename the prow check such that it is less confusing to developers.

Depends-On: https://github.com/istio/cni/pull/194