### PR TITLE
Use istioctl install for standard integ tests

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1067,6 +1067,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1115,6 +1118,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1163,6 +1169,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1259,6 +1268,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1802,6 +1814,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1850,6 +1865,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1897,6 +1915,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
@@ -1991,6 +2012,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -40,17 +40,26 @@ jobs:
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.galley.kube.presubmit]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-mixer-k8s-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.mixer.kube.presubmit]
     requirements: [kind]
     modifiers: [optional]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-pilot-k8s-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-security-k8s-tests
     type: presubmit
@@ -61,6 +70,9 @@ jobs:
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.telemetry.kube.presubmit]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-new-install-k8s-tests
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.new.installer]
@@ -172,16 +184,25 @@ jobs:
     type: postsubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.galley.kube]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-mixer-k8s-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.mixer.kube]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-pilot-k8s-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-security-k8s-tests
     type: postsubmit
@@ -192,6 +213,9 @@ jobs:
     type: postsubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.telemetry.kube]
     requirements: [kind]
+    env:
+    - name: TEST_USE_OPERATOR
+      value: "true"
 
   - name: integ-conformance-k8s-tests
     type: postsubmit


### PR DESCRIPTION
This is tested in https://github.com/istio/istio/pull/19867 showing that
all tests pass with this enabled (except security, due to known issues,
which is intentionlly left out here).

Helm is still covered by other targets in postsubmit