### PR TITLE
Revert "Updating prow master jobs to use new common build-tools (#2051)"

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -49,7 +49,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -79,7 +79,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -206,7 +206,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -302,7 +302,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -350,7 +350,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -399,7 +399,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -450,7 +450,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -503,7 +503,7 @@ postsubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -557,7 +557,7 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -611,7 +611,7 @@ postsubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -663,7 +663,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -709,7 +709,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -756,7 +756,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -784,7 +784,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -812,7 +812,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -840,7 +840,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -868,7 +868,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -896,7 +896,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -924,7 +924,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -971,7 +971,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1018,7 +1018,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1065,7 +1065,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1112,7 +1112,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1159,7 +1159,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1206,7 +1206,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1253,7 +1253,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1304,7 +1304,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.12.10
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1355,7 +1355,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.13.10
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1406,7 +1406,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1457,7 +1457,7 @@ postsubmits:
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1503,7 +1503,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1530,7 +1530,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1564,7 +1564,7 @@ presubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1591,7 +1591,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1620,7 +1620,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1647,7 +1647,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1674,7 +1674,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1701,7 +1701,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1728,7 +1728,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1755,7 +1755,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1801,7 +1801,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1847,7 +1847,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1894,7 +1894,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1940,7 +1940,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -1986,7 +1986,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2032,7 +2032,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2079,7 +2079,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2126,7 +2126,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2173,7 +2173,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2220,7 +2220,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2267,7 +2267,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2314,7 +2314,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2364,7 +2364,7 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2416,7 +2416,7 @@ presubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2469,7 +2469,7 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2522,7 +2522,7 @@ presubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2567,7 +2567,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2613,7 +2613,7 @@ presubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2639,7 +2639,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:
@@ -2666,7 +2666,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-11-05T18-58-07
+image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
 
 jobs:
   - name: unit-tests


### PR DESCRIPTION
This reverts commit 49ad268aa6c523744fe529bcb3e595c5c07e066e.

python appears to be broken in the new image.