### PR TITLE
Update build tools image

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -77,7 +77,7 @@ postsubmits:
         - --repo=client-go
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ postsubmits:
         - --repo=istio
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -156,7 +156,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -182,7 +182,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -165,7 +165,7 @@ postsubmits:
             secretKeyRef:
               key: githubOauthClientSecret
               name: policybot
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -251,7 +251,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -16,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -45,7 +45,7 @@ postsubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -78,7 +78,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -151,7 +151,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -208,7 +208,7 @@ presubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -240,7 +240,7 @@ presubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -311,7 +311,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/installer/istio.installer.master.gen.yaml
+++ b/prow/cluster/jobs/istio/installer/istio.installer.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - run-build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint_modern
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -76,7 +76,7 @@ postsubmits:
         - bin/with-kind.sh
         - make
         - run-test-demo
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ postsubmits:
         - bin/with-kind.sh
         - make
         - run-test-noauth
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -182,7 +182,7 @@ postsubmits:
         - bin/with-kind.sh
         - make
         - run-base-reachability
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -228,7 +228,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -256,7 +256,7 @@ presubmits:
       - command:
         - make
         - run-build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -282,7 +282,7 @@ presubmits:
       - command:
         - make
         - lint_modern
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -315,7 +315,7 @@ presubmits:
         - bin/with-kind.sh
         - make
         - run-test-demo
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -367,7 +367,7 @@ presubmits:
         - bin/with-kind.sh
         - make
         - run-test-noauth
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -419,7 +419,7 @@ presubmits:
         - bin/with-kind.sh
         - make
         - run-base-reachability
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -464,7 +464,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -43,7 +43,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -49,7 +49,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -78,7 +78,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -106,7 +106,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -155,7 +155,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -203,7 +203,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -251,7 +251,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -299,7 +299,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -347,7 +347,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -444,7 +444,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -495,7 +495,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -548,7 +548,7 @@ postsubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -602,7 +602,7 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -656,7 +656,7 @@ postsubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -708,7 +708,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -754,7 +754,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -801,7 +801,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -835,7 +835,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -869,7 +869,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -903,7 +903,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -937,7 +937,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -971,7 +971,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1005,7 +1005,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1052,7 +1052,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1099,7 +1099,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1146,7 +1146,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1193,7 +1193,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1240,7 +1240,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1287,7 +1287,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1338,7 +1338,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.9
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1389,7 +1389,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.15.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1440,7 +1440,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.16.3
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1489,7 +1489,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.operator
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1535,7 +1535,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1562,7 +1562,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1596,7 +1596,7 @@ presubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1623,7 +1623,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1651,7 +1651,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1678,7 +1678,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1711,7 +1711,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1744,7 +1744,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1777,7 +1777,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1824,7 +1824,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1870,7 +1870,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1916,7 +1916,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1962,7 +1962,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2008,7 +2008,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2055,7 +2055,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2102,7 +2102,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2149,7 +2149,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2196,7 +2196,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2243,7 +2243,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2293,7 +2293,7 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2345,7 +2345,7 @@ presubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2398,7 +2398,7 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2451,7 +2451,7 @@ presubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2496,7 +2496,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2542,7 +2542,7 @@ presubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2574,7 +2574,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2600,7 +2600,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - mesh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - mandiff
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -151,7 +151,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -200,7 +200,7 @@ postsubmits:
         - entrypoint
         - make
         - docker.all
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -228,7 +228,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
       - command:
         - make
         - mesh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -280,7 +280,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -306,7 +306,7 @@ presubmits:
       - command:
         - make
         - mandiff
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -359,7 +359,7 @@ presubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -213,7 +213,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -268,7 +268,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -295,7 +295,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -322,7 +322,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -102,7 +102,7 @@ postsubmits:
         - -C
         - authentios
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -141,7 +141,7 @@ postsubmits:
         - -C
         - prow/genjobs
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -175,7 +175,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -227,7 +227,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -161,7 +161,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -213,7 +213,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -269,7 +269,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: api
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: bots
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: client-go
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: cni
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/cri.yaml
+++ b/prow/config/jobs/cri.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: cri
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/installer.yaml
+++ b/prow/config/jobs/installer.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: installer
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio.io
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: lint

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: unit-tests

--- a/prow/config/jobs/operator.yaml
+++ b/prow/config/jobs/operator.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: operator
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: lint

--- a/prow/config/jobs/pkg.yaml
+++ b/prow/config/jobs/pkg.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: pkg
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: release-builder
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: lint

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: test-infra
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: lint

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: tools
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
 
 jobs:
   - name: build


### PR DESCRIPTION
This does not need full common-files rollout pain, the only change is
for the prow entrypoint to properly cleanup containers