### PR TITLE
Add a new job to try out proxy-build-tools

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.yaml
@@ -36,6 +36,38 @@ presubmits:
       nodeSelector:
         testing: build-pool
 
+  - name: proxy-presubmit-new-builder
+    annotations:
+      testgrid-dashboards: istio_proxy
+    context: prow/proxy-presubmit.sh
+    branches: *branch_spec
+    always_run: true
+    decorate: true
+    path_alias: istio.io/proxy
+    timeout: 60m
+    optional: true
+    extra_refs:
+    - org: istio
+      repo: istio
+      base_ref: master
+      path_alias: istio.io/istio
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
+        command:
+        - ./prow/proxy-presubmit.sh
+        resources:
+          requests:
+            memory: "8Gi"
+            cpu: "8000m"
+          limits:
+            memory: "60Gi"
+            cpu: "16000m"
+      nodeSelector:
+        testing: build-pool
+
   - name: proxy-presubmit-asan
     annotations:
       testgrid-dashboards: istio_proxy


### PR DESCRIPTION
add a new optional presubmit job to istio proxy to use the new proxy-builder-tools image. This is just a temporary job to experiment the new docker image. I don't want to block proxy changes on this since it might need some iterations to pass.

cc @PiotrSikora 