### PR TITLE
Fix automator istio/api update naming

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -75,6 +75,8 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=client-go
+        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency'
+        - --modifier=client-go_update_api
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
@@ -118,6 +120,8 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio
+        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency'
+        - --modifier=istio_update_api
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
         image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -16,6 +16,8 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=client-go
+    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency"
+    - --modifier=client-go_update_api
     - --token-path=/etc/github-token/oauth
     - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
     requirements: [github]
@@ -27,6 +29,8 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio
+    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency"
+    - --modifier=istio_update_api
     - --token-path=/etc/github-token/oauth
     - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
     requirements: [github]


### PR DESCRIPTION
fix #2262

> Dependent on #2223 which adds the `modifier` flag and fixes PR updating currently plaguing this tool.