### PR TITLE
Fix prowbazel push-safe

### DIFF
--- a/docker/prowbazel/Makefile
+++ b/docker/prowbazel/Makefile
@@ -7,7 +7,7 @@ image:
 
 # Push image only if it does not exist.
 push-safe:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "gcr.io/$(PROJECT)/prowbazel:$(VERSION)" &>/dev/null || $(MAKE) push
+	-DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "gcr.io/$(PROJECT)/prowbazel:$(VERSION)" >/dev/null 2>&1 || $(MAKE) push
 
 push:
 	docker push "gcr.io/$(PROJECT)/prowbazel:$(VERSION)"


### PR DESCRIPTION
The idea is that the `-` will resolve the issue with *early* exit. [xref](https://stackoverflow.com/a/3477400/4279440)

https://prow.istio.io/view/gcs/istio-prow/logs/post-test-infra-push-prowbazel/20
> Note: the `|| make push` portion of the command **never** gets run