### PR TITLE
Align perf cluster with standard per machine type.

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -42,8 +42,8 @@ resources:
     content: |
       gcp-perf-test:
         - clusters:
-          - machinetype: n1-highmem-8
-            numnodes: 7
+          - machinetype: n1-standard-32
+            numnodes: 4
             version: 1.13
             zone: us-central1-f
             scopes:


### PR DESCRIPTION
Align perf cluster with n1-standard-32 machine type which is standard in performance tests.