### PR TITLE
override BAZEL_ENVOY_PATH for local envoy tests

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -70,6 +70,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
@@ -109,6 +111,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
@@ -148,6 +152,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
@@ -187,6 +193,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -85,6 +85,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
@@ -130,6 +132,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
@@ -175,6 +179,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
@@ -220,6 +226,8 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
+        - name: BAZEL_ENVOY_PATH
+          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY

--- a/prow/genjobs/gen-private-jobs.sh
+++ b/prow/genjobs/gen-private-jobs.sh
@@ -57,7 +57,7 @@ go run ./genjobs \
   --modifier=master_priv \
   --labels preset-enable-netrc=true \
   --job-type presubmit \
-  --env BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
+  --env BAZEL_ENVOY_PATH=/home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy,BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
   --repo-whitelist proxy
 
 # istio/proxy master build jobs(s) - postsubmit(s)
@@ -77,7 +77,7 @@ go run ./genjobs \
   --modifier=release-1.4_priv \
   --labels preset-enable-netrc=true \
   --job-type presubmit \
-  --env BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
+  --env BAZEL_ENVOY_PATH=/home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy,BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
   --repo-whitelist proxy
 
 # istio/proxy release-1.4 build jobs(s) - postsubmit(s)


### PR DESCRIPTION
There were some changes recently to the `istio/proxy` build process. This is a workaround for testing against an envoy binary from a local source inside of Prow. 

Ideally this logic would live in the `istio/proxy` as part of the build/test logic, but since that logic is convoluted and has the potential to break another build/test mechanic (e.g. circleci or public CI), for now I prefer to simply set `BAZEL_ENVOY_PATH` via the environment.

This fixes the following tests when using a local envoy source:
- `proxy-presubmit_release-1.4`
- `proxy-presubmit-tsan_release-1.4`
- `proxy-presubmit-asan_release-1.4`