### PR TITLE
Authentikos: use SA until workload identity can be properly configured

### DIFF
--- a/prow/cluster/private/authentikos_deployment.yaml
+++ b/prow/cluster/private/authentikos_deployment.yaml
@@ -41,6 +41,16 @@ spec:
         args:
         - --verbose
         - --secret=authentikos-token
+        - --creds=/etc/creds/service-account.json
         - --namespace=test-pods
         - --scopes=https://www.googleapis.com/auth/devstorage.full_control
         - "--format=Authorization: Bearer %v"
+        volumeMounts:
+        - name: creds
+          mountPath: /etc/creds
+          readOnly: true
+      volumes:
+      - name: creds
+        secret:
+          defaultMode: 0644
+          secretName: service-account


### PR DESCRIPTION
use service account (SA) until workload identity can be properly configured