### PR TITLE
Revert "Add direct as fallback for GOPROXY"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -414,6 +414,6 @@ presets:
 # Enable GOPROXY by default
 - env:
   - name: GOPROXY
-    value: "https://proxy.golang.org,direct"
+    value: "https://proxy.golang.org"
   - name: BUILD_WITH_CONTAINER
     value: "0"


### PR DESCRIPTION
Reverts istio/test-infra#2081

This breaks proxy which is using go 1.12.

for now just revert