### PR TITLE
Enable "allow_cancellations", and suppress warning

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,5 +1,6 @@
 ---
 plank:
+  allow_cancellations: true
   job_url_template: 'https://prow.istio.io/view/gcs/istio-prow{{if eq .Spec.Type "presubmit"}}/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/pr-logs/pull/batch{{else}}/logs{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
   job_url_prefix_config:
     '*': https://prow.istio.io/view/gcs/


### PR DESCRIPTION
Suppress the warning message and enable this useful feature.

fix #2115

https://github.com/kubernetes/test-infra/blob/93c6c43b21f60e4ff2f7955f6fd7660d2290c6bb/prow/config/config.go#L1261-L1263
