### PR TITLE
Add chases2 to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
-*                                    @clarketm @fejta @Katharine @michelle192837
+*                                    @clarketm @fejta @Katharine @michelle192837 @chases2
 Makefile*                            @istio/wg-test-and-release-maintainers
 /common/                             @istio/wg-test-and-release-maintainers
 /docker/                             @istio/wg-test-and-release-maintainers
-/prow/                               @clarketm @cjwagner @fejta @Katharine @michelle192837
+/prow/                               @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
 /prow/config/                        @istio/wg-test-and-release-maintainers
-/prow/config/jobs/test-infra.yaml    @clarketm @cjwagner @fejta @Katharine @michelle192837
-/prow/cluster/                       @clarketm @cjwagner @fejta @Katharine @michelle192837
+/prow/config/jobs/test-infra.yaml    @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
+/prow/cluster/                       @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
 /prow/cluster/jobs/                  @istio/wg-test-and-release-maintainers
-/prow/cluster/jobs/istio/test-infra/ @clarketm @cjwagner @fejta @Katharine @michelle192837
+/prow/cluster/jobs/istio/test-infra/ @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
 /prow/genjobs/                       @istio/wg-test-and-release-maintainers @clarketm


### PR DESCRIPTION
Part of oncall support for Istio's Prow instance.

This will also me, primarily, to approve bump PRs without needing help or [helplessly sending /lgtm comments](https://github.com/istio/test-infra/pull/2239)