### PR TITLE
Add Transfigure Presubmit

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -19,6 +19,27 @@ presubmits:
         - --exclude-warning=mismatched-tide
         - --exclude-warning=non-decorated-jobs
 
+
+  - name: pull-test-infra-check-testgrid-config
+    run_if_changed: '^(prow/cluster/jobs/.*\.yaml)|(testgrid/default\.yaml)$'
+    decorate: true
+    optional: true
+    branches:
+    - master
+    annotations:
+      testgrid-create-test-group: "false"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/transfigure
+        command:
+        - /transfigure.sh
+        args:
+        - test
+        - prow/config.yaml
+        - prow/cluster/jobs
+        - testgrid/default.yaml
+        - istio
+
   - name: flakey-run
     branches:
       - ^master$


### PR DESCRIPTION
Adds optional (for now) testing presubmit for Transfigure

Addresses #2140
Depends on https://github.com/kubernetes/test-infra/pull/15471
/hold