### PR TITLE
Add var/lib/docker mount for docker jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -872,8 +872,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - branches:
     - ^master$
     clone_uri: git@github.com:istio-private/istio.git
@@ -903,8 +909,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - branches:
     - ^master$
     clone_uri: git@github.com:istio-private/istio.git
@@ -934,8 +946,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - branches:
     - ^master$
     clone_uri: git@github.com:istio-private/istio.git
@@ -965,8 +983,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - branches:
     - ^master$
     clone_uri: git@github.com:istio-private/istio.git
@@ -996,8 +1020,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - branches:
     - ^master$
     clone_uri: git@github.com:istio-private/istio.git
@@ -1027,8 +1057,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - branches:
     - ^master$
     clone_uri: git@github.com:istio-private/istio.git
@@ -1888,8 +1924,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     branches:
     - ^master$
@@ -1920,8 +1962,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     branches:
     - ^master$
@@ -1952,8 +2000,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     branches:
     - ^master$
@@ -1984,8 +2038,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     branches:
     - ^master$
@@ -2963,8 +3023,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     branches:
     - ^master$

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -812,8 +812,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -840,8 +846,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -868,8 +880,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -896,8 +914,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -924,8 +948,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -952,8 +982,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -1753,8 +1789,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1780,8 +1822,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1807,8 +1855,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1834,8 +1888,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2718,8 +2778,14 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -138,8 +138,14 @@ postsubmits:
             memory: 4Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio/tools:
   - always_run: true
@@ -155,7 +161,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -181,7 +187,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -207,7 +213,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -233,7 +239,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -263,7 +269,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
+        image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
         name: ""
         resources:
           limits:
@@ -274,5 +280,11 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -24,18 +24,22 @@ jobs:
   - name: integ-framework-local-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.framework.local.presubmit]
+    requirements: [docker]
 
   - name: integ-galley-local-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.galley.local.presubmit]
+    requirements: [docker]
 
   - name: integ-pilot-local-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.pilot.local.presubmit]
+    requirements: [docker]
 
   - name: integ-security-local-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.security.local.presubmit]
+    requirements: [docker]
 
   - name: integ-framework-k8s-tests
     type: presubmit
@@ -147,26 +151,32 @@ jobs:
 
   - name: istio_e2e_cloudfoundry
     command: [entrypoint, make, e2e_cloudfoundry]
+    requirements: [docker]
 
   - name: integ-framework-local-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.framework.local]
+    requirements: [docker]
 
   - name: integ-galley-local-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.galley.local]
+    requirements: [docker]
 
   - name: integ-pilot-local-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.pilot.local]
+    requirements: [docker]
 
   - name: integ-security-local-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.security.local]
+    requirements: [docker]
 
   - name: integ-conformance-local-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-local.sh, test.integration.conformance.local]
+    requirements: [docker]
 
   - name: integ-framework-k8s-tests
     type: postsubmit

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: tools
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
+image: gcr.io/istio-testing/build-tools:master-2019-11-08T17-21-18
 
 jobs:
   - name: build
@@ -21,16 +21,14 @@ jobs:
     command: [entrypoint, make, containers]
     resources: build
     regex: 'docker/.+|cmd/.+'
-    requirements: [gcp]
-    image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
+    requirements: [gcp, docker]
 
   - name: containers-test
     type: presubmit
     command: [entrypoint, make, containers-test]
     resources: build
     regex: 'docker/.+|cmd/.+'
-    requirements: [gcp]
-    image: gcr.io/istio-testing/istio-builder:v20190807-7d818206
+    requirements: [gcp, docker]
 
 resources:
   build:


### PR DESCRIPTION
This adds a new `requirements: docker` option to the config. Right now
this adds a /var/lib/docker mount, which is already being done for kind
jobs. This is why we have not had problems already; there are very few
jobs running docker without kind.

Fixes https://github.com/istio/istio/issues/19236 (hopefully?)