### PR TITLE
Disable "long-job-names" warning in checkconfig

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -19,6 +19,7 @@ presubmits:
         - --exclude-warning=mismatched-tide
         - --exclude-warning=unknown-fields
         - --exclude-warning=non-decorated-jobs
+        - --exclude-warning=long-job-names
 
   - name: flakey-run
     branches:


### PR DESCRIPTION
This warning is too restrictive.