### PR TITLE
Update CODEOWNERS so istio T&R owns anything non-Prow infra related

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,7 @@
-*                                    @clarketm @fejta @Katharine @michelle192837 @chases2
-.prow.yaml                           @istio/wg-test-and-release-maintainers
-Makefile*                            @istio/wg-test-and-release-maintainers
-/common/                             @istio/wg-test-and-release-maintainers
-/docker/                             @istio/wg-test-and-release-maintainers
+*                                    @istio/wg-test-and-release-maintainers
 /prow/                               @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
 /prow/config/                        @istio/wg-test-and-release-maintainers
 /prow/config/jobs/test-infra.yaml    @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
-/prow/cluster/                       @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
 /prow/cluster/jobs/                  @istio/wg-test-and-release-maintainers
 /prow/cluster/jobs/istio/test-infra/ @clarketm @cjwagner @fejta @Katharine @michelle192837 @chases2
-/prow/genjobs/                       @istio/wg-test-and-release-maintainers @clarketm
+/prow/genjobs/                       @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Restructure `CODEONWERS` (ref: https://github.com/istio/test-infra/pull/2223#issuecomment-572246817)