### PR TITLE
Drop Boskos cluster amount to 20 (from 50)

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -1,9 +1,9 @@
 resources:
 - type: gke-e2e-test
   state: dirty
-  # Set back to 10 when mason client supports request ids.
-  min-count: 50
-  max-count: 50
+  # Set min back to 10 when mason client supports request ids.
+  min-count: 20
+  max-count: 20
   needs:
     gcp-project: 1
   config:


### PR DESCRIPTION
Per
https://velodrome.istio.io/dashboard/db/boskos-dashboard?orgId=1&from=1567260126490&to=1571962688260

We haven't exceeded 20 in 90 days.

We are not using gke-e2e-test on any repo on `master` anymore, so all
usages are from old release branches that are unlikely to ever get an
influx of many PRs at once and go over the limit.