### PR TITLE
update "release-builder" jobs w/ env overrides

### DIFF
--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -11,8 +11,6 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
     name: lint_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -43,8 +41,6 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
     name: test_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -75,8 +71,6 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
     name: gencheck_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -108,40 +102,7 @@ postsubmits:
       ssh_key_secrets:
       - ssh-key-secret
     labels:
-      preset-override-envoy: "true"
-      preset-service-account: "true"
-    name: dry-run_release-builder_postsubmit_priv
-    path_alias: istio.io/release-builder
-    run_if_changed: \.go$|\.sh$
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
+      preset-override-deps: release-1.4
       preset-override-envoy: "true"
       preset-release-pipeline: "true"
     name: build-release_release-builder_postsubmit_priv
@@ -152,40 +113,11 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-      preset-release-pipeline: "true"
-    name: publish-release_release-builder_postsubmit_priv
-    path_alias: istio.io/release-builder
-    run_if_changed: ^release/trigger-publish$
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - release/publish.sh
+        env:
+        - name: GCS_BUCKET
+          value: istio-private-prerelease/prerelease
+        - name: PRERELEASE_DOCKER_HUB
+          value: gcr.io/istio-prow-build
         image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
         name: ""
         resources:
@@ -305,40 +237,6 @@ presubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-service-account: "true"
-    name: dry-run_release-builder_priv
-    path_alias: istio.io/release-builder
-    run_if_changed: \.go$|\.sh$
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: false
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: build-warning_release-builder_priv
     optional: true
     path_alias: istio.io/release-builder
@@ -347,38 +245,11 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: false
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    name: publish-warning_release-builder_priv
-    optional: true
-    path_alias: istio.io/release-builder
-    run_if_changed: ^release/trigger-publish$
-    spec:
-      containers:
-      - command:
-        - release/publish-warning.sh
+        env:
+        - name: GCS_BUCKET
+          value: istio-private-prerelease/prerelease
+        - name: PRERELEASE_DOCKER_HUB
+          value: gcr.io/istio-prow-build
         image: gcr.io/istio-testing/build-tools:2019-10-24T14-05-17
         name: ""
         resources:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.4.gen.yaml
@@ -11,8 +11,6 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
     name: lint_release-builder_release-1.4_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -43,8 +41,6 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
     name: test_release-builder_release-1.4_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -75,8 +71,6 @@ postsubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
     name: gencheck_release-builder_release-1.4_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -108,40 +102,7 @@ postsubmits:
       ssh_key_secrets:
       - ssh-key-secret
     labels:
-      preset-override-envoy: "true"
-      preset-service-account: "true"
-    name: dry-run_release-builder_release-1.4_postsubmit_priv
-    path_alias: istio.io/release-builder
-    run_if_changed: \.go$|\.sh$
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-05T22-47-16
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - branches:
-    - ^release-1.4$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
+      preset-override-deps: release-1.4
       preset-override-envoy: "true"
       preset-release-pipeline: "true"
     name: build-release_release-builder_release-1.4_postsubmit_priv
@@ -152,40 +113,11 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-05T22-47-16
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - branches:
-    - ^release-1.4$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-      preset-release-pipeline: "true"
-    name: publish-release_release-builder_release-1.4_postsubmit_priv
-    path_alias: istio.io/release-builder
-    run_if_changed: ^release/trigger-publish$
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - release/publish.sh
+        env:
+        - name: GCS_BUCKET
+          value: istio-private-prerelease/prerelease
+        - name: PRERELEASE_DOCKER_HUB
+          value: gcr.io/istio-prow-build
         image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-05T22-47-16
         name: ""
         resources:
@@ -305,40 +237,6 @@ presubmits:
         bucket: istio-private-build
       ssh_key_secrets:
       - ssh-key-secret
-    labels:
-      preset-service-account: "true"
-    name: dry-run_release-builder_release-1.4_priv
-    path_alias: istio.io/release-builder
-    run_if_changed: \.go$|\.sh$
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-05T22-47-16
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: false
-    branches:
-    - ^release-1.4$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: build-warning_release-builder_release-1.4_priv
     optional: true
     path_alias: istio.io/release-builder
