### PR TITLE
Remove allow_cancellations: true as its now default behavior

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,6 +1,5 @@
 ---
 plank:
-  allow_cancellations: true
   job_url_template: 'https://prow.istio.io/view/gcs/istio-prow{{if eq .Spec.Type "presubmit"}}/pr-logs/pull/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/pr-logs/pull/batch{{else}}/logs{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}'
   job_url_prefix_config:
     '*': https://prow.istio.io/view/gcs/


### PR DESCRIPTION
This was just to silence the warning message, which we've now fixed upstream.