### PR TITLE
Automator: fix git push by removing shallow clone

### DIFF
--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -167,7 +167,7 @@ create_pr() {
 work() {
   evaluate_opts
 
-  git clone --single-branch --branch "$branch" --depth 1 "https://github.com/$org/$repo.git" "$repo"
+  git clone --single-branch --branch "$branch" "https://github.com/$org/$repo.git" "$repo"
 
   pushd "$repo" || print_error_and_exit "invalid repo: $repo"
 


### PR DESCRIPTION
The `git push` is failing because we are modifying a shallow clone, so removing the `--depth` flag. 

https://storage.googleapis.com/istio-prow/logs/gen_istio_api_postsubmit/20/build-log.txt