### PR TITLE
Use "default_decoration_configs" for istio-private

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -8,11 +8,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-ssh: "true"
       preset-service-account: "true"
@@ -28,7 +23,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -48,11 +43,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: unit-tests_istio_postsubmit_priv
@@ -68,7 +58,7 @@ postsubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -88,11 +78,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: codecov_istio_postsubmit_priv
@@ -103,7 +88,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -123,11 +108,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-new-install-k8s-tests_istio_postsubmit_priv
@@ -138,7 +118,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -155,6 +135,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -177,11 +158,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -193,7 +169,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -210,6 +186,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -232,11 +209,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-mixer-no_auth_istio_postsubmit_priv
@@ -248,7 +220,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -265,6 +237,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -287,11 +260,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: pilot-e2e-envoyv2-v1alpha3_istio_postsubmit_priv
@@ -303,7 +271,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -320,6 +288,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -342,11 +311,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-dashboard_istio_postsubmit_priv
@@ -358,7 +322,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -375,6 +339,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -397,11 +362,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_postsubmit_priv
@@ -413,7 +373,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -430,6 +390,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -452,11 +413,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-trustdomain_istio_postsubmit_priv
@@ -468,7 +424,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -485,6 +441,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -507,11 +464,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-non-mcp_istio_postsubmit_priv
@@ -524,7 +476,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -541,6 +493,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -563,11 +516,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests_istio_postsubmit_priv
@@ -582,7 +530,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -599,6 +547,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -621,11 +570,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-distroless_istio_postsubmit_priv
@@ -642,7 +586,7 @@ postsubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -659,6 +603,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -681,11 +626,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTestsMinProfile_istio_postsubmit_priv
@@ -703,7 +643,7 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -720,6 +660,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -742,11 +683,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-cni_istio_postsubmit_priv
@@ -764,7 +700,7 @@ postsubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -781,6 +717,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -803,11 +740,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-non-mcp_istio_postsubmit_priv
@@ -823,7 +755,7 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -840,6 +772,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -862,11 +795,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: pilot-multicluster-e2e_istio_postsubmit_priv
@@ -876,7 +804,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -893,6 +821,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -915,93 +844,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: istio_e2e_cloudfoundry_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: integ-framework-local-tests_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-local.sh
-        - test.integration.framework.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-local-tests_istio_postsubmit_priv
@@ -1012,7 +854,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1038,11 +880,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-local-tests_istio_postsubmit_priv
@@ -1053,7 +890,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1079,11 +916,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-local-tests_istio_postsubmit_priv
@@ -1094,7 +926,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1120,11 +952,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-conformance-local-tests_istio_postsubmit_priv
@@ -1135,7 +962,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1161,119 +988,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: integ-framework-k8s-tests_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.framework.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: integ-istioctl-k8s-tests_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.istioctl.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-k8s-tests_istio_postsubmit_priv
@@ -1284,7 +998,10 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1301,6 +1018,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1323,11 +1041,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-mixer-k8s-tests_istio_postsubmit_priv
@@ -1338,7 +1051,10 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1355,6 +1071,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1377,11 +1094,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-k8s-tests_istio_postsubmit_priv
@@ -1392,7 +1104,10 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1409,6 +1124,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1431,11 +1147,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_postsubmit_priv
@@ -1446,7 +1157,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1463,6 +1174,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1485,11 +1197,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-telemetry-k8s-tests_istio_postsubmit_priv
@@ -1500,7 +1207,10 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1517,6 +1227,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1539,11 +1250,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-conformance-k8s-tests_istio_postsubmit_priv
@@ -1554,7 +1260,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1571,6 +1277,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1594,67 +1301,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-      timeout: 4h0m0s
-    labels:
-      preset-override-envoy: "true"
-    name: integ-k8s-113_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --node-image
-        - kindest/node:v1.13.12
-        - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1668,7 +1314,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.9
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1685,6 +1331,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1708,10 +1355,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1725,7 +1368,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.15.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1742,6 +1385,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1765,14 +1409,10 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
-    name: integ-k8s-117_istio_postsubmit_priv
+    name: integ-k8s-116_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1780,9 +1420,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.17.0
+        - kindest/node:v1.16.3
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1799,6 +1439,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1822,10 +1463,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1837,7 +1474,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.operator
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1854,6 +1491,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1876,11 +1514,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: lint_istio_postsubmit_priv
@@ -1890,7 +1523,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1910,11 +1543,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: gencheck_istio_postsubmit_priv
@@ -1924,7 +1552,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1947,11 +1575,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: unit-tests_istio_priv
@@ -1967,7 +1590,7 @@ presubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -1988,11 +1611,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: codecov_istio_priv
@@ -2003,7 +1621,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2024,11 +1642,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -2039,7 +1652,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2060,53 +1673,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: integ-framework-local-tests_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-local.sh
-        - test.integration.framework.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-local-tests_istio_priv
@@ -2117,7 +1683,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2144,11 +1710,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-local-tests_istio_priv
@@ -2159,7 +1720,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2186,11 +1747,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-local-tests_istio_priv
@@ -2201,7 +1757,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2228,121 +1784,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: integ-framework-k8s-tests_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.framework.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: integ-istioctl-k8s-tests_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.istioctl.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-k8s-tests_istio_priv
@@ -2353,7 +1794,10 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2370,6 +1814,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2393,11 +1838,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-mixer-k8s-tests_istio_priv
@@ -2409,7 +1849,10 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2426,6 +1869,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2449,11 +1893,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-k8s-tests_istio_priv
@@ -2464,7 +1903,10 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2481,6 +1923,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2504,11 +1947,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_priv
@@ -2519,7 +1957,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2536,6 +1974,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2559,11 +1998,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-telemetry-k8s-tests_istio_priv
@@ -2574,7 +2008,10 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        env:
+        - name: TEST_USE_OPERATOR
+          value: "true"
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2591,6 +2028,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2614,11 +2052,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-new-install-k8s-tests_istio_priv
@@ -2629,7 +2062,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2646,6 +2079,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2669,11 +2103,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-istioio-k8s-tests_istio_priv
@@ -2685,7 +2114,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2702,6 +2131,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2725,11 +2155,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-mixer-no_auth_istio_priv
@@ -2741,7 +2166,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2758,6 +2183,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2781,11 +2207,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: pilot-e2e-envoyv2-v1alpha3_istio_priv
@@ -2797,7 +2218,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2814,6 +2235,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2837,11 +2259,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-dashboard_istio_priv
@@ -2853,7 +2270,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2870,6 +2287,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2893,11 +2311,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_priv
@@ -2909,7 +2322,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2926,6 +2339,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2949,11 +2363,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests_istio_priv
@@ -2968,7 +2377,7 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -2985,6 +2394,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3008,11 +2418,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-distroless_istio_priv
@@ -3029,7 +2434,7 @@ presubmits:
         - helm
         - --variant
         - distroless
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -3046,6 +2451,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3069,11 +2475,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTestsMinProfile_istio_priv
@@ -3091,7 +2492,7 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -3108,6 +2509,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3131,11 +2533,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-cni_istio_priv
@@ -3153,7 +2550,7 @@ presubmits:
           value: "true"
         - name: E2E_ARGS
           value: ' --kube_inject_configmap=istio-sidecar-injector'
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -3170,6 +2567,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3193,11 +2591,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: pilot-multicluster-e2e_istio_priv
@@ -3207,7 +2600,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -3224,6 +2617,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3247,53 +2641,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
-    labels:
-      preset-override-envoy: "true"
-    name: istio_e2e_cloudfoundry_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - e2e_cloudfoundry
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
-        name: ""
-        resources:
-          limits:
-            cpu: "8"
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: lint_istio_priv
@@ -3303,7 +2650,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -3324,11 +2671,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: gencheck_istio_priv
@@ -3338,7 +2680,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-11T03-52-26
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.4.gen.yaml
@@ -8,11 +8,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-ssh: "true"
       preset-service-account: "true"
