### PR TITLE
Make multicluster job required

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2561,7 +2561,6 @@ presubmits:
     - ^master$
     decorate: true
     name: pilot-multicluster-e2e_istio
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -146,7 +146,6 @@ jobs:
   - name: pilot-multicluster-e2e
     command: [entrypoint, prow/istio-pilot-multicluster-e2e.sh]
     requirements: [kind]
-    modifiers: [optional]
 
   - name: istio_e2e_cloudfoundry
     command: [entrypoint, make, e2e_cloudfoundry]


### PR DESCRIPTION
This job has been stable for a while. The only times it was failing was
boskos related flakes, and has now been migrated to kind, so I think its
time to bump this to requied.