### PR TITLE
Update istio postsubmits

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1476,59 +1476,6 @@ postsubmits:
       ssh_key_secrets:
       - ssh-key-secret
       timeout: 4h0m0s
-    name: integ-k8s-112_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --node-image
-        - kindest/node:v1.12.10
-        - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-      timeout: 4h0m0s
     name: integ-k8s-113_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1537,7 +1484,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.13.10
+        - kindest/node:v1.13.12
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
@@ -1590,7 +1537,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.14.6
+        - kindest/node:v1.14.9
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
@@ -1635,7 +1582,7 @@ postsubmits:
       ssh_key_secrets:
       - ssh-key-secret
       timeout: 4h0m0s
-    name: integ-k8s-116_istio_postsubmit_priv
+    name: integ-k8s-115_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1643,7 +1590,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.16.2
+        - kindest/node:v1.15.6
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
@@ -1696,8 +1643,59 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.17.0-beta.1
+        - gcr.io/istio-testing/kind-node:v1.17.0-rc.1
         - test.integration.kube.presubmit
+        image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: istio-private-build
+      ssh_key_secrets:
+      - ssh-key-secret
+      timeout: 4h0m0s
+    name: integ-k8s-operator_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.operator
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1375,57 +1375,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-112_istio_postsubmit
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --node-image
-        - kindest/node:v1.12.10
-        - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_istio_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
     name: integ-k8s-113_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -1434,7 +1383,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.13.10
+        - kindest/node:v1.13.12
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
@@ -1485,7 +1434,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.14.6
+        - kindest/node:v1.14.9
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
@@ -1528,7 +1477,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-116_istio_postsubmit
+    name: integ-k8s-115_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1536,7 +1485,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.16.2
+        - kindest/node:v1.15.6
         - test.integration.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
@@ -1587,8 +1536,57 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.17.0-beta.1
+        - gcr.io/istio-testing/kind-node:v1.17.0-rc.1
         - test.integration.kube.presubmit
+        image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-operator_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.operator
         image: gcr.io/istio-testing/build-tools:master-2019-11-25T15-38-58
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -221,24 +221,13 @@ jobs:
     # The node image must be kept in sync with the kind version we use.
     # See docker/istio/shared/tools/install-golang.sh for the kind image
     # https://github.com/kubernetes-sigs/kind/releases for node corresponding node image
-  - name: integ-k8s-112
-    type: postsubmit
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --node-image
-      - kindest/node:v1.12.10
-      - test.integration.kube.presubmit
-    requirements: [kind]
-    timeout: 4h
-
   - name: integ-k8s-113
     type: postsubmit
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.13.10
+      - kindest/node:v1.13.12
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -249,18 +238,18 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.14.6
+      - kindest/node:v1.14.9
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
 
-  - name: integ-k8s-116
+  - name: integ-k8s-115
     type: postsubmit
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.16.2
+      - kindest/node:v1.15.6
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -273,8 +262,17 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.17.0-beta.1
+      - gcr.io/istio-testing/kind-node:v1.17.0-rc.1
       - test.integration.kube.presubmit
+    requirements: [kind]
+    timeout: 4h
+
+  - name: integ-k8s-operator
+    type: postsubmit
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - test.integration.operator
     requirements: [kind]
     timeout: 4h
 


### PR DESCRIPTION
* Use new kind v0.6.0 node images
* Replace v16 test with v15, as v16 is now the default
* Update to 1.17-rc.1
* Replace v12 test (way out of our support window) with operator test

waiting on https://github.com/istio/istio/pull/18991