### PR TITLE
Use GKE managed cert for "prow.istio.io"

### DIFF
--- a/prow/cluster/prow-istio-io_managedcertificate.yaml
+++ b/prow/cluster/prow-istio-io_managedcertificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: prow-istio-io
+spec:
+  domains:
+  - prow.istio.io


### PR DESCRIPTION
Preparation for transition from cert-manager to GKE cert. By being not being defined in `ingress` this will not cause any complication with TLS or drop webhooks. 

Step 2 towards: #1984

/assign @cjwagner 