### PR TITLE
Authentikos: add --key option and update GM deployment example

### DIFF
--- a/authentikos/Makefile
+++ b/authentikos/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = istio-testing
 HUB = gcr.io
-VERSION ?= 0.0.3
+VERSION ?= 0.0.4
 
 .PHONY: deploy
 deploy: image push

--- a/authentikos/README.md
+++ b/authentikos/README.md
@@ -37,6 +37,7 @@ The following is a list of supported options for `authentikos`:
 
 ```console
   -c, --creds string           Path to a JSON credentials file.
+  -k, --key string             Name of secret data key. (default "token")
   -n, --namespace strings      Namespace(s) to create the secret in. (default [default])
   -s, --scopes strings         Oauth scope(s) to request for token.
   -o, --secret string          Name of secret to create. (default "authentikos-token")
@@ -50,3 +51,4 @@ The following is a list of supported options for `authentikos`:
 - 0.0.1: initial release
 - 0.0.2: remove `--format` option and add `--template` and `--template-file` options.
 - 0.0.3: add new `TimeToUnix`, `UnixToTime`, and `Parse` template variable and change method signature for math template variables from `(a, b time.Duration) time.Duration` to `(a, b int64) int64`.
+- 0.0.4: add `--key` option for specifying the name of the data key in the created Kubernetes secret.

--- a/authentikos/examples/authentikos-deployment.yaml
+++ b/authentikos/examples/authentikos-deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: authentikos
       containers:
       - name: authentikos
-        image: gcr.io/istio-testing/authentikos:0.0.2
+        image: gcr.io/istio-testing/authentikos:0.0.4
         imagePullPolicy: Always
         args:
         - --verbose

--- a/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
+++ b/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
@@ -63,18 +63,18 @@ spec:
       serviceAccountName: authentikos
       containers:
       - name: authentikos
-        image: gcr.io/istio-testing/authentikos:0.0.3
+        image: gcr.io/istio-testing/authentikos:0.0.4
         imagePullPolicy: Always
         args:
         - --verbose
         - --secret=http-cookiefile
+        - --key=cookies
         - --creds=/etc/creds/service-account.json
         - --namespace=test-pods
-        - --scopes=https://www.googleapis.com/auth/devstorage.full_control
-        - >
-          --template=
-          .googlesource.com TRUE  {{.Now | .TimeToUnix | .Add 3600}} {{.Token}}
-          source.developers.google.com FALSE  {{.Now | .TimeToUnix | .Add 3600}} {{.Token}}
+        - --scopes=https://www.googleapis.com/auth/gerritcodereview
+        - |
+        --template=.googlesource.com	TRUE	/	TRUE	{{.Now | .TimeToUnix | .Add 3600}}	o	{{.Token}}
+        source.developers.google.com	FALSE	/	TRUE	{{.Now | .TimeToUnix | .Add 3600}}	o	{{.Token}}
         volumeMounts:
         - name: creds
           mountPath: /etc/creds


### PR DESCRIPTION
1. add `--key` option for specifying the name of the data key in the created Kubernetes secret.
2. Update (and **verify**) *example* for grandmatriarch with proper scopes, key, and cookie format.

cc @cjwagner 