### PR TITLE
increase timeout for benchmark job

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -243,6 +243,7 @@ periodics:
   name: daily-performance-benchmark
   branches: master
   decorate: true
+  timeout: 12h
   extra_refs:
     - base_ref: master
       org: istio


### PR DESCRIPTION
let the whole job to finish first.
next step would be trying to figure out a good way to breakdown the jobs or shorten the time