### PR TITLE
Updated prow build-tools image for client-go

### DIFF
--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: client-go
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+image: gcr.io/istio-testing/build-tools:master-2019-11-15T13-58-33
 
 jobs:
   - name: build


### PR DESCRIPTION
Updated prow build-tools image for client-go to pickup latest `kubetype-gen` changes in `istio/tools`.

cc @sdake 