### PR TITLE
Shorten job names

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -371,7 +371,7 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_postsubmit_priv
+    name: e2e-bookInfoTests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2614,7 +2614,7 @@ presubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_priv
+    name: e2e-bookInfoTests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.4.gen.yaml
@@ -269,7 +269,7 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.4_posts_priv
+    name: e2e-bookInfoTests_istio_release-1.4_posts_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2462,7 +2462,7 @@ presubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.4_priv
+    name: e2e-bookInfoTests_istio_release-1.4_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -338,7 +338,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_postsubmit
+    name: e2e-bookInfoTests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2399,7 +2399,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio
+    name: e2e-bookInfoTests_istio
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -106,7 +106,7 @@ presubmits:
         - prow/e2e-dashboard.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3
+  - name: e2e-bookInfoTests
     <<: *job_template
     annotations:
       testgrid-create-test-group: "false"
@@ -264,7 +264,7 @@ postsubmits:
         - prow/istio-unit-tests.sh
       nodeSelector:
         testing: test-pool
-  
+
   - name: e2e-simpleTests
     <<: *job_template
     annotations:
@@ -310,7 +310,7 @@ postsubmits:
         - prow/e2e-simpleTests-non-mcp.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3
+  - name: e2e-bookInfoTests
     <<: *job_template
     annotations:
       testgrid-create-test-group: "false"
@@ -352,7 +352,7 @@ postsubmits:
         - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp
+  - name: e2e-bookInfoTests-non-mcp
     <<: *job_template
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.2.yaml
@@ -269,7 +269,7 @@ presubmits:
         - prow/e2e-dashboard.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-release-1.2
+  - name: e2e-bookInfoTests-release-1.2
     <<: *job_template
     always_run: true
     annotations:
@@ -526,7 +526,7 @@ postsubmits:
         - prow/e2e-simpleTests-non-mcp.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-release-1.2
+  - name: e2e-bookInfoTests-release-1.2
     <<: *job_template
     annotations:
       testgrid-dashboards: istio_release-1.2_istio_postsubmit
@@ -574,7 +574,7 @@ postsubmits:
         - prow/istio-pilot-e2e-envoyv2-v1alpha3-k8s-latest.sh
       nodeSelector:
         testing: test-pool
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp-release-1.2
+  - name: e2e-bookInfoTests-non-mcp-release-1.2
     <<: *job_template
     annotations:
       testgrid-dashboards: istio_release-1.2_istio_postsubmit

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
@@ -254,7 +254,7 @@ postsubmits:
     branches:
     - ^release-1.3$
     decorate: true
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.3_postsubmit
+    name: e2e-bookInfoTests_istio_release-1.3_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2243,7 +2243,7 @@ presubmits:
     branches:
     - ^release-1.3$
     decorate: true
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.3
+    name: e2e-bookInfoTests_istio_release-1.3
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.4.gen.yaml
@@ -242,7 +242,7 @@ postsubmits:
     branches:
     - ^release-1.4$
     decorate: true
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.4_postsubmit
+    name: e2e-bookInfoTests_istio_release-1.4_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2255,7 +2255,7 @@ presubmits:
     branches:
     - ^release-1.4$
     decorate: true
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.4
+    name: e2e-bookInfoTests_istio_release-1.4
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio-1.3.yaml
+++ b/prow/config/jobs/istio-1.3.yaml
@@ -102,7 +102,7 @@ jobs:
     command: [entrypoint, prow/e2e-dashboard.sh]
     requirements: [gcp]
 
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3
+  - name: e2e-bookInfoTests
     command: [entrypoint, prow/e2e-kind-suite.sh, --single_test, e2e_bookinfo_envoyv2_v1alpha3]
     requirements: [kind]
 

--- a/prow/config/jobs/istio-1.4.yaml
+++ b/prow/config/jobs/istio-1.4.yaml
@@ -163,7 +163,7 @@ jobs:
   - prow/e2e-kind-suite.sh
   - --single_test
   - e2e_bookinfo_envoyv2_v1alpha3
-  name: e2e-bookInfoTests-envoyv2-v1alpha3
+  name: e2e-bookInfoTests
   requirements:
   - kind
 - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -101,7 +101,7 @@ jobs:
     command: [entrypoint, prow/e2e-kind-suite.sh, --single_test, e2e_dashboard]
     requirements: [kind]
 
-  - name: e2e-bookInfoTests-envoyv2-v1alpha3
+  - name: e2e-bookInfoTests
     command: [entrypoint, prow/e2e-kind-suite.sh, --single_test, e2e_bookinfo_envoyv2_v1alpha3]
     requirements: [kind]
 


### PR DESCRIPTION
Shorten *overly* verbose job names by a few character:
- e2e-bookInfoTests...~envoyv2-v1alpha3~...

To preserve [job history](https://prow.istio.io/job-history/istio-prow/pr-logs/directory/e2e-bookInfoTests-envoyv2-v1alpha3_istio) for past jobs (before rename), we will need to copy (i.e. `gsutil cp`) from *old* dir to *new* dir. @fejta - any other measure I need to take besides repairing job history so this goes smoothly?
