### PR TITLE
Disable explicit GOPROXY and use default

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -515,9 +515,6 @@ presets:
       configMapKeyRef:
         name: release-1.4-deps
         key: dependencies
-# Enable GOPROXY by default and fallback to direct connection.
 - env:
-  - name: GOPROXY
-    value: "https://proxy.golang.org,direct"
   - name: BUILD_WITH_CONTAINER
     value: "0"


### PR DESCRIPTION
`https://proxy.golang.org,direct` is the *default* in go 1.13 so this declaration is redundant. The only drawback is go 1.12 and earlier will not use a proxy.