### PR TITLE
Fix deck-private issue from inrepoconfig enablement

### DIFF
--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -29,9 +29,13 @@ spec:
         - --redirect-http-to=prow-private.istio.io
         - --kubeconfig=/etc/kubeconfig/istio-config
         - --gcs-credentials-file=/etc/service-account/service-account.json
+        - --github-token-path=/etc/github/oauth
         - --spyglass
         - --hidden-only
         volumeMounts:
+        - name: oauth-token
+          mountPath: /etc/github
+          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -99,6 +103,9 @@ spec:
               name: deck-oauth-proxy
               key: cookieSecret
       volumes:
+      - name: oauth-token
+        secret:
+          secretName: oauth-token
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
Fix error in **deck-private** related to enablement of inrepoconfig.

```console
{
 insertId: "1qpyyv6gg243f19"  
 jsonPayload: {
  component: "deck"   
  file: "prow/cmd/deck/main.go:558"   
  func: "main.prodOnlyMain"   
  level: "fatal"   
  msg: "--github-token-path must be configured with a valid token when using the inrepoconfig feature"   
 }
 severity: "ERROR"  
...
}
```