### PR TITLE
Make new installer test required, run in postsubmit

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -107,7 +107,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:2019-10-25T15-41-11
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -99,6 +99,53 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-new-install-k8s-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.new.installer
+        image: gcr.io/istio-testing/build-tools:2019-10-25T15-41-11
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     labels:
       preset-service-account: "true"
     max_concurrency: 5
@@ -2122,7 +2169,6 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-new-install-k8s-tests_istio
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -74,10 +74,8 @@ jobs:
     requirements: [kind]
 
   - name: integ-new-install-k8s-tests
-    type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.new.installer]
     requirements: [kind]
-    modifiers: [optional]
 
   - name: integ-istioio-k8s-tests
     type: presubmit


### PR DESCRIPTION
The reason this was not required before is not because it was flaky, but because it was broken for two reason:
* We were running published images, so we were not even testing the PR really
* We were pulling from `HEAD` of istio/installer, so tests depended on external state that may fail

Both of these are fixed now