@@ -48,11 +43,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.4_postsubmit_priv
@@ -88,11 +78,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: codecov_istio_release-1.4_postsubmit_priv
@@ -123,11 +108,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-mixer-no_auth_istio_release-1.4_postsubmit_priv
@@ -156,6 +136,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -178,11 +159,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: pilot-e2e-envoyv2-v1alpha3_istio_release-1.4_postsubmit_priv
@@ -211,6 +187,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -233,11 +210,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -265,6 +237,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -287,11 +260,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.4_posts_priv
@@ -320,6 +288,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -342,11 +311,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-trustdomain_istio_release-1.4_postsubmit_priv
@@ -375,6 +339,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -397,11 +362,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-non-mcp_istio_release-1.4_postsubmit_priv
@@ -431,6 +391,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -453,11 +414,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests_istio_release-1.4_postsubmit_priv
@@ -489,6 +445,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -511,11 +468,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-distroless_istio_release-1.4_postsubmit_priv
@@ -549,6 +501,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -571,11 +524,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTestsMinProfile_istio_release-1.4_postsubmit_priv
@@ -610,6 +558,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -632,11 +581,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-cni_istio_release-1.4_postsubmit_priv
@@ -671,6 +615,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -693,11 +638,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-non-mcp_istio_release-1.4_postsubmit_priv
@@ -730,6 +670,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -752,11 +693,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -784,6 +720,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -806,11 +743,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: istio_e2e_cloudfoundry_istio_release-1.4_postsubmit_priv
@@ -841,11 +773,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-framework-local-tests_istio_release-1.4_postsubmit_priv
@@ -876,11 +803,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-local-tests_istio_release-1.4_postsubmit_priv
@@ -911,11 +833,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-local-tests_istio_release-1.4_postsubmit_priv
@@ -946,11 +863,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-local-tests_istio_release-1.4_postsubmit_priv
@@ -981,11 +893,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-conformance-local-tests_istio_release-1.4_postsubmit_priv
@@ -1016,11 +923,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-framework-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1048,6 +950,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1070,11 +973,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-istioctl-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1102,6 +1000,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1124,11 +1023,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1156,6 +1050,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1178,11 +1073,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-mixer-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1210,6 +1100,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1232,11 +1123,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1264,6 +1150,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1286,11 +1173,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1318,6 +1200,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1340,11 +1223,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-telemetry-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1372,6 +1250,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1394,11 +1273,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-conformance-k8s-tests_istio_release-1.4_postsubmit_priv
@@ -1426,6 +1300,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1449,10 +1324,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1483,6 +1354,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1506,10 +1378,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1540,6 +1408,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1563,10 +1432,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1597,6 +1462,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1620,10 +1486,6 @@ postsubmits:
     cluster: private
     decorate: true
     decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
       timeout: 4h0m0s
     labels:
       preset-override-envoy: "true"
