### PR TITLE
Clean up boskos resources

### DIFF
--- a/boskos/cluster/metrics-deployment.yaml
+++ b/boskos/cluster/metrics-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       - name: metrics
         image: gcr.io/k8s-prow/boskos/metrics:v20190730-dbac84bd7
         args:
-        - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test,gke-e2e-test-latest
+        - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/boskos/cluster/reaper-deployment.yaml
+++ b/boskos/cluster/reaper-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       - name: boskos-reaper
         image: gcr.io/k8s-prow/boskos/reaper:v20190730-dbac84bd7
         args:
-        - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test,gke-e2e-test-latest
+        - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test
       nodeSelector:
         prod: boskos
 

--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -1,43 +1,4 @@
 resources:
-- type: gke-e2e-test-latest
-  state: dirty
-  # Set back to 1 when mason client supports request ids.
-  min-count: 5
-  max-count: 5
-  needs:
-    gcp-project: 1
-  config:
-    type: GCPResourceConfig
-    content: |
-      gcp-project:
-        - clusters:
-          - machinetype: n1-standard-2
-            numnodes: 4
-            version: 1.11
-            networkpolicy:
-              enabled: true
-              provider: CALICO
-            scopes:
-            - https://www.googleapis.com/auth/cloud-platform
-            - https://www.googleapis.com/auth/trace.append
-          - machinetype: n1-standard-2
-            numnodes: 4
-            version: 1.11
-            networkpolicy:
-              enabled: true
-              provider: CALICO
-            scopes:
-            - https://www.googleapis.com/auth/cloud-platform
-            - https://www.googleapis.com/auth/trace.append
-          vms:
-          - machinetype: n1-standard-4
-            sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
-            tags:
-            - http-server
-            - https-server
-            scopes:
-            - https://www.googleapis.com/auth/cloud-platform
-            - https://www.googleapis.com/auth/trace.append
 - type: gke-e2e-test
   state: dirty
   # Set back to 10 when mason client supports request ids.
@@ -52,22 +13,19 @@ resources:
         - clusters:
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.10
+            version: 1.13
+            networkpolicy:
+              enabled: true
+              provider: CALICO
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
             - https://www.googleapis.com/auth/trace.append
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.10
-            scopes:
-            - https://www.googleapis.com/auth/cloud-platform
-            - https://www.googleapis.com/auth/trace.append
-          vms:
-          - machinetype: n1-standard-4
-            sourceimage: projects/debian-cloud/global/images/debian-9-stretch-v20180206
-            tags:
-            - http-server
-            - https-server
+            version: 1.13
+            networkpolicy:
+              enabled: true
+              provider: CALICO
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
             - https://www.googleapis.com/auth/trace.append
@@ -86,18 +44,8 @@ resources:
         - clusters:
           - machinetype: n1-highmem-8
             numnodes: 7
-            version: 1.10
+            version: 1.13
             zone: us-central1-f
-            scopes:
-            - https://www.googleapis.com/auth/cloud-platform
-            - https://www.googleapis.com/auth/trace.append
-          vms:
-          - machinetype: n1-highmem-8
-            sourceimage: projects/ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20180612
-            zone: us-central1-f
-            tags:
-            - http-server
-            - https-server
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
             - https://www.googleapis.com/auth/trace.append


### PR DESCRIPTION
* Kill `gke-e2e-test-latest`. We can just have every test use `gke-e2e-test`
* Remove VMs - as far as I know they are never used
* Upgrade to k8s 1.13. This is already happening from gke automatically, so having `1.10` here was deceiving 

This is marked as WIP only because (1) will require changes to istio/istio, which I will make if this is approved. 