### PR TITLE
Bump test CPU requests

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -56,7 +56,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -115,7 +115,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -163,7 +163,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -212,7 +212,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -260,7 +260,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -308,7 +308,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -357,7 +357,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -408,7 +408,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -461,7 +461,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -515,7 +515,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -569,7 +569,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -621,7 +621,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -670,7 +670,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -717,7 +717,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -745,7 +745,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -773,7 +773,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -801,7 +801,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -829,7 +829,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -857,7 +857,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -885,7 +885,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -932,7 +932,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -979,7 +979,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1026,7 +1026,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1073,7 +1073,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1120,7 +1120,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1167,7 +1167,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1214,7 +1214,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1265,7 +1265,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1316,7 +1316,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1367,7 +1367,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1418,7 +1418,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1491,7 +1491,7 @@ postsubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1525,7 +1525,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1552,7 +1552,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1581,7 +1581,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1608,7 +1608,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1635,7 +1635,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1662,7 +1662,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1689,7 +1689,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1716,7 +1716,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1762,7 +1762,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1808,7 +1808,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1855,7 +1855,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1901,7 +1901,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1947,7 +1947,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1993,7 +1993,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2040,7 +2040,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2087,7 +2087,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2134,7 +2134,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2182,7 +2182,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2229,7 +2229,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2279,7 +2279,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2331,7 +2331,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2384,7 +2384,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2437,7 +2437,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2486,7 +2486,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2532,7 +2532,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2584,7 +2584,7 @@ presubmits:
             cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "3"
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -234,7 +234,7 @@ resources:
   default:
     requests:
       memory: "3Gi"
-      cpu: "3000m"
+      cpu: "5000m"
     limits:
       memory: "24Gi"
       cpu: "8000m"


### PR DESCRIPTION
We have been seeing an increasing number of infrastructure flakes. It
seems likely this is related to overloaded pods as it is correlated to
times when large number of tests are running. Bumping the requests up
should give us some more consistent behavior.

Note that as we scaled down boskos the prow cluster load has increased.