### PR TITLE
Remove build-pool

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -13,7 +13,7 @@ test_infra_master_spec: &test_infra_master_spec
 
 istio_rel_pipeline_spec: &istio_rel_pipeline_spec
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
   image: gcr.io/istio-testing/build-tools:2019-10-18T14-31-21

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -45,7 +45,7 @@ postsubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 presubmits:
   istio-private/proxy:
   - always_run: true
@@ -86,7 +86,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     branches:
     - ^master$
@@ -125,7 +125,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     branches:
     - ^master$
@@ -164,7 +164,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     branches:
     - ^master$
@@ -203,4 +203,4 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -52,7 +52,7 @@ postsubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 presubmits:
   istio-private/proxy:
   - always_run: true
@@ -99,7 +99,7 @@ presubmits:
             cpu: "8"
             memory: 8Gi
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     branches:
     - ^release-1.4$
@@ -144,7 +144,7 @@ presubmits:
             cpu: "8"
             memory: 8Gi
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     branches:
     - ^release-1.4$
@@ -189,7 +189,7 @@ presubmits:
             cpu: "8"
             memory: 8Gi
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     branches:
     - ^release-1.4$
@@ -234,4 +234,4 @@ presubmits:
             cpu: "8"
             memory: 8Gi
       nodeSelector:
-        testing: build-pool
+        testing: test-pool

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.1.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
 
 istio_rel_pipeline_spec: &istio_rel_pipeline_spec
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
   image: gcr.io/istio-testing/istio-builder:v20190823-25f7c637

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.2.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
 
 istio_rel_pipeline_spec: &istio_rel_pipeline_spec
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
   image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.3.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.3.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
 
 istio_rel_pipeline_spec: &istio_rel_pipeline_spec
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 istio_rel_pipeline_container: &istio_rel_pipeline_container
   image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.1.yaml
@@ -34,7 +34,7 @@ presubmits:
         - entrypoint
         - prow/istio-unit-tests.sh
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: test-e2e-mixer-no_auth
     <<: *job_template

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 presubmits:
   istio/proxy:
   - always_run: true
@@ -55,7 +55,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -80,7 +80,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -105,7 +105,7 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -130,4 +130,4 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        testing: build-pool
+        testing: test-pool

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.1.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.1.yaml
@@ -17,7 +17,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
         memory: "30Gi"
         cpu: "8000m"
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 bazel_spec: &bazel_spec
   containers:
@@ -37,7 +37,7 @@ bazel_spec: &bazel_spec
         memory: "30Gi"
         cpu: "8000m"
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 branch_spec: &branch_spec
 - "^release-1.1$"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.2.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.2.yaml
@@ -17,7 +17,7 @@ bazel_postsubmit_spec: &bazel_postsubmit_spec
         memory: "24Gi"
         cpu: "7000m"
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 bazel_spec: &bazel_spec
   containers:
@@ -37,7 +37,7 @@ bazel_spec: &bazel_spec
         memory: "24Gi"
         cpu: "7000m"
   nodeSelector:
-    testing: build-pool
+    testing: test-pool
 
 branch_spec: &branch_spec
 - "^release-1.2$"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.3.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.3.yaml
@@ -34,7 +34,7 @@ presubmits:
                 memory: "60Gi"
                 cpu: "16000m"
         nodeSelector:
-          testing: build-pool
+          testing: test-pool
 
     - name: proxy-presubmit-asan
       annotations:
@@ -65,7 +65,7 @@ presubmits:
                 memory: "60Gi"
                 cpu: "16000m"
         nodeSelector:
-          testing: build-pool
+          testing: test-pool
 
     - name: proxy-presubmit-tsan
       annotations:
@@ -96,7 +96,7 @@ presubmits:
                 memory: "60Gi"
                 cpu: "16000m"
         nodeSelector:
-          testing: build-pool
+          testing: test-pool
 
 postsubmits:
 
@@ -135,4 +135,4 @@ postsubmits:
                 memory: "60Gi"
                 cpu: "16000m"
         nodeSelector:
-          testing: build-pool
+          testing: test-pool

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
@@ -34,7 +34,7 @@ presubmits:
             memory: "60Gi"
             cpu: "16000m"
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: proxy-presubmit-asan
     annotations:
@@ -65,7 +65,7 @@ presubmits:
             memory: "60Gi"
             cpu: "16000m"
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: proxy-presubmit-tsan
     annotations:
@@ -96,7 +96,7 @@ presubmits:
             memory: "60Gi"
             cpu: "16000m"
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
   - name: proxy-presubmit-release
     annotations:
@@ -127,7 +127,7 @@ presubmits:
             memory: "60Gi"
             cpu: "16000m"
       nodeSelector:
-        testing: build-pool
+        testing: test-pool
 
 postsubmits:
 
@@ -166,4 +166,4 @@ postsubmits:
             memory: "60Gi"
             cpu: "16000m"
       nodeSelector:
-        testing: build-pool
+        testing: test-pool

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -3,9 +3,6 @@ repo: proxy
 support_release_branching: true
 image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-03T17-07-58
 
-node_selector:
-  testing: build-pool
-
 jobs:
 - name: test
   type: presubmit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,5 +37,5 @@ Example based on current clusters (cluster name, zone etc.):
 - Cleanup Prow cluster:
 
     ```bash
-    $ scripts/cleanup-cache -c prow -z us-west1-a -s cloud.google.com/gke-nodepool=build-pool
+    $ scripts/cleanup-cache -c prow -z us-west1-a -s cloud.google.com/gke-nodepool=test-pool
     ```


### PR DESCRIPTION
Currently we have two node pools: build-pool (20 nodes) used for
istio/proxy, and test-pool (60 nodes) used for everything else. 20 nodes
is probably way to many for proxy, but rather than trying to optimize
this we should just merge the two so we can bin-pack more efficiently