### PR TITLE
Private Deck instance 

### DIFF
--- a/prow/cluster/cert-manager/tls-ing.yaml
+++ b/prow/cluster/cert-manager/tls-ing.yaml
@@ -15,6 +15,7 @@ spec:
   - secretName: prow-tls
     hosts:
     - prow.istio.io
+    - prow-private.istio.io
   rules:
   - host: prow.istio.io
     http:
@@ -27,3 +28,10 @@ spec:
         backend:
           serviceName: hook
           servicePort: 8888
+  - host: prow-private.istio.io
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: deck-private
+          servicePort: 80

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deck-private
+  labels:
+    app: deck-private
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deck-private
+  template:
+    metadata:
+      labels:
+        app: deck-private
+    spec:
+      serviceAccountName: deck-private
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: deck-private
+        image: gcr.io/k8s-prow/deck:v20191101-c5bcba610
+        ports:
+        - name: http
+          containerPort: 8080
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --hook-url=http://hook:8888/plugin-help
+        - --job-config-path=/etc/job-config
+        - --redirect-http-to=prow-private.istio.io
+        - --kubeconfig=/etc/kubeconfig/istio-config
+        - --hidden-only
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
+      - name: oauth2-proxy
+        image: quay.io/pusher/oauth2_proxy:v4.0.0
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+        args:
+        - --provider=github
+        - --github-org=istio-private
+        - --http-address=0.0.0.0:4180
+        - --upstream=http://localhost:8080
+        - --email-domain=*
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: deck-oauth-proxy
+              key: clientID
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: deck-oauth-proxy
+              key: clientSecret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: deck-oauth-proxy
+              key: cookieSecret
+        - name: OAUTH2_PROXY_COOKIE_DOMAIN
+          value: prow-private.istio.com
+      volumes:
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig

--- a/prow/cluster/deck_private_rbac.yaml
+++ b/prow/cluster/deck_private_rbac.yaml
@@ -1,0 +1,59 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: default
+  name: deck-private
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: deck-private
+rules:
+- apiGroups:
+  - prow.k8s.io
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: deck-private
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: deck-private
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deck-private
+subjects:
+- kind: ServiceAccount
+  name: deck-private
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: deck-private
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deck-private
+subjects:
+- kind: ServiceAccount
+  name: deck-private
+  namespace: default

--- a/prow/cluster/deck_private_service.yaml
+++ b/prow/cluster/deck_private_service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deck-private
+spec:
+  selector:
+    app: deck-private
+  ports:
+  - port: 80
+    targetPort: 4180
+  type: NodePort


### PR DESCRIPTION
Before merge:
- [x] Create an A record for `prow-private.istio.io`.
- [x] Add `clientID`, `clientSecret`, and `cookieSecret` to cluster.
- [x] ~Upload `private-config` ConfigMap to cluster~ using `--hidden-only` flag.

---

After merge:
- [x] ~Add *postsubmit* job to update `private-config` on changes.~ using `--hidden-only` flag.
- [x] Update SSL cert to include `prow-private.istio.io` #2052 ~#2047~
- [x] Perform a security audit. 
---

After deployed and stable:
- [x] Enable `spyglass`. #2061 
- [x] Enable job `rerun`, will not implement.
