### PR TITLE
Update image for client-go tests

### DIFF
--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -1,6 +1,7 @@
 org: istio
 repo: client-go
 support_release_branching: true
+image: gcr.io/istio-testing/build-tools:2019-10-17T13-30-59
 
 jobs:
   - name: build


### PR DESCRIPTION
Contains new build tools for kubernetes-1.16.2

Required, as tests for https://github.com/istio/client-go/pull/12#issuecomment-543209519 fail due to an older image being used