### PR TITLE
Use builder image for tools build

### DIFF
--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
           limits:
@@ -263,7 +263,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -22,6 +22,7 @@ jobs:
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [gcp]
+    image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
 
   - name: containers-test
     type: presubmit
@@ -29,6 +30,7 @@ jobs:
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [gcp]
+    image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
 
 resources:
   build:


### PR DESCRIPTION
For some reason just changing the image and doubling the resources made
the build 3x+ slower. I assume it was not a result of the resources
increasing, so reverting just the image change. If this fixes the
problem we should investigate why its so much slower.