### PR TITLE
Remove max concurrency for jobs requiring gcp access

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -71,7 +71,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -148,7 +147,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: integ-istioio-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -1710,7 +1708,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release-test_istio
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
@@ -102,7 +102,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release-test_istio_release-1.3_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -228,7 +227,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-dashboard_istio_release-1.3_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -667,7 +665,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: pilot-multicluster-e2e_istio_release-1.3_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -1593,7 +1590,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release-test_istio_release-1.3
     path_alias: istio.io/istio
     spec:
@@ -2221,7 +2217,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-dashboard_istio_release-1.3
     path_alias: istio.io/istio
     spec:
@@ -2552,7 +2547,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: pilot-multicluster-e2e_istio_release-1.3
     optional: true
     path_alias: istio.io/istio

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.4.gen.yaml
@@ -71,7 +71,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release_istio_release-1.4_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -197,7 +196,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-dashboard_istio_release-1.4_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -655,7 +653,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: pilot-multicluster-e2e_istio_release-1.4_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -1566,7 +1563,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release-test_istio_release-1.4
     path_alias: istio.io/istio
     spec:
@@ -2214,7 +2210,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: e2e-dashboard_istio_release-1.4
     path_alias: istio.io/istio
     spec:
@@ -2517,7 +2512,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: pilot-multicluster-e2e_istio_release-1.4
     optional: true
     path_alias: istio.io/istio

--- a/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
@@ -192,7 +192,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release_operator_postsubmit
     path_alias: istio.io/operator
     spec:

--- a/prow/cluster/jobs/istio/operator/istio.operator.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.release-1.4.gen.yaml
@@ -118,7 +118,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: release_operator_release-1.4_postsubmit
     path_alias: istio.io/operator
     spec:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -91,7 +91,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: publish_release-builder_postsubmit
     path_alias: istio.io/release-builder
     spec:
@@ -260,7 +259,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: publish_release-builder
     path_alias: istio.io/release-builder
     spec:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.4.gen.yaml
@@ -91,7 +91,6 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: publish_release-builder_release-1.4_postsubmit
     path_alias: istio.io/release-builder
     spec:
@@ -260,7 +259,6 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    max_concurrency: 5
     name: publish_release-builder_release-1.4
     path_alias: istio.io/release-builder
     spec:

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -455,9 +455,7 @@ func applyRequirements(job *config.JobBase, requirements []string) {
 	for _, req := range requirements {
 		switch req {
 		case RequirementGCP:
-			// GCP resources are limited, so set max concurrency to 5
 			// The preset service account will set up the required resources
-			job.MaxConcurrency = 5
 			job.Labels["preset-service-account"] = "true"
 		case RequirementRelease:
 			// Grant access to release resources, such as docker and github


### PR DESCRIPTION
This was originally intended as a way to prevent overloading Boskos,
which we no longer use. There is no reason to artificially limit the
number of jobs we have.