### PR TITLE
Fix release janitor

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -71,7 +71,7 @@ periodics:
     <<: *istio_rel_pipeline_spec
     containers:
     - <<: *istio_rel_pipeline_container
-      image: gcr.io/istio-testing/istio-builder:v20181008-db31a9fd
+      image: gcr.io/istio-testing/build-tools:master-2019-12-04T21-25-52
       env:
       - name: GIT_BRANCH
         value: master


### PR DESCRIPTION
Upgrade to new image using golang 1.13 to fix `go get` command.