### PR TITLE
disable RBE in private builds until configured and update .netrc

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -21,6 +21,8 @@ postsubmits:
       - command:
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_JOBS
+          value: "0"
         - name: DOCKER_REPOSITORY
           value: istio-prow-build/envoy
         - name: ENVOY_PREFIX

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -28,6 +28,8 @@ postsubmits:
       - command:
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_JOBS
+          value: "0"
         - name: DOCKER_REPOSITORY
           value: istio-prow-build/envoy
         - name: ENVOY_PREFIX

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -422,7 +422,7 @@ presets:
 - labels:
     preset-enable-netrc: "true"
   volumeMounts:
-  - mountPath: /root
+  - mountPath: /home/bootstrap
     name: netrc
     readOnly: true
   volumes:

--- a/prow/gen-private-jobs.sh
+++ b/prow/gen-private-jobs.sh
@@ -57,7 +57,7 @@ go run ./genjobs \
   --modifier=master_priv \
   --labels preset-enable-netrc=true \
   --job-type postsubmit \
-  --env GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
+  --env BAZEL_BUILD_RBE_JOBS=0,GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
   --repo-whitelist proxy
 
 # istio/proxy release-1.4 build jobs(s) - postsubmit(s)
@@ -67,7 +67,7 @@ go run ./genjobs \
   --modifier=release-1.4_priv \
   --labels preset-enable-netrc=true \
   --job-type postsubmit \
-  --env GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
+  --env BAZEL_BUILD_RBE_JOBS=0,GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
   --repo-whitelist proxy
 
 # istio/proxy test jobs(s) - presubmit(s)


### PR DESCRIPTION
disable RBE in private builds until configured and update netrc preset to use appropriate `.netrc` path for `prowbazel` image.