### PR TITLE
Revert "`install` misnamed `test` (#1898)"

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -36,13 +36,14 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test_cni_postsubmit
+    name: install_cni_postsubmit
     path_alias: istio.io/cni
     spec:
       containers:
       - command:
         - entrypoint
         - make
+        - docker
         - test
         image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
         name: ""
@@ -172,13 +173,14 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test_cni
+    name: install_cni
     path_alias: istio.io/cni
     spec:
       containers:
       - command:
         - entrypoint
         - make
+        - docker
         - test
         image: gcr.io/istio-testing/build-tools:2019-10-02T14-57-08
         name: ""

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -9,8 +9,8 @@ jobs:
   - name: build
     command: [make, docker]
 
-  - name: test
-    command: [make, test]
+  - name: install
+    command: [make, docker, test]
 
   - name: e2e
     command: [make, e2e]


### PR DESCRIPTION
This reverts commit 7f30362ff7b3313150ef6ba7eabb112d20eba213.