### PR TITLE
Fix inrepoconfig branch declaration

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,8 +1,6 @@
 presubmits:
 
 - name: pull-test-infra-prow-checkconfig
-  branches:
-  - ^master$
   decorate: true
   run_if_changed: '^(\.prow|prow/(config|plugins|cluster/jobs/.*))\.yaml$'
   spec:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 *                                    @clarketm @fejta @Katharine @michelle192837 @chases2
+.prow.yaml                           @istio/wg-test-and-release-maintainers
 Makefile*                            @istio/wg-test-and-release-maintainers
 /common/                             @istio/wg-test-and-release-maintainers
 /docker/                             @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Tide is currently erroring with the following blocking merges for this repo (which makes sense in retrospect since the config is versioned in the repo):
```console
{
 insertId: "u3a4egeefrvk4"  
 jsonPayload: {
  component: "tide"   
  controller: "status-update"   
  error: "failed to get presubmits: job "pull-test-infra-prow-checkconfig" contains branchconfig. This is not allowed for jobs in ".prow.yaml""   
  file: "prow/tide/status.go:343"   
  func: "k8s.io/test-infra/prow/tide.(*statusController).setStatuses.func1"   
  level: "error"   
  msg: "setting up context register"   
  org: "istio"   
  pr: 2260   
  repo: "test-infra"   
  sha: "4f54f35f9f953eb9e39aa12e9bbf0ba9ab98dcf0"   
 }
 labels: {…}  
 logName: "projects/istio-testing/logs/tide"  
 receiveTimestamp: "2020-01-08T17:26:27.009367012Z"  
 resource: {…}  
 severity: "ERROR"  
 timestamp: "2020-01-08T17:26:25Z"  
}
```