### PR TITLE
Promote prowbazel image for istio/proxy master and release-1.4 to 0.5.13

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit.sh
         resources:
@@ -54,7 +54,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit-asan.sh
         resources:
@@ -85,7 +85,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit-tsan.sh
         resources:
@@ -116,7 +116,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit-release.sh
         resources:
@@ -153,7 +153,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-postsubmit.sh
         securityContext:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
@@ -23,7 +23,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit.sh
         resources:
@@ -54,7 +54,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit-asan.sh
         resources:
@@ -85,7 +85,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit-tsan.sh
         resources:
@@ -116,7 +116,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-presubmit-release.sh
         resources:
@@ -153,7 +153,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/istio-testing/prowbazel:0.5.12
+      - image: gcr.io/istio-testing/prowbazel:0.5.13
         command:
         - ./prow/proxy-postsubmit.sh
         securityContext:


### PR DESCRIPTION
Bump to `prowbazel:0.5.13` in `istio/proxy` `master`/`release-1.4` jobs.

> Image includes fix for `bazel` symlinking #1985 