### PR TITLE
Allow override-selector to remove a node selector

### DIFF
--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -393,11 +393,15 @@ func updateLabels(o options, job *config.JobBase) {
 
 // updateNodeSelector updates the jobs NodeSelector fields based on provided inputs.
 func updateNodeSelector(o options, job *config.JobBase) {
+	if o.overrideSelector {
+		job.Spec.NodeSelector = make(map[string]string)
+	}
+
 	if len(o.selector) == 0 {
 		return
 	}
 
-	if o.overrideSelector || job.Spec.NodeSelector == nil {
+	if job.Spec.NodeSelector == nil {
 		job.Spec.NodeSelector = make(map[string]string)
 	}
 


### PR DESCRIPTION
Right now we return too early so we cannot override a node selector