### PR TITLE
Add "push-safe" target

### DIFF
--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -5,6 +5,10 @@ VERSION ?= 0.5.13
 image:
 	docker build -t "gcr.io/$(PROJECT)/prowbazel:$(VERSION)" -f Dockerfile ../../
 
+# Push image only if it does not exist.
+push-safe:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "gcr.io/$(PROJECT)/prowbazel:$(VERSION)" &>/dev/null || $(MAKE) push
+
 push:
 	docker push "gcr.io/$(PROJECT)/prowbazel:$(VERSION)"
 
@@ -14,4 +18,4 @@ run:
 # Example of running a job:
 # ~/bootstrap.py --repo="github.com/<org>/<repo>" --job="<job-name>" --clean --root="${GOPATH}/src" --pull=master:<sha>,<pr-#>:<sha>
 
-.PHONY: image push
+.PHONY: image push push-safe

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -83,7 +83,7 @@ postsubmits:
         - -C
         - docker/prowbazel
         - image
-        - push
+        - push-safe
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Add `push-safe` to check for existence of image before pushing.
