### PR TITLE
Stop using the the trigger plugin's trusted_org feature.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -2,14 +2,6 @@
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
 ---
-triggers:
-- repos:
-  - istio
-  - istio-ecosystem
-  - istio-releases
-  - istio-private
-  trusted_org: istio
-
 config_updater:
   maps:
     prow/config.yaml:


### PR DESCRIPTION
Warning message:
> trusted_org functionality is deprecated. Please ensure your configuration is updated before the end of December 2019.

ref: https://github.com/kubernetes/test-infra/issues/14875

__Effect:__ Previously repos under the `istio-ecosystem` and `istio-releases` orgs allowed any member of the `istio` org to trigger presubmit tests. Now the `istio-ecosystem` repos will only allow `istio-ecosystem` org members to trigger presubmits and similarly for `istio-releases` will only allow `istio-releases` org members.

I'm not sure what kind of impact this will have or who needs to be notified so I'll let Istio engprod/admins merge this at their leasure.
/hold
/assign @clarketm @geeknoid @howardjohn 

ref https://github.com/istio/test-infra/issues/2114