### PR TITLE
Update build-tools image tag

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -23,7 +23,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -119,7 +119,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ postsubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -223,7 +223,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -274,7 +274,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -325,7 +325,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -427,7 +427,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -479,7 +479,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -528,7 +528,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -578,7 +578,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -614,7 +614,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -650,7 +650,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -686,7 +686,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -725,7 +725,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -778,7 +778,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -831,7 +831,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -884,7 +884,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -937,7 +937,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -987,7 +987,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1041,7 +1041,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.9
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1095,7 +1095,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.15.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1149,7 +1149,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.16.3
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1198,7 +1198,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1227,7 +1227,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1265,7 +1265,7 @@ presubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1296,7 +1296,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1327,7 +1327,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1358,7 +1358,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1395,7 +1395,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1432,7 +1432,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1469,7 +1469,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1509,7 +1509,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1564,7 +1564,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1618,7 +1618,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1672,7 +1672,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1726,7 +1726,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1778,7 +1778,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1832,7 +1832,7 @@ presubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1883,7 +1883,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1935,7 +1935,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1987,7 +1987,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2039,7 +2039,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2091,7 +2091,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2141,7 +2141,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2191,7 +2191,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2221,7 +2221,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -31,7 +31,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -75,7 +75,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -111,7 +111,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -147,7 +147,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -184,7 +184,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -221,7 +221,7 @@ presubmits:
           value: envoy-wasm
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy-wasm
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -107,7 +107,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -165,7 +165,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -227,7 +227,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -79,7 +79,7 @@ postsubmits:
         - --modifier=client-go_update_api
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
         - --modifier=istio_update_api
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_BRANCH && go mod tidy && make gen
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -186,7 +186,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -165,7 +165,7 @@ postsubmits:
             secretKeyRef:
               key: githubOauthClientSecret
               name: policybot
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -251,7 +251,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -16,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -45,7 +45,7 @@ postsubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -78,7 +78,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -125,7 +125,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -181,7 +181,7 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -209,7 +209,7 @@ presubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -241,7 +241,7 @@ presubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -287,7 +287,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/installer/istio.installer.master.gen.yaml
+++ b/prow/cluster/jobs/istio/installer/istio.installer.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - run-build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint_modern
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -76,7 +76,7 @@ postsubmits:
         - bin/with-kind.sh
         - make
         - run-test-demo
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -130,7 +130,7 @@ postsubmits:
         - bin/with-kind.sh
         - make
         - run-test-noauth
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -184,7 +184,7 @@ postsubmits:
         - bin/with-kind.sh
         - make
         - run-base-reachability
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -231,7 +231,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -259,7 +259,7 @@ presubmits:
       - command:
         - make
         - run-build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - lint_modern
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -318,7 +318,7 @@ presubmits:
         - bin/with-kind.sh
         - make
         - run-test-demo
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -371,7 +371,7 @@ presubmits:
         - bin/with-kind.sh
         - make
         - run-test-noauth
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -424,7 +424,7 @@ presubmits:
         - bin/with-kind.sh
         - make
         - run-base-reachability
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -470,7 +470,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -43,7 +43,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -49,7 +49,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -78,7 +78,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -108,7 +108,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -208,7 +208,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -257,7 +257,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -306,7 +306,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -404,7 +404,7 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -501,7 +501,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -549,7 +549,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -583,7 +583,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -617,7 +617,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -651,7 +651,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -688,7 +688,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -739,7 +739,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -790,7 +790,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -841,7 +841,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -892,7 +892,7 @@ postsubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -940,7 +940,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -992,7 +992,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.9
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1044,7 +1044,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.15.6
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1096,7 +1096,7 @@ postsubmits:
         - --node-image
         - kindest/node:v1.16.3
         - test.integration.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1143,7 +1143,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1170,7 +1170,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1204,7 +1204,7 @@ presubmits:
         - localTestEnv
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1231,7 +1231,7 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1259,7 +1259,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1286,7 +1286,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1319,7 +1319,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1352,7 +1352,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1385,7 +1385,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1421,7 +1421,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1472,7 +1472,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1522,7 +1522,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1572,7 +1572,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1622,7 +1622,7 @@ presubmits:
         env:
         - name: TEST_USE_OPERATOR
           value: "true"
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1670,7 +1670,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioio.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1720,7 +1720,7 @@ presubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1767,7 +1767,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1815,7 +1815,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1863,7 +1863,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1911,7 +1911,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_dashboard
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -1959,7 +1959,7 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2005,7 +2005,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2051,7 +2051,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -2077,7 +2077,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - mesh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - mandiff
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -151,7 +151,7 @@ postsubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
         - entrypoint
         - make
         - docker.all
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -229,7 +229,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
       - command:
         - make
         - mesh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -281,7 +281,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -307,7 +307,7 @@ presubmits:
       - command:
         - make
         - mandiff
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -333,7 +333,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -360,7 +360,7 @@ presubmits:
         - entrypoint
         - make
         - e2e
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -17,7 +17,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -50,7 +50,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -75,7 +75,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -100,7 +100,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -127,7 +127,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -153,7 +153,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -213,7 +213,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -268,7 +268,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -295,7 +295,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -322,7 +322,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -106,7 +106,7 @@ postsubmits:
         - deploy-gcsweb
         - deploy-build
         - deploy-private
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -139,7 +139,7 @@ postsubmits:
         - -C
         - authentios
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -178,7 +178,7 @@ postsubmits:
         - -C
         - prow/genjobs
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -264,7 +264,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -161,7 +161,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -213,7 +213,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:
@@ -269,7 +269,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+        image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: api
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: bots
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: client-go
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-06T18-35-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: cni
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/cri.yaml
+++ b/prow/config/jobs/cri.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: cri
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/installer.yaml
+++ b/prow/config/jobs/installer.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: installer
 support_release_branching: false
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio.io
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: lint

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: unit-tests

--- a/prow/config/jobs/operator.yaml
+++ b/prow/config/jobs/operator.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: operator
 support_release_branching: false
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: lint

--- a/prow/config/jobs/pkg.yaml
+++ b/prow/config/jobs/pkg.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: pkg
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: proxy
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools-proxy:master-2019-12-15T16-17-48
+image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-27T04-51-23
 
 jobs:
 - name: test

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: release-builder
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: lint

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: test-infra
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: lint

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: tools
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2020-01-18T00-45-13
+image: gcr.io/istio-testing/build-tools:master-2020-01-27T04-51-23
 
 jobs:
   - name: build


### PR DESCRIPTION
Looks like the proxy build tools has not been updated for a while... I think we need a lint tool to check that.