### PR TITLE
Add "post-test-infra-upload-testgrid-config" job

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -93,6 +93,34 @@ postsubmits:
       - name: docker-root
         emptyDir: {}
 
+  - name: post-test-infra-upload-testgrid-config
+    cluster: test-infra-trusted
+    run_if_changed: '^(prow/cluster/jobs/.*\.yaml)|(testgrid/default\.yaml)$'
+    decorate: true
+    branches:
+    - master
+    annotations:
+      testgrid-create-test-group: "false"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/transfigure
+        command:
+        - /transfigure.sh
+        args:
+        - /etc/github-token/oauth
+        - prow/config.yaml
+        - prow/cluster/jobs
+        - testgrid/default.yaml
+        - istio
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
+
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour
   name: ci-test-infra-branchprotector


### PR DESCRIPTION
Job maintains a PR in k8s/test-infra that contains the TestGrid config of this repository.

Now uses k8s-prow image instead of local canary