### PR TITLE
update to stable "checkconfig" image

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -8,7 +8,7 @@ presubmits:
     run_if_changed: '^prow/(config|plugins|cluster/jobs/.*)\.yaml$'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20191115-8d288a842
+      - image: gcr.io/k8s-prow/checkconfig:v20191117-403e116f9
         command:
         - /checkconfig
         args:


### PR DESCRIPTION
Picking up latest patch from https://github.com/kubernetes/test-infra/pull/15315. This is a *stable* version of `checkconfig`. 