### PR TITLE
Use docker-capable entrypoint

### DIFF
--- a/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - mesh
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - mandiff
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/e2e_install.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -170,7 +170,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
         - entrypoint
         - make
         - docker.all
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -229,7 +229,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
       - command:
         - make
         - mesh
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -281,7 +281,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -307,7 +307,7 @@ presubmits:
       - command:
         - make
         - mandiff
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/e2e_install.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:
@@ -381,7 +381,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
+        image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/operator.yaml
+++ b/prow/config/jobs/operator.yaml
@@ -1,33 +1,37 @@
 org: istio
 repo: operator
-image: gcr.io/istio-testing/build-tools:2019-10-08T20-57-24
-suppress_entrypoint: true
+image: gcr.io/istio-testing/build-tools:2019-10-09T20-39-13
 branches:
   - master
 
 jobs:
   - name: lint
     command: [make, lint]
+    suppress_entrypoint: true
 
   - name: mesh
     command: [make, mesh]
+    suppress_entrypoint: true
 
   - name: test
     command: [make, test]
+    suppress_entrypoint: true
 
   - name: mandiff
     command: [make, mandiff]
+    suppress_entrypoint: true
 
   - name: manifest-apply
-    command: [entrypoint, prow/e2e_install.sh]
+    command: [prow/e2e_install.sh]
     requirements: [kind]
     modifiers: [optional, hidden]
 
   - name: gencheck
     command: [make, gen-check]
     modifiers: [optional]
+    suppress_entrypoint: true
 
   - name: release
     type: postsubmit
-    command: [entrypoint, make, docker.all]
+    command: [make, docker.all]
     requirements: [gcp]


### PR DESCRIPTION
This additionally moves around the surpress_entrypoint from global
for the operator to per job.