### PR TITLE
Require TestGrid Presubmit Test

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -23,7 +23,6 @@ presubmits:
   - name: pull-test-infra-check-testgrid-config
     run_if_changed: '^(prow/cluster/jobs/.*\.yaml)|(testgrid/default\.yaml)$'
     decorate: true
-    optional: true
     branches:
     - master
     annotations:


### PR DESCRIPTION
It may be worth it to make this test required, so that the TestGrid config can't fall out of sync and stop working.