### PR TITLE
Fix directory for prowbazel image push

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -81,6 +81,7 @@ postsubmits:
         args:
         - make
         - -C
+        - docker/prowbazel
         - image
         - push
         securityContext:


### PR DESCRIPTION
I made a careless typo in job when I switched over to `build-tools` image 😭.