### PR TITLE
Update gke version for perf cluster

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -44,7 +44,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-32
             numnodes: 4
-            version: 1.13
+            version: 1.14
             zone: us-central1-f
             scopes:
             - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
1.5 perf test fails at installation step because of similar issue mentioned here: https://github.com/istio/istio/issues/20290