@@ -1654,6 +1516,7 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1676,11 +1539,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: lint_istio_release-1.4_postsubmit_priv
@@ -1710,11 +1568,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.4_postsubmit_priv
@@ -1747,11 +1600,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.4_priv
@@ -1788,11 +1636,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: codecov_istio_release-1.4_priv
@@ -1824,11 +1667,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -1860,11 +1698,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-framework-local-tests_istio_release-1.4_priv
@@ -1896,11 +1729,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-local-tests_istio_release-1.4_priv
@@ -1932,11 +1760,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-local-tests_istio_release-1.4_priv
@@ -1968,11 +1791,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-local-tests_istio_release-1.4_priv
@@ -2004,11 +1822,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-framework-k8s-tests_istio_release-1.4_priv
@@ -2036,6 +1849,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2059,11 +1873,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-istioctl-k8s-tests_istio_release-1.4_priv
@@ -2091,6 +1900,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2114,11 +1924,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-galley-k8s-tests_istio_release-1.4_priv
@@ -2146,6 +1951,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2169,11 +1975,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-mixer-k8s-tests_istio_release-1.4_priv
@@ -2202,6 +2003,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2225,11 +2027,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-pilot-k8s-tests_istio_release-1.4_priv
@@ -2257,6 +2054,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2280,11 +2078,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_release-1.4_priv
@@ -2312,6 +2105,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2335,11 +2129,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-telemetry-k8s-tests_istio_release-1.4_priv
@@ -2367,6 +2156,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2390,11 +2180,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-new-install-k8s-tests_istio_release-1.4_priv
@@ -2423,6 +2208,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2446,11 +2232,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: integ-istioio-k8s-tests_istio_release-1.4_priv
@@ -2479,6 +2260,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2502,11 +2284,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-mixer-no_auth_istio_release-1.4_priv
@@ -2535,6 +2312,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2558,11 +2336,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: pilot-e2e-envoyv2-v1alpha3_istio_release-1.4_priv
@@ -2591,6 +2364,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2614,11 +2388,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -2646,6 +2415,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2669,11 +2439,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.4_priv
@@ -2702,6 +2467,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2725,11 +2491,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests_istio_release-1.4_priv
@@ -2761,6 +2522,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2784,11 +2546,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-distroless_istio_release-1.4_priv
@@ -2822,6 +2579,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2845,11 +2603,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTestsMinProfile_istio_release-1.4_priv
@@ -2884,6 +2637,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2907,11 +2661,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: e2e-simpleTests-cni_istio_release-1.4_priv
@@ -2946,6 +2695,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2969,11 +2719,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
       preset-service-account: "true"