@@ -347,38 +245,11 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-05T22-47-16
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        testing: test-pool
-  - always_run: false
-    branches:
-    - ^release-1.4$
-    clone_uri: git@github.com:istio-private/release-builder.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    name: publish-warning_release-builder_release-1.4_priv
-    optional: true
-    path_alias: istio.io/release-builder
-    run_if_changed: ^release/trigger-publish$
-    spec:
-      containers:
-      - command:
-        - release/publish-warning.sh
+        env:
+        - name: GCS_BUCKET
+          value: istio-private-prerelease/prerelease
+        - name: PRERELEASE_DOCKER_HUB
+          value: gcr.io/istio-prow-build
         image: gcr.io/istio-testing/build-tools:release-1.4-2019-11-05T22-47-16
         name: ""
         resources:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -479,6 +479,14 @@ presets:
       secretKeyRef:
         name: authentikos-token
         key: token
+- labels:
+    preset-override-deps: "release-1.4"
+  env:
+  - name: DEPENDENCIES
+    valueFrom:
+      configMapKeyRef:
+        name: release-1.4-deps
+        key: dependencies
 # Enable GOPROXY by default
 - env:
   - name: GOPROXY

--- a/prow/genjobs/gen-private-jobs.sh
+++ b/prow/genjobs/gen-private-jobs.sh
@@ -91,15 +91,37 @@ go run ./genjobs \
   --env BAZEL_BUILD_RBE_JOBS=0,GCS_BUILD_BUCKET=istio-private-build,GCS_ARTIFACTS_BUCKET=istio-private-artifacts,DOCKER_REPOSITORY=istio-prow-build/envoy,ENVOY_REPOSITORY=https://github.com/istio-private/envoy,ENVOY_PREFIX=envoy \
   --repo-whitelist proxy
 
+# istio/release-builder master test jobs(s) - pre/postsubmit(s)
+go run ./genjobs \
+  "${COMMON_OPTS[@]}" \
+  --branches=master \
+  --job-type presubmit,postsubmit \
+  --repo-whitelist release-builder \
+  --job-whitelist lint_release-builder,lint_release-builder_postsubmit,test_release-builder,test_release-builder_postsubmit,gencheck_release-builder,gencheck_release-builder_postsubmit
+
+# istio/release-builder release-1.4 test jobs(s) - pre/postsubmit(s)
+go run ./genjobs \
+  "${COMMON_OPTS[@]}" \
+  --branches=release-1.4 \
+  --job-type presubmit,postsubmit \
+  --repo-whitelist release-builder \
+  --job-whitelist lint_release-builder_release-1.4,lint_release-builder_release-1.4_postsubmit,test_release-builder_release-1.4,test_release-builder_release-1.4_postsubmit,gencheck_release-builder_release-1.4,gencheck_release-builder_release-1.4_postsubmit
+
+# istio/release-builder build warning jobs(s) - presubmit(s)
+go run ./genjobs \
+  "${COMMON_OPTS[@]}" \
+  --branches=release-1.4,master \
+  --env PRERELEASE_DOCKER_HUB=gcr.io/istio-prow-build,GCS_BUCKET=istio-private-prerelease/prerelease \
+  --job-type presubmit \
+  --repo-whitelist release-builder \
+  --job-whitelist build-warning_release-builder,build-warning_release-builder_release-1.4
+
 # istio/release-builder build jobs(s) - postsubmit(s)
 go run ./genjobs \
   "${COMMON_OPTS[@]}" \
-  --labels preset-override-envoy=true \
+  --branches=release-1.4,master \
+  --labels preset-override-envoy=true,preset-override-deps=release-1.4 \
+  --env PRERELEASE_DOCKER_HUB=gcr.io/istio-prow-build,GCS_BUCKET=istio-private-prerelease/prerelease \
   --job-type postsubmit \
-  --repo-whitelist release-builder
-
-# istio/release-builder test jobs(s) - presubmit(s)
-go run ./genjobs \
-  "${COMMON_OPTS[@]}" \
-  --job-type presubmit \
-  --repo-whitelist release-builder
+  --repo-whitelist release-builder \
+  --job-whitelist build-release_release-builder_release-1.4_postsubmit,build-release_release-builder_postsubmit


### PR DESCRIPTION
Dependent on changes to`istio/release-builder` https://github.com/istio/release-builder/pull/85

> **Note:** I have a follow-up `sort` PR (https://github.com/istio/test-infra/pull/2160) that will ensure the job order is deterministic regardless of execution order. 