### PR TITLE
migrate velodrome

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -30,6 +30,9 @@ update-config: get-cluster-credentials
 deploy: get-cluster-credentials
 	kubectl apply -f ./cluster/
 
+deploy-velodrome: get-cluster-credentials
+	kubectl apply -f ./cluster/velodrome/
+
 deploy-build: PROJECT=$(PROJECT_BUILD)
 deploy-build: CLUSTER=$(CLUSTER_BUILD)
 deploy-build: get-build-cluster-credentials
@@ -40,4 +43,4 @@ deploy-private: CLUSTER=$(CLUSTER_PRIVATE)
 deploy-private: get-private-cluster-credentials
 	kubectl apply -f ./cluster/private/
 
-.PHONY: gen-private-jobs deploy deploy-build deploy-private update-config update-config-dry-run
+.PHONY: gen-private-jobs deploy deploy-velodrome deploy-build deploy-private update-config update-config-dry-run

--- a/prow/cluster/velodrome/velodrome-istio-io_managedcertificate.yaml
+++ b/prow/cluster/velodrome/velodrome-istio-io_managedcertificate.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: velodrome-istio-io
+  namespace: velodrome
+spec:
+  domains:
+  - velodrome.istio.io

--- a/prow/cluster/velodrome/velodrome_ing.yaml
+++ b/prow/cluster/velodrome/velodrome_ing.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: velodrome-ing
+  namespace: velodrome
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: velodrome
+    networking.gke.io/managed-certificates: velodrome-istio-io
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+  - host: velodrome.istio.io
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: velodrome
+          servicePort: 80

--- a/prow/cluster/velodrome/velodrome_namespace.yaml
+++ b/prow/cluster/velodrome/velodrome_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velodrome

--- a/prow/cluster/velodrome/velodrome_service.yaml
+++ b/prow/cluster/velodrome/velodrome_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: velodrome
+  namespace: velodrome
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: velodrome
+  namespace: velodrome
+subsets:
+- addresses:
+  - ip: 130.211.224.127 # public ip for nginx-istio
+  ports:
+  - port: 80


### PR DESCRIPTION
fix #2207

- [x] Update A record for `velodrome`
- [x] Re-provisioned TLS cert
