### PR TITLE
Use multiple comma-delimited dirs in COMPONENT_FILE_DIR

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -166,7 +166,7 @@ periodics:
       - name: PLANK_DEPLOYMENT_FILE
         value: prow/cluster/plank_deployment.yaml
       - name: COMPONENT_FILE_DIR
-        value: prow/cluster
+        value: prow/cluster,prow/config/jobs
       - name: CONFIG_PATH
         value: prow/config.yaml
       - name: JOB_CONFIG_PATH


### PR DESCRIPTION
Use multiple directories for `COMPONENT_FILE_DIR`.

> Dependent on deployment of https://github.com/kubernetes/test-infra/pull/15800

/hold