### PR TITLE
update decoration timeout overwrite for benchmark job

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -244,6 +244,8 @@ periodics:
   branches: master
   decorate: true
   timeout: 12h
+  decoration_config:
+    timeout: 12h0m0s
   extra_refs:
     - base_ref: master
       org: istio


### PR DESCRIPTION
looks like the timeout overwrite doesn't work with default_decoration_configs, add the local decoration_config overwrite