### PR TITLE
increase perf test timeout for clientsidecar mode

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -131,9 +131,9 @@ periodics:
   name: daily-performance-benchmark
   branches: master
   decorate: true
-  timeout: 14h
+  timeout: 17h
   decoration_config:
-    timeout: 14h0m0s
+    timeout: 17h0m0s
   extra_refs:
     - org: istio
       repo: tools
@@ -159,9 +159,9 @@ periodics:
   name: daily-performance-benchmark-release-1.4
   branches: release-1.4
   decorate: true
-  timeout: 14h
+  timeout: 17h
   decoration_config:
-    timeout: 14h0m0s
+    timeout: 17h0m0s
   extra_refs:
     - org: istio
       repo: tools


### PR DESCRIPTION
As we added clientsidecar only mode for each configs:
which will add: [(240/60) * 6 * 6] / 60 = 2.4 h

