### PR TITLE
Run dry run publish only if code changes

### DIFF
--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -91,8 +91,9 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    name: publish_release-builder_postsubmit
+    name: dry-run_release-builder_postsubmit
     path_alias: istio.io/release-builder
+    run_if_changed: \.go$|\.sh$
     spec:
       containers:
       - command:
@@ -251,7 +252,7 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_release-builder
     branches:
@@ -259,8 +260,9 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    name: publish_release-builder
+    name: dry-run_release-builder
     path_alias: istio.io/release-builder
+    run_if_changed: \.go$|\.sh$
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.4.gen.yaml
@@ -91,8 +91,9 @@ postsubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    name: publish_release-builder_release-1.4_postsubmit
+    name: dry-run_release-builder_release-1.4_postsubmit
     path_alias: istio.io/release-builder
+    run_if_changed: \.go$|\.sh$
     spec:
       containers:
       - command:
@@ -251,7 +252,7 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.4_release-builder
     branches:
@@ -259,8 +260,9 @@ presubmits:
     decorate: true
     labels:
       preset-service-account: "true"
-    name: publish_release-builder_release-1.4
+    name: dry-run_release-builder_release-1.4
     path_alias: istio.io/release-builder
+    run_if_changed: \.go$|\.sh$
     spec:
       containers:
       - command:

--- a/prow/config/jobs/release-builder-1.4.yaml
+++ b/prow/config/jobs/release-builder-1.4.yaml
@@ -14,10 +14,11 @@ jobs:
 - name: gencheck
   command: [make, gen-check]
 
-- name: publish
+- name: dry-run
   command: [entrypoint, test/publish.sh]
   requirements: [gcp]
   resources: build
+  regex: '\.go$|\.sh$'
 
 - name: build-warning
   type: presubmit

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -13,10 +13,11 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-  - name: publish
+  - name: dry-run
     command: [entrypoint, test/publish.sh]
     requirements: [gcp]
     resources: build
+    regex: '\.go$|\.sh$'
 
   - name: build-warning
     type: presubmit


### PR DESCRIPTION
Right now we run a ~30min test of a dry run build as part of presubmit.
This makes building and publishing official releases painful.

Instead, only run when the actual release logic changes.

Additionally, rename this to dry-run. `publish` is really confusing name
when we also have a real publish.