### PR TITLE
enable rerun "deck-private"

### DIFF
--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -30,10 +30,21 @@ spec:
         - --redirect-http-to=prow-private.istio.io
         - --kubeconfig=/etc/kubeconfig/istio-config
         - --gcs-credentials-file=/etc/service-account/service-account.json
-        - --github-token-path=/etc/github/oauth
         - --spyglass
         - --hidden-only
+        - --rerun-creates-job
+        - --oauth-url=/github-login
+        - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy
+        - --github-oauth-config-file=/etc/githuboauth/secret
+        - --cookie-secret=/etc/cookie/secret
         volumeMounts:
+        - name: oauth-config
+          mountPath: /etc/githuboauth
+          readOnly: true
+        - name: cookie-secret
+          mountPath: /etc/cookie
+          readOnly: true
         - name: oauth-token
           mountPath: /etc/github
           readOnly: true
@@ -105,9 +116,15 @@ spec:
               name: deck-oauth-proxy
               key: cookieSecret
       volumes:
+      - name: oauth-config
+        secret:
+          secretName: github-oauth-config-private
       - name: oauth-token
         secret:
           secretName: oauth-token
+      - name: cookie-secret
+        secret:
+          secretName: cookie
       - name: config
         configMap:
           name: config

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --oauth-url=/github-login
         - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
         - --cookie-secret=/etc/cookie/secret
         volumeMounts:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -74,19 +74,22 @@ deck:
   - istio-private
 
   tide_update_period: 1s
-  rerun_auth_config:
-    github_users:
-    - chxchx
-    - cjwagner
-    - fejta
-    - clarketm
-    - chases2
-    - Katharine
-    - bentheelder
-    - michelle192837
-    github_team_slugs:
-    - org: istio
-      slug: maintainers
+  rerun_auth_configs:
+    istio:
+      github_users:
+      - cjwagner
+      - fejta
+      - clarketm
+      - chases2
+      - Katharine
+      - bentheelder
+      - michelle192837
+      github_team_slugs:
+      - org: istio
+        slug: maintainers
+    istio-private:
+      github_orgs:
+      - istio-private
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Still need to:
- [x] create the Oauth app, 
- [x] install the secrets, 
- [x] and add support for configuring the `rerun_auth_config` by Github `repo` or `org` ~https://github.com/kubernetes/test-infra/pull/15393~, ~https://github.com/kubernetes/test-infra/pull/15396~, https://github.com/kubernetes/test-infra/pull/15437

https://github.com/istio/test-infra/blob/8d4d38afcf205ff6e100790f5f7f2a814037c1cc/prow/config.yaml#L47-L55