@@ -3002,6 +2747,7 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3025,11 +2771,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: istio_e2e_cloudfoundry_istio_release-1.4_priv
@@ -3061,11 +2802,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: lint_istio_release-1.4_priv
@@ -3096,11 +2832,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.4_priv

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -8,11 +8,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
@@ -21,6 +16,7 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit.sh
         env:
         - name: BAZEL_BUILD_RBE_JOBS
@@ -35,7 +31,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
         name: ""
         resources:
           limits:
@@ -46,8 +42,14 @@ postsubmits:
             memory: 8Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio-private/proxy:
   - always_run: true
@@ -58,11 +60,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-netrc: "true"
     name: test_proxy_master_priv
@@ -78,7 +75,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
         name: ""
         resources:
           limits:
@@ -99,11 +96,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-netrc: "true"
     name: test-asan_proxy_master_priv
@@ -119,7 +111,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
         name: ""
         resources:
           limits:
@@ -140,11 +132,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_master_priv
@@ -160,7 +147,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
         name: ""
         resources:
           limits:
@@ -181,11 +168,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-netrc: "true"
     name: release-test_proxy_master_priv
@@ -201,7 +183,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
         name: ""
         resources:
           limits:
@@ -214,3 +196,47 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-netrc: "true"
+    name: check-wasm_proxy_master_priv
+    optional: true
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - ./prow/proxy-presubmit-wasm.sh
+        env:
+        - name: BAZEL_BUILD_RBE_JOBS
+          value: "0"
+        - name: ENVOY_PREFIX
+          value: envoy-wasm
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/envoyproxy/envoy-wasm
+        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        name: ""
+        resources:
+          limits:
+            cpu: "16"
+            memory: 60Gi
+          requests:
+            cpu: "8"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - emptyDir: {}
+        name: docker-root

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -9,11 +9,6 @@ postsubmits:
     cluster: private
     context: prow/proxy-postsubmit.sh
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     extra_refs:
     - base_ref: release-1.4
       clone_uri: git@github.com:istio-private/istio.git
@@ -66,11 +61,6 @@ presubmits:
     cluster: private
     context: prow/proxy-presubmit.sh
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     extra_refs:
     - base_ref: release-1.4
       clone_uri: git@github.com:istio-private/istio.git
@@ -113,11 +103,6 @@ presubmits:
     cluster: private
     context: prow/proxy-presubmit-asan.sh
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     extra_refs:
     - base_ref: release-1.4
       clone_uri: git@github.com:istio-private/istio.git
@@ -160,11 +145,6 @@ presubmits:
     cluster: private
     context: prow/proxy-presubmit-tsan.sh
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     extra_refs:
     - base_ref: release-1.4
       clone_uri: git@github.com:istio-private/istio.git
