### PR TITLE
Enable network policy on boskos resources

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -52,13 +52,19 @@ resources:
         - clusters:
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.10
+            version: 1.13
+            networkpolicy:
+              enabled: true
+              provider: CALICO
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
             - https://www.googleapis.com/auth/trace.append
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.10
+            version: 1.13
+            networkpolicy:
+              enabled: true
+              provider: CALICO
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
             - https://www.googleapis.com/auth/trace.append


### PR DESCRIPTION
This is a subset of https://github.com/istio/test-infra/pull/1953

I realized we cannot merge the above PR without breaking istio/istio on
3 release branches, so we would need to atomically commit 4 PRs, which
seems unnecesarily risky.

By merging this change first, we can update istio/istio at our leisure,
then merge 1953.