### PR TITLE
Revert "Add "post-test-infra-upload-testgrid-config" job (#2006)"

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -93,34 +93,6 @@ postsubmits:
       - name: docker-root
         emptyDir: {}
 
-  - name: post-test-infra-upload-testgrid-config
-    cluster: test-infra-trusted
-    run_if_changed: '^(prow/cluster/jobs/.*\.yaml)|(testgrid/default\.yaml)$'
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: "false"
-    spec:
-      containers:
-      - image: gcr.io/slchase-canary/transfigure #TODO(chases2) Change to k8s-prow project once pushed
-        command:
-        - /transfigure.sh
-        args:
-        - /etc/github-token/oauth
-        - prow/config.yaml
-        - prow/cluster/jobs
-        - testgrid/default.yaml
-        - istio
-      volumeMounts:
-      - name: github
-        mountPath: /etc/github-token
-        readOnly: true
-    volumes:
-    - name: github
-      secret:
-        secretName: oauth-token
-
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour
   name: ci-test-infra-branchprotector


### PR DESCRIPTION
This reverts commit a80434d68587cd83861af72411a3444667f2f8ea.

Job is failing with the following:
```
{
  component: "entrypoint"   
  error: "wrapped process failed: exit status 1"   
  file: "prow/entrypoint/run.go:80"   
  func: "k8s.io/test-infra/prow/entrypoint.Options.Run"   
  level: "error"   
  msg: "Error executing test process"   
 }
```
...which can be recreated with `pj-on-kind.sh`. Root cause unknown.

/assign @cjwagner 