### PR TITLE
Use GKE managed certs for "prow-private.istio.io"

### DIFF
--- a/prow/cluster/cert-manager/tls-ing.yaml
+++ b/prow/cluster/cert-manager/tls-ing.yaml
@@ -9,13 +9,13 @@ metadata:
     certmanager.k8s.io/acme-challenge-type: dns01
     certmanager.k8s.io/acme-dns01-provider: clouddns
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    networking.gke.io/managed-certificates: prow-private-istio-io
     kubernetes.io/ingress.class: "gce"
 spec:
   tls:
   - secretName: prow-tls
     hosts:
     - prow.istio.io
-    - prow-private.istio.io
   rules:
   - host: prow.istio.io
     http:

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -62,6 +62,8 @@ spec:
         - --github-org=istio-private
         - --http-address=0.0.0.0:4180
         - --upstream=http://localhost:8080
+        - --cookie-domain=prow-private.istio.io
+        - --cookie-name=prow-private-istio-io-oauth2-proxy
         - --email-domain=*
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
@@ -79,8 +81,6 @@ spec:
             secretKeyRef:
               name: deck-oauth-proxy
               key: cookieSecret
-        - name: OAUTH2_PROXY_COOKIE_DOMAIN
-          value: prow-private.istio.com
       volumes:
       - name: config
         configMap:

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -65,6 +65,18 @@ spec:
         - --cookie-domain=prow-private.istio.io
         - --cookie-name=prow-private-istio-io-oauth2-proxy
         - --email-domain=*
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 3
+          periodSeconds: 3
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:

--- a/prow/cluster/prow-private-istio-io_managedcertificate.yaml
+++ b/prow/cluster/prow-private-istio-io_managedcertificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: prow-private-istio-io
+spec:
+  domains:
+  - prow-private.istio.io


### PR DESCRIPTION
Since this is an ingress change (which is currently not auto-deployed) and the certificate itself take time to be issued, I went ahead and preconfigured this in the cluster to ensure it was a *safe* change and that it would not cause downtime: 

https://prow-private.istio.io/

Step 1 towards: #1984

/assign @cjwagner 