### PR TITLE
Install gcloud binaries in /usr/local/bin.

### DIFF
--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -1,5 +1,5 @@
 PROJECT = istio-testing
-VERSION ?= 0.5.14
+VERSION ?= 0.5.15
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:

--- a/docker/prowbazel/README.md
+++ b/docker/prowbazel/README.md
@@ -58,3 +58,4 @@ Our dependency on this script is because it appropariately writes test job resul
 * 0.5.12: Install clang and libc++ from the official releases instead of packages.
 * 0.5.13: Switch image user from bootstrap to root.
 * 0.5.14: Install goimports and golangci-lint
+* 0.5.15: Install gcloud binaries in /usr/local/bin

--- a/scripts/tools/linux-install-gcloud
+++ b/scripts/tools/linux-install-gcloud
@@ -35,5 +35,10 @@ function update_gcloud() {
   ${SUDO} sed -i -e 's/true/false/' /usr/lib/google-cloud-sdk/lib/googlecloudsdk/core/config.json
   ${SUDO} "${GCLOUD}" -q components update kubectl beta \
     || error_exit 'Cannot update gcloud'
+  ${SUDO} cp -p /usr/lib/google-cloud-sdk/bin/gcloud /usr/local/bin/
+  ${SUDO} sed -i -e 's/export CLOUDSDK_ROOT_DIR/export CLOUDSDK_ROOT_DIR=\/usr\/lib\/google-cloud-sdk/g' /usr/local/bin/gcloud
+  ${SUDO} cp -p /usr/lib/google-cloud-sdk/bin/docker-credential-gcloud /usr/local/bin/
+  ${SUDO} sed -i -e 's/export CLOUDSDK_ROOT_DIR/export CLOUDSDK_ROOT_DIR=\/usr\/lib\/google-cloud-sdk/g' /usr/local/bin/docker-credential-gcloud
+  ${SUDO} cp -p /usr/lib/google-cloud-sdk/bin/git-credential-gcloud.sh /usr/local/bin/
+  ${SUDO} sed -i -e 's/export CLOUDSDK_ROOT_DIR/export CLOUDSDK_ROOT_DIR=\/usr\/lib\/google-cloud-sdk/g' /usr/local/bin/git-credential-gcloud.sh
 }
-


### PR DESCRIPTION
This fixes the postsubmit job when using RBE toolchain with hardcoded PATH:

exec: "docker-credential-gcloud": executable file not found in $PATH

Signed-off-by: Piotr Sikora <piotrsikora@google.com>