### PR TITLE
Consolidate job generation

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -34,6 +34,7 @@ testgrid:
 generate-config:
 	@rm -fr prow/cluster/jobs/istio/*/*.gen.yaml
 	@(cd prow/config/cmd; GOARCH=amd64 GOOS=linux go run generate.go write)
+	@$(MAKE) -C prow gen-private-jobs
 
 diff-config:
 	@(cd prow/config/cmd; GOARCH=amd64 GOOS=linux go run generate.go diff)

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,7 +12,7 @@ ZONE    ?= us-west1-a
 CLUSTER ?= prow
 
 gen-private-jobs:
-	./gen-private-jobs.sh
+	@./gen-private-jobs.sh
 
 update-config-dry-run: get-cluster-credentials
 	./recreate_prow_configmaps.py \

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -29,7 +29,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -68,7 +68,7 @@ postsubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -102,7 +102,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -136,7 +136,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -245,7 +245,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -299,7 +299,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -353,7 +353,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -407,7 +407,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -461,7 +461,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -516,7 +516,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -573,7 +573,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -632,7 +632,7 @@ postsubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -692,7 +692,7 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -752,7 +752,7 @@ postsubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -810,7 +810,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -862,7 +862,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -915,7 +915,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -949,7 +949,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -983,7 +983,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1017,7 +1017,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1051,7 +1051,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1085,7 +1085,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1119,7 +1119,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1172,7 +1172,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1225,7 +1225,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1278,7 +1278,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1331,7 +1331,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1384,7 +1384,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1437,7 +1437,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1490,7 +1490,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1546,7 +1546,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.12.10
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1602,7 +1602,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.13.10
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1658,7 +1658,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1714,7 +1714,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.16.2
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1770,7 +1770,7 @@ postsubmits:
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.17.0-beta.1
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1822,7 +1822,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1855,7 +1855,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1897,7 +1897,7 @@ presubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1932,7 +1932,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -1968,7 +1968,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2003,7 +2003,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2038,7 +2038,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2073,7 +2073,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2108,7 +2108,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2143,7 +2143,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2197,7 +2197,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2251,7 +2251,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2306,7 +2306,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2360,7 +2360,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2414,7 +2414,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2468,7 +2468,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2522,7 +2522,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2577,7 +2577,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2632,7 +2632,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2687,7 +2687,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2742,7 +2742,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2797,7 +2797,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2855,7 +2855,7 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2915,7 +2915,7 @@ presubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -2976,7 +2976,7 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -3037,7 +3037,7 @@ presubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -3090,7 +3090,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -3144,7 +3144,7 @@ presubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -3178,7 +3178,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:
@@ -3212,7 +3212,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
+        image: gcr.io/istio-testing/build-tools:master-2019-11-14T12-01-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -5,23 +5,16 @@ postsubmits:
     - ^master$
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
-    context: prow/proxy-postsubmit.sh
     decorate: true
     decoration_config:
       gcs_configuration:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    extra_refs:
-    - base_ref: master
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
-    name: proxy-postsubmit_master_priv
+    name: release_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     reporter_config:
       slack:
@@ -41,60 +34,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/prowbazel:0.5.16
-        name: ""
-        resources:
-          limits:
-            cpu: "16"
-            memory: 60Gi
-          requests:
-            cpu: "8"
-            memory: 8Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: build-pool
-  - branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/proxy.git
-    cluster: private
-    context: prow/proxy-postsubmit.sh
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    extra_refs:
-    - base_ref: master
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
-    labels:
-      preset-enable-netrc: "true"
-      preset-service-account: "true"
-    name: proxy-postsubmit_release-1.4_priv
-    path_alias: istio.io/proxy
-    reporter_config:
-      slack:
-        channel: '-'
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-postsubmit.sh
-        env:
-        - name: DOCKER_REPOSITORY
-          value: istio-prow-build/envoy
-        - name: ENVOY_PREFIX
-          value: envoy
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
-        - name: GCS_BUILD_BUCKET
-          value: istio-private-build
-        image: gcr.io/istio-testing/prowbazel:0.5.16
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -114,22 +54,13 @@ presubmits:
     - ^master$
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
-    context: prow/proxy-presubmit.sh
     decorate: true
     decoration_config:
       gcs_configuration:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    extra_refs:
-    - base_ref: master
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
-    labels:
-      preset-service-account: "true"
-    name: proxy-presubmit_priv
+    name: test_proxy_priv
     path_alias: istio.io/proxy
     reporter_config:
       slack:
@@ -138,7 +69,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/prowbazel:0.5.16
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -147,6 +78,8 @@ presubmits:
           requests:
             cpu: "8"
             memory: 8Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         testing: build-pool
   - always_run: true
@@ -154,22 +87,13 @@ presubmits:
     - ^master$
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
-    context: prow/proxy-presubmit-asan.sh
     decorate: true
     decoration_config:
       gcs_configuration:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    extra_refs:
-    - base_ref: master
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
-    labels:
-      preset-service-account: "true"
-    name: proxy-presubmit-asan_priv
+    name: test-asan_proxy_priv
     path_alias: istio.io/proxy
     reporter_config:
       slack:
@@ -178,7 +102,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/prowbazel:0.5.16
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -187,6 +111,8 @@ presubmits:
           requests:
             cpu: "8"
             memory: 8Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         testing: build-pool
   - always_run: true
@@ -194,22 +120,13 @@ presubmits:
     - ^master$
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
-    context: prow/proxy-presubmit-tsan.sh
     decorate: true
     decoration_config:
       gcs_configuration:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    extra_refs:
-    - base_ref: master
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
-    labels:
-      preset-service-account: "true"
-    name: proxy-presubmit-tsan_priv
+    name: test-tsan_proxy_priv
     path_alias: istio.io/proxy
     reporter_config:
       slack:
@@ -218,7 +135,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/prowbazel:0.5.16
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -227,6 +144,8 @@ presubmits:
           requests:
             cpu: "8"
             memory: 8Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         testing: build-pool
   - always_run: true
@@ -234,22 +153,13 @@ presubmits:
     - ^master$
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
-    context: prow/proxy-presubmit-release.sh
     decorate: true
     decoration_config:
       gcs_configuration:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    extra_refs:
-    - base_ref: master
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
-    labels:
-      preset-service-account: "true"
-    name: proxy-presubmit-release_priv
+    name: release-test_proxy_priv
     path_alias: istio.io/proxy
     reporter_config:
       slack:
@@ -258,7 +168,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/prowbazel:0.5.16
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -267,5 +177,7 @@ presubmits:
           requests:
             cpu: "8"
             memory: 8Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         testing: build-pool

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -21,59 +21,6 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
-    name: proxy-postsubmit_master_priv
-    path_alias: istio.io/proxy
-    reporter_config:
-      slack:
-        channel: '-'
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-postsubmit.sh
-        env:
-        - name: DOCKER_REPOSITORY
-          value: istio-prow-build/envoy
-        - name: ENVOY_PREFIX
-          value: envoy-wasm
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/envoyproxy/envoy-wasm
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
-        - name: GCS_BUILD_BUCKET
-          value: istio-private-build
-        image: gcr.io/istio-testing/prowbazel:0.5.16
-        name: ""
-        resources:
-          limits:
-            cpu: "16"
-            memory: 60Gi
-          requests:
-            cpu: "8"
-            memory: 8Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: build-pool
-  - branches:
-    - ^release-1.4$
-    clone_uri: git@github.com:istio-private/proxy.git
-    cluster: private
-    context: prow/proxy-postsubmit.sh
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    extra_refs:
-    - base_ref: release-1.4
-      clone_uri: git@github.com:istio-private/istio.git
-      org: istio-private
-      path_alias: istio.io/istio
-      repo: istio
-    labels:
-      preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: proxy-postsubmit_release-1.4_priv
     path_alias: istio.io/proxy
     reporter_config:

--- a/prow/gen-private-jobs.sh
+++ b/prow/gen-private-jobs.sh
@@ -28,7 +28,6 @@ COMMON_OPTS=(
   "--bucket=istio-private-build"
   "--cluster=private"
   "--modifier=priv"
-  "--branches=release-1.4,master"
 )
 
 # Clean ./prow/cluster/jobs/istio-private directory
@@ -37,6 +36,7 @@ go run ./genjobs --clean --mapping=istio=istio-private --output=./cluster/jobs/ 
 # istio/istio build job(s) - postsubmit(s)
 go run ./genjobs \
   "${COMMON_OPTS[@]}" \
+  --branches=release-1.4,master \
   --env DOCKER_HUB=gcr.io/istio-prow-build,GCS_BUCKET=istio-private-build/dev \
   --labels preset-enable-ssh=true \
   --job-type postsubmit \
@@ -46,6 +46,7 @@ go run ./genjobs \
 # istio/istio test jobs(s) - presubmit(s) and postsubmit(s)
 go run ./genjobs \
   "${COMMON_OPTS[@]}" \
+  --branches=release-1.4,master \
   --job-type presubmit,postsubmit \
   --repo-whitelist istio \
   --job-blacklist release_istio_postsubmit,release_istio_release-1.4_postsubmit
@@ -54,9 +55,9 @@ go run ./genjobs \
 go run ./genjobs \
   "${COMMON_OPTS[@]}" \
   --branches master \
+  --modifier=master_priv \
   --labels preset-enable-netrc=true \
   --job-type postsubmit \
-  --modifier=master_priv \
   --env GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
   --repo-whitelist proxy
 
@@ -64,14 +65,15 @@ go run ./genjobs \
 go run ./genjobs \
   "${COMMON_OPTS[@]}" \
   --branches release-1.4 \
+  --modifier=release-1.4_priv \
   --labels preset-enable-netrc=true \
   --job-type postsubmit \
-  --modifier=release-1.4_priv \
   --env GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
   --repo-whitelist proxy
 
 # istio/proxy test jobs(s) - presubmit(s)
 go run ./genjobs \
   "${COMMON_OPTS[@]}" \
+  --branches=release-1.4,master \
   --job-type presubmit \
   --repo-whitelist proxy


### PR DESCRIPTION
To keep *private* jobs from diverging, we should regenerate them when the *public* jobs are generated

@howardjohn - any reason to continue to keep these separate?