### PR TITLE
Hide gencheck for operator

### DIFF
--- a/prow/cluster/jobs/istio/operator/istio.operator.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.release-1.4.gen.yaml
@@ -163,33 +163,6 @@ postsubmits:
     branches:
     - ^release-1.4$
     decorate: true
-    name: gencheck_operator_release-1.4_postsubmit
-    path_alias: istio.io/operator
-    spec:
-      containers:
-      - command:
-        - make
-        - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-11T13-37-52
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_release-1.4_operator_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^release-1.4$
-    decorate: true
     labels:
       preset-service-account: "true"
     max_concurrency: 5
@@ -367,30 +340,3 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_release-1.4_operator
-    branches:
-    - ^release-1.4$
-    decorate: true
-    name: gencheck_operator_release-1.4
-    optional: true
-    path_alias: istio.io/operator
-    spec:
-      containers:
-      - command:
-        - make
-        - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-11T13-37-52
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool

--- a/prow/config/jobs/operator-1.4.yaml
+++ b/prow/config/jobs/operator-1.4.yaml
@@ -28,12 +28,6 @@ jobs:
   requirements:
   - kind
 - command:
-  - make
-  - gen-check
-  modifiers:
-  - optional
-  name: gencheck
-- command:
   - entrypoint
   - make
   - docker.all


### PR DESCRIPTION
This test has never passed. Hiding in master to avoid confusion, and
disable in 1.4 as it will presumably never be fixed in 1.4.