### PR TITLE
Fix post-test-infra-upload-testgrid-config

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -112,14 +112,14 @@ postsubmits:
         - prow/cluster/jobs
         - testgrid/default.yaml
         - istio
-      volumeMounts:
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
       - name: github
-        mountPath: /etc/github-token
-        readOnly: true
-    volumes:
-    - name: github
-      secret:
-        secretName: oauth-token
+        secret:
+          secretName: oauth-token
 
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour


### PR DESCRIPTION
Indentation issue was preventing the volume or volume mount from reading correctly.

Address issue #2036 

Tested with pj-on-kind using an updated version of transfigure; see [updates](https://github.com/kubernetes/test-infra/pull/15127)

/hold for updates