### PR TITLE
disable circleci required status "istio-private"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -238,7 +238,10 @@ branch-protection:
     istio-private:
       required_pull_request_reviews: *protection_required_pull_request_reviews
       restrictions: *protection_restrictions
-      repos: *protection_repos
+      repos:
+        <<: *protection_repos
+        proxy:
+          required_status_checks:
 
 tide:
   queries:


### PR DESCRIPTION
This disables the `circleci` required status context for `istio-private/proxy` branches ... since it is not needed at the moment.