### PR TITLE
Update prowbazel to run as "root" user

### DIFF
--- a/docker/prowbazel/Dockerfile
+++ b/docker/prowbazel/Dockerfile
@@ -9,8 +9,7 @@ RUN rm -rf /var/lib/apt/lists/* \
     && apt-get install -qqy --no-install-recommends git iptables procps sudo xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Adding sudo group user no password access.
-# This is used by bootstrap user to start docker service
+# Adding sudo group user no password access to start docker service.
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Installing
@@ -23,11 +22,8 @@ VOLUME /var/lib/docker
 EXPOSE 2375
 
 ENV PATH /usr/local/go/bin:/usr/lib/google-cloud-sdk/bin:/opt/go/bin:${PATH}
-
-# Create bootstrap user
 ENV HOME /home/bootstrap
-RUN useradd -c "Bootstrap user" -d ${HOME} -G docker,sudo -m bootstrap -s /bin/bash
-USER bootstrap
+
 WORKDIR ${HOME}
 
 # Explicitly set bazel cache, to avoid cache issues with checking out
@@ -37,18 +33,17 @@ ENV TEST_TMPDIR /home/bootstrap/.cache/bazel
 # Move preloaded Bazel binaries to bootstrap's cache.
 # hadolint ignore=DL3004
 RUN mkdir -p /home/bootstrap/.cache/ \
-    && sudo mv /root/.cache/bazelisk ${HOME}/.cache/ \
-    && sudo chown -R bootstrap:bootstrap ${HOME}/.cache/
+    && mv /root/.cache/bazelisk ${HOME}/.cache/
 
 # Add bootstrap, the test harness (checks out code, captures log and status)
 ADD https://raw.githubusercontent.com/nlandolfi/test-infra-1/d7900388fa1fb69738e231a21230373fd4b5ede9/jenkins/bootstrap.py ${HOME}
 # hadolint ignore=DL3004
-RUN sudo chmod +rx ${HOME}/bootstrap.py
+RUN chmod +rx ${HOME}/bootstrap.py
 
 # Add entrypoint that runs bootstrap with appropriate arguments
 COPY ./docker/prowbazel/entrypoint /usr/local/bin/entrypoint
 # hadolint ignore=DL3004
-RUN sudo chmod +rx /usr/local/bin/entrypoint
+RUN chmod +rx /usr/local/bin/entrypoint
 
 # Final GOPATH configuration
 RUN mkdir -p /home/bootstrap/go/src

--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION ?= 0.5.12
+VERSION ?= 0.5.13
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:


### PR DESCRIPTION
Fixes #1985

> `bazel` symlink(s) from `root` owned directories (i.e Prow `GOPATH`) are permitted using this version of image: https://prow.istio.io/view/gcs/istio-prow/logs/proxy-postsubmit/788

@PiotrSikora - For versioning the image, I went with a patch update; let me know if you want to use another version #.

cc @kyessenov 