### PR TITLE
Add fork-repo arg to Transfigure job

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -112,6 +112,7 @@ postsubmits:
         - prow/cluster/jobs
         - testgrid/default.yaml
         - istio
+        - test-infra-1
         volumeMounts:
         - name: github
           mountPath: /etc/github-token


### PR DESCRIPTION
Required since `istio-testing/test-infra` is a fork of `istio/test-infra`, and not `kubernetes/test-infra`

Uses the repository `istio-testing/test-infra-1` instead.

Addresses #2036 
Depends on https://github.com/kubernetes/test-infra/pull/15149
Test: https://github.com/kubernetes/test-infra/pull/15148