### PR TITLE
Automator: ensure automator search title is unique

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -75,7 +75,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=client-go
-        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency'
+        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --modifier=client-go_update_api
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
@@ -120,7 +120,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio
-        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency'
+        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --modifier=istio_update_api
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio,operator,istio.io,common-files,api,proxy,test-infra,tools,installer,bots,release-builder,pkg,cni,cri,community,client-go
-        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -16,7 +16,7 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=client-go
-    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency"
+    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --modifier=client-go_update_api
     - --token-path=/etc/github-token/oauth
     - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
@@ -29,7 +29,7 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio
-    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency"
+    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --modifier=istio_update_api
     - --token-path=/etc/github-token/oauth
     - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -13,7 +13,7 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio,operator,istio.io,common-files,api,proxy,test-infra,tools,installer,bots,release-builder,pkg,cni,cri,community,client-go
-    - "--title=Automator: update common-files@$AUTOMATOR_BRANCH"
+    - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --modifier=commonfiles
     - --token-path=/etc/github-token/oauth
     - --cmd=make update-common gen

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -141,7 +141,7 @@ evaluate_opts() {
   export AUTOMATOR_ORG="$org" AUTOMATOR_REPO="$repo" AUTOMATOR_BRANCH="$branch"
 
   if [ -z "${title:-}" ]; then
-    title="Automator: update $org/$repo@$branch"
+    title="Automator: update $org/$repo@$branch-$modifier"
   fi
   title="$(eval echo "$title")"
 


### PR DESCRIPTION
Automator can improperly modify PRs if the title is not unique. This is resolved now by:
1. Using unique, custom titles; or
2. Appending the `modifier` to the *default* title.