### PR TITLE
Add optional gencheck jobs on all repos with Go code.

### DIFF
--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -82,6 +82,33 @@ postsubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_bots_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_bots_postsubmit
+    path_alias: istio.io/bots
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/bots:
   - always_run: true
@@ -149,6 +176,33 @@ presubmits:
       - command:
         - make
         - test
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_bots
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_bots
+    optional: true
+    path_alias: istio.io/bots
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
         image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -143,6 +143,7 @@ presubmits:
     - ^master$
     decorate: true
     name: gencheck_client-go
+    optional: true
     path_alias: istio.io/client-go
     spec:
       containers:

--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -137,6 +137,33 @@ postsubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_cni_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_cni_postsubmit
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/cni:
   - always_run: true
@@ -258,6 +285,33 @@ presubmits:
       - command:
         - make
         - lint
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_cni
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_cni
+    optional: true
+    path_alias: istio.io/cni
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
         image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
@@ -143,6 +143,7 @@ presubmits:
     - ^master$
     decorate: true
     name: gencheck_gogo-genproto
+    optional: true
     path_alias: istio.io/gogo-genproto
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2668,6 +2668,7 @@ presubmits:
     - ^master$
     decorate: true
     name: gencheck_istio
+    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
@@ -327,6 +327,7 @@ presubmits:
     - ^master$
     decorate: true
     name: gencheck_operator
+    optional: true
     path_alias: istio.io/operator
     spec:
       containers:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -82,6 +82,33 @@ postsubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_pkg_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_pkg_postsubmit
+    path_alias: istio.io/pkg
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/pkg:
   - always_run: true
@@ -149,6 +176,33 @@ presubmits:
       - command:
         - make
         - test
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_pkg
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_pkg
+    optional: true
+    path_alias: istio.io/pkg
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
         image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -62,6 +62,33 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: gencheck_release-builder_postsubmit
+    path_alias: istio.io/release-builder
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_release-builder_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     labels:
       preset-service-account: "true"
     max_concurrency: 5
@@ -186,6 +213,33 @@ presubmits:
       - command:
         - make
         - test
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_release-builder
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_release-builder
+    optional: true
+    path_alias: istio.io/release-builder
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
         image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -196,6 +196,7 @@ presubmits:
     - ^master$
     decorate: true
     name: gencheck_test-infra
+    optional: true
     path_alias: istio.io/test-infra
     spec:
       containers:

--- a/prow/cluster/jobs/istio/tests/istio.tests.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tests/istio.tests.master.gen.yaml
@@ -82,6 +82,33 @@ postsubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_tests_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_tests_postsubmit
+    path_alias: istio.io/tests
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/tests:
   - always_run: true
@@ -149,6 +176,33 @@ presubmits:
       - command:
         - make
         - test
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_tests
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_tests
+    optional: true
+    path_alias: istio.io/tests
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
         image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -82,6 +82,33 @@ postsubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_tools_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_tools_postsubmit
+    path_alias: istio.io/tools
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
 presubmits:
   istio/tools:
   - always_run: true
@@ -149,6 +176,33 @@ presubmits:
       - command:
         - make
         - test
+        image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_tools
+    branches:
+    - ^master$
+    decorate: true
+    name: gencheck_tools
+    optional: true
+    path_alias: istio.io/tools
+    spec:
+      containers:
+      - command:
+        - make
+        - gen-check
         image: gcr.io/istio-testing/build-tools:2019-10-18T22-40-12
         name: ""
         resources:

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -10,3 +10,7 @@ jobs:
 
   - name: test
     command: [make, test]
+
+  - name: gencheck
+    command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -11,3 +11,4 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -16,3 +16,7 @@ jobs:
 
   - name: lint
     command: [make, lint]
+
+  - name: gencheck
+    command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/gogo-genproto.yaml
+++ b/prow/config/jobs/gogo-genproto.yaml
@@ -11,3 +11,4 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -266,6 +266,7 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    modifiers: [optional]
 
 resources:
   default:

--- a/prow/config/jobs/operator.yaml
+++ b/prow/config/jobs/operator.yaml
@@ -17,6 +17,7 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    modifiers: [optional]
 
   - name: e2e
     command: [entrypoint, make, e2e]

--- a/prow/config/jobs/pkg.yaml
+++ b/prow/config/jobs/pkg.yaml
@@ -11,3 +11,7 @@ jobs:
 
   - name: test
     command: [make, test]
+
+  - name: gencheck
+    command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -9,6 +9,10 @@ jobs:
   - name: test
     command: [make, test]
 
+  - name: gencheck
+    command: [make, gen-check]
+    modifiers: [optional]
+
   - name: publish
     command: [entrypoint, test/publish.sh]
     requirements: [gcp]

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -13,3 +13,4 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/tests.yaml
+++ b/prow/config/jobs/tests.yaml
@@ -10,3 +10,7 @@ jobs:
 
   - name: test
     command: [make, test]
+
+  - name: gencheck
+    command: [make, gen-check]
+    modifiers: [optional]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -11,3 +11,7 @@ jobs:
 
   - name: test
     command: [make, test]
+
+  - name: gencheck
+    command: [make, gen-check]
+    modifiers: [optional]


### PR DESCRIPTION
- Make all existing gencheck jobs optional. This is so I can roll out new
common files without breaking everything. Once common-files is rolled out,
then I'll make the gencheck jobs required, and update the container image
used by prow.