### PR TITLE
Add `channel` flag to Genjobs

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -16,6 +16,7 @@ generate-istio-private-jobs:
 		--clean \
 		--mapping istio=istio-private \
 		--job-type postsubmit \
+		--channel - \
 		--env DOCKER_HUB=gcr.io/istio-prow-build,GCS_BUCKET=istio-private-build/dev \
 		--input ./cluster/jobs/ \
 		--output ./cluster/jobs/ \

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -16,6 +16,9 @@ postsubmits:
     max_concurrency: 5
     name: release_istio_postsubmit_private
     path_alias: istio.io/istio
+    reporter_config:
+      slack:
+        channel: '-'
     spec:
       containers:
       - command:
@@ -26,7 +29,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:2019-10-25T15-41-11
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""
         resources:
           limits:

--- a/prow/genjobs/README.md
+++ b/prow/genjobs/README.md
@@ -23,12 +23,13 @@ The following is a list of supported options for `genjobs`. The only **required*
 ```console
       --branches strings          Branch(es) to generate job(s) for.
       --bucket string             GCS bucket name to upload logs and build artifacts to. (default "private-build")
+      --channel string            Slack channel to report job status notifications to.
       --clean                     Clean output directory before job(s) generation.
       --cluster string            GCP cluster to run the job(s) in. (default "private")
   -e, --env stringToString        Environment variables to set for the job(s). (default [])
   -i, --input string              Input directory containing job(s) to convert. (default ".")
       --job-blacklist strings     Job(s) to blacklist in generation process.
-  -t, --job-type strings          Job types to whitelist in generation process (e.g. presubmit, postsubmit. periodic). (default [presubmit,postsubmit,periodic])
+  -t, --job-type strings          Job type(s) to process (e.g. presubmit, postsubmit. periodic). (default [presubmit,postsubmit,periodic])
       --job-whitelist strings     Job(s) to whitelist in generation process.
   -l, --labels stringToString     Prow labels to apply to the job(s). (default [])
   -m, --mapping stringToString    Mapping between public and private Github organization(s). (default [])

--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -109,14 +109,6 @@ func (o *options) validateFlags() error {
 		return &util.ExitError{Message: "-m, --mapping option is required.", Code: 1}
 	}
 
-	if o.bucket == "" {
-		return &util.ExitError{Message: "--bucket option is required.", Code: 1}
-	}
-
-	if o.sshKeySecret == "" {
-		return &util.ExitError{Message: "--ssh-key-secret option is required.", Code: 1}
-	}
-
 	o.input, err = filepath.Abs(o.input)
 	if err != nil {
 		return &util.ExitError{Message: fmt.Sprintf("-i, --input option invalid: %v.", o.input), Code: 1}
@@ -191,28 +183,45 @@ func convertOrgRepoStr(o options, s string) string {
 	return strings.Join([]string{o.orgMap[org], repo}, "/")
 }
 
-// updateUtilityConfig updates the jobs UtilityConfig fields based on provided inputs to work with private repositories.
+// updateUtilityConfig updates the jobs UtilityConfig fields based on provided inputs.
 func updateUtilityConfig(o options, job *config.UtilityConfig) {
+	if o.bucket == "" && o.sshKeySecret == "" {
+		return
+	}
+
 	if job.DecorationConfig == nil {
-		job.DecorationConfig = &prowjob.DecorationConfig{
-			GCSConfiguration: &prowjob.GCSConfiguration{
-				Bucket: o.bucket,
-			},
-			SSHKeySecrets: []string{o.sshKeySecret},
+		job.DecorationConfig = &prowjob.DecorationConfig{}
+	}
+
+	updateGCSConfiguration(o, job.DecorationConfig)
+	updateSSHKeySecrets(o, job.DecorationConfig)
+}
+
+// updateGCSConfiguration updates the jobs GCSConfiguration fields based on provided inputs.
+func updateGCSConfiguration(o options, job *prowjob.DecorationConfig) {
+	if o.bucket == "" {
+		return
+	}
+
+	if job.GCSConfiguration == nil {
+		job.GCSConfiguration = &prowjob.GCSConfiguration{
+			Bucket: o.bucket,
 		}
 	} else {
-		if job.DecorationConfig.GCSConfiguration == nil {
-			job.DecorationConfig.GCSConfiguration = &prowjob.GCSConfiguration{
-				Bucket: o.bucket,
-			}
-		} else {
-			job.DecorationConfig.GCSConfiguration.Bucket = o.bucket
-		}
-		if job.DecorationConfig.SSHKeySecrets == nil {
-			job.DecorationConfig.SSHKeySecrets = []string{o.sshKeySecret}
-		} else {
-			job.DecorationConfig.SSHKeySecrets = append(job.DecorationConfig.SSHKeySecrets, o.sshKeySecret)
-		}
+		job.GCSConfiguration.Bucket = o.bucket
+	}
+}
+
+// updateSSHKeySecrets updates the jobs SSHKeySecrets fields based on provided inputs.
+func updateSSHKeySecrets(o options, job *prowjob.DecorationConfig) {
+	if o.sshKeySecret == "" {
+		return
+	}
+
+	if job.SSHKeySecrets == nil {
+		job.SSHKeySecrets = []string{o.sshKeySecret}
+	} else {
+		job.SSHKeySecrets = append(job.SSHKeySecrets, o.sshKeySecret)
 	}
 }
 


### PR DESCRIPTION
1. Add `--channel` flag to `genjobs` for configuring *slack reporting channel*
2. Make `--bucket` and `--ssh-key-secret` *optional* since they can be set via tuning **new** `default_decoration_configs` field.
3. Regenerate `istio-private` jobs.