@@ -207,11 +187,6 @@ presubmits:
     cluster: private
     context: prow/proxy-presubmit-release.sh
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     extra_refs:
     - base_ref: release-1.4
       clone_uri: git@github.com:istio-private/istio.git

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -8,11 +8,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: lint_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -20,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -40,11 +35,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: test_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -52,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -72,11 +62,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: gencheck_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -84,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -104,11 +89,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4
@@ -127,7 +107,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -150,11 +130,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: lint_release-builder_priv
     path_alias: istio.io/release-builder
     spec:
@@ -162,7 +137,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -183,11 +158,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: test_release-builder_priv
     path_alias: istio.io/release-builder
     spec:
@@ -195,7 +165,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -216,11 +186,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: gencheck_release-builder_priv
     path_alias: istio.io/release-builder
     spec:
@@ -228,7 +193,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:
@@ -249,11 +214,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: build-warning_release-builder_priv
     optional: true
     path_alias: istio.io/release-builder
@@ -267,7 +227,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2019-12-03T17-07-58
+        image: gcr.io/istio-testing/build-tools:master-2019-12-18T18-07-47
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.4.gen.yaml
@@ -8,11 +8,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: lint_release-builder_release-1.4_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -40,11 +35,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: test_release-builder_release-1.4_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -72,11 +62,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: gencheck_release-builder_release-1.4_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -104,11 +89,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     labels:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4
@@ -150,11 +130,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: lint_release-builder_release-1.4_priv
     path_alias: istio.io/release-builder
     spec:
@@ -183,11 +158,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: test_release-builder_release-1.4_priv
     path_alias: istio.io/release-builder
     spec:
@@ -216,11 +186,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: gencheck_release-builder_release-1.4_priv
     path_alias: istio.io/release-builder
     spec:
@@ -249,11 +214,6 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: istio-private-build
-      ssh_key_secrets:
-      - ssh-key-secret
     name: build-warning_release-builder_release-1.4_priv
     optional: true
     path_alias: istio.io/release-builder

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -18,6 +18,20 @@ plank:
         bucket: "istio-prow"
         path_strategy: "explicit"
       gcs_credentials_secret: "service-account"
+    istio-private:
+      timeout: 2h
+      grace_period: 15s
+      utility_images:
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20191219-b8438ff62"
+        initupload: "gcr.io/k8s-prow/initupload:v20191219-b8438ff62"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20191219-b8438ff62"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20191219-b8438ff62"
+      gcs_configuration:
+        bucket: "istio-private-build"
+        path_strategy: "explicit"
+      gcs_credentials_secret: "service-account"
+      ssh_key_secrets:
+      - ssh-key-secret
 
 sinker:
   resync_period: 1h

--- a/prow/genjobs/gen-private-jobs.sh
+++ b/prow/genjobs/gen-private-jobs.sh
@@ -22,17 +22,15 @@ COMMON_OPTS=(
   "--mapping=istio=istio-private"
   "--ssh-clone"
   "--extra-refs"
-  "--input=./cluster/jobs/"
-  "--output=./cluster/jobs/"
-  "--bucket=istio-private-build"
-  "--ssh-key-secret=ssh-key-secret"
+  "--input=../cluster/jobs/"
+  "--output=../cluster/jobs/"
   "--cluster=private"
   "--modifier=priv"
   "--annotations=testgrid-create-test-group=false"
 )
 
 # Clean ./prow/cluster/jobs/istio-private directory
-go run . --clean --mapping=istio=istio-private --output=./cluster/jobs/ --dry-run >/dev/null
+go run . --clean --mapping=istio=istio-private --input=../cluster/jobs/ --output=../cluster/jobs/ --dry-run >/dev/null
 
 # istio/istio build job(s) - postsubmit(s)
 go run . \


### PR DESCRIPTION
Use `default_decoration_configs` rather than job-level `decoration_config` overrides for **istio-private**.

> Also fix `--input` and `--output` paths which were incorrect for private job gen.

fix #2261