### PR TITLE
Revert "Use prowbazel:0.5.11 in istio/proxy master and release-1.4."

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-presubmit.sh
         resources:
@@ -54,7 +54,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-presubmit-asan.sh
         resources:
@@ -85,7 +85,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-presubmit-tsan.sh
         resources:
@@ -122,7 +122,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-postsubmit.sh
         securityContext:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-presubmit.sh
         resources:
@@ -54,7 +54,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-presubmit-asan.sh
         resources:
@@ -85,7 +85,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-presubmit-tsan.sh
         resources:
@@ -122,7 +122,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.11
+      - image: gcr.io/istio-testing/prowbazel:0.5.10
         command:
         - ./prow/proxy-postsubmit.sh
         securityContext:


### PR DESCRIPTION
Something is wrong with clang and/or libc++ 9.0, so let's revert back to 8.0
until I can figure it out.

This reverts commit 12071b8a029af7160d6bc5be1b1dfdb3ba5388ee.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>