### PR TITLE
Update golang to 1.12.12 for 1.3 release

### DIFF
--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.3.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.3.yaml
@@ -10,7 +10,7 @@ istio_rel_pipeline_spec: &istio_rel_pipeline_spec
     testing: build-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
-  image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
+  image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
   # Docker in Docker
   securityContext:
     privileged: true
@@ -23,7 +23,7 @@ istio_rel_pipeline_container: &istio_rel_pipeline_container
       cpu: "3000m"
 
 istio_container: &istio_container
-  image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637
+  image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
   # Docker in Docker
   securityContext:
     privileged: true
@@ -36,7 +36,7 @@ istio_container: &istio_container
       cpu: "3000m"
 
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/istio-builder:v20190926-b1cd57d5
+  image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
   securityContext:
     privileged: true
   resources:

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
@@ -16,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -45,7 +45,7 @@ postsubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -78,7 +78,7 @@ postsubmits:
         - entrypoint
         - make
         - prow-e2e
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -208,7 +208,7 @@ presubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -240,7 +240,7 @@ presubmits:
         - entrypoint
         - make
         - prow-e2e
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         - localTestEnv
         - test
         - binaries-test
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -52,7 +52,7 @@ postsubmits:
         - T=-v
         - localTestEnv
         - racetest
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -80,7 +80,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -139,7 +139,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -236,7 +236,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/e2e-dashboard.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -362,7 +362,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -413,7 +413,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -466,7 +466,7 @@ postsubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -520,7 +520,7 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -574,7 +574,7 @@ postsubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -626,7 +626,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -675,7 +675,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -703,7 +703,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -731,7 +731,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -759,7 +759,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -787,7 +787,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.mixer.local
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -815,7 +815,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -843,7 +843,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -871,7 +871,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -898,7 +898,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-integ-race-native-tests.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -926,7 +926,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -973,7 +973,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1020,7 +1020,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1067,7 +1067,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1114,7 +1114,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1161,7 +1161,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1208,7 +1208,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1255,7 +1255,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1306,7 +1306,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.13.10
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1357,7 +1357,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1408,7 +1408,7 @@ postsubmits:
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1461,7 +1461,7 @@ presubmits:
         - localTestEnv
         - test
         - binaries-test
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1488,7 +1488,7 @@ presubmits:
         - entrypoint
         - make
         - lint
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1518,7 +1518,7 @@ presubmits:
         - T=-v
         - localTestEnv
         - racetest
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1545,7 +1545,7 @@ presubmits:
         - entrypoint
         - make
         - shellcheck
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1572,7 +1572,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1601,7 +1601,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1628,7 +1628,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1655,7 +1655,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1682,7 +1682,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.mixer.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1709,7 +1709,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1736,7 +1736,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1763,7 +1763,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1809,7 +1809,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1855,7 +1855,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1902,7 +1902,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1948,7 +1948,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -1994,7 +1994,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2040,7 +2040,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2087,7 +2087,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2134,7 +2134,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2181,7 +2181,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2229,7 +2229,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/e2e-dashboard.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2257,7 +2257,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2304,7 +2304,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2354,7 +2354,7 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2406,7 +2406,7 @@ presubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2459,7 +2459,7 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2512,7 +2512,7 @@ presubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2561,7 +2561,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -2588,7 +2588,7 @@ presubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/operator/istio.operator.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.release-1.3.gen.yaml
@@ -124,7 +124,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/e2e_install.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/e2e_install.sh
-        image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+        image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/cni-1.3.yaml
+++ b/prow/config/jobs/cni-1.3.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: cni
-image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
 branches:
   - release-1.3
 

--- a/prow/config/jobs/istio-1.3.yaml
+++ b/prow/config/jobs/istio-1.3.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: istio
-image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
 branches:
   - release-1.3
 

--- a/prow/config/jobs/operator-1.3.yaml
+++ b/prow/config/jobs/operator-1.3.yaml
@@ -18,7 +18,7 @@ jobs:
     command: [make, mandiff]
 
   - name: manifest-apply
-    image: gcr.io/istio-testing/istio-builder:v20190829-4edc0e70
+    image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
     command: [entrypoint, prow/e2e_install.sh]
     requirements: [kind]
     modifiers: [optional, hidden]


### PR DESCRIPTION
Update the builder image from `v20190823-25f7c637` to `v20191017-386873c9-dirty` to upgrade Golang to 1.12.12 as was done for the 1.2 release branch in https://github.com/istio/test-infra/pull/1960.