### PR TITLE
Update prow build-tools image for client-go-1.4

### DIFF
--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.4.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/client-go-1.4.yaml
+++ b/prow/config/jobs/client-go-1.4.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.4
-image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-12T19-29-46
+image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-20T13-58-27
 jobs:
 - command:
   - make


### PR DESCRIPTION
Update prow build-tools image for client-go to pickup latest kubetype-gen changes in istio/tools release-1.4 branch.

