### PR TITLE
Revert "override BAZEL_ENVOY_PATH for local envoy tests (#2125)"

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -70,8 +70,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
@@ -111,8 +109,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
@@ -152,8 +148,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
@@ -193,8 +187,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy-wasm
         - name: ENVOY_REPOSITORY

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -85,8 +85,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
@@ -132,8 +130,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
@@ -179,8 +175,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
@@ -226,8 +220,6 @@ presubmits:
         env:
         - name: BAZEL_BUILD_RBE_JOBS
           value: "0"
-        - name: BAZEL_ENVOY_PATH
-          value: /home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY

--- a/prow/genjobs/gen-private-jobs.sh
+++ b/prow/genjobs/gen-private-jobs.sh
@@ -57,7 +57,7 @@ go run ./genjobs \
   --modifier=master_priv \
   --labels preset-enable-netrc=true \
   --job-type presubmit \
-  --env BAZEL_ENVOY_PATH=/home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy,BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
+  --env BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/envoyproxy/envoy-wasm,ENVOY_PREFIX=envoy-wasm \
   --repo-whitelist proxy
 
 # istio/proxy master build jobs(s) - postsubmit(s)
@@ -77,7 +77,7 @@ go run ./genjobs \
   --modifier=release-1.4_priv \
   --labels preset-enable-netrc=true \
   --job-type presubmit \
-  --env BAZEL_ENVOY_PATH=/home/prow/go/src/istio.io/proxy/bazel-bin/src/envoy/envoy,BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
+  --env BAZEL_BUILD_RBE_JOBS=0,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
   --repo-whitelist proxy
 
 # istio/proxy release-1.4 build jobs(s) - postsubmit(s)


### PR DESCRIPTION
This reverts commit 1b088eaaed888349322a03729412cd1cd2b965c3.

This workaround is no longer needed ~once~ since https://github.com/istio/proxy/pull/2578 ~goes~ went through.