### PR TITLE
Add new Kubernetes 1.17 postsubmit job

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1455,7 +1455,58 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
+        - kindest/node:v1.16.2
+        - test.integration.kube.presubmit
+        image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-117_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.17.0-beta.1
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-04T22-35-09
         name: ""

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -246,15 +246,26 @@ jobs:
     requirements: [kind]
     timeout: 4h
 
-  # TODO replace with official kindest/node image. Currently this is a custom built image of the beta
-  # As 1.16 has not been official released
   - name: integ-k8s-116
     type: postsubmit
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
+      - kindest/node:v1.16.2
+      - test.integration.kube.presubmit
+    requirements: [kind]
+    timeout: 4h
+
+  # TODO replace with official kindest/node image. Currently this is a custom built image of the beta
+  # As 1.17 has not been official released
+  - name: integ-k8s-117
+    type: postsubmit
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --node-image
+      - gcr.io/istio-testing/kind-node:v1.17.0-beta.1
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
I did some sanity checking of this so Istio at least runs, but not sure
if it will pass all tests, but it is postsubmit so it will not block
anything.

Also switch to official 1.16 image