### PR TITLE
Remove trusted_org from prow config.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -8,7 +8,6 @@ triggers:
   - istio-ecosystem
   - istio-releases
   - istio-private
-  trusted_org: istio
 
 config_updater:
   maps:


### PR DESCRIPTION
This will mean that only members of istio-private will be able to auto-start presubmits. An istio member (who is not
also an istio-private member) will need to wait for an /ok-to-test (along with anyone else).

Fixes https://github.com/istio/test-infra/issues/2114