### PR TITLE
Enable explicit GOPROXY for release-1.3

### DIFF
--- a/prow/cluster/jobs/all-presets.yaml
+++ b/prow/cluster/jobs/all-presets.yaml
@@ -158,6 +158,11 @@ presets:
       configMapKeyRef:
         name: release-1.4-deps
         key: dependencies
+- labels:
+    preset-goproxy: "true"
+  env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"
 - env:
   - name: BUILD_WITH_CONTAINER
     value: "0"

--- a/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.3.yaml
+++ b/prow/cluster/jobs/istio-releases/pipeline/istio-releases.pipeline.release-1.3.yaml
@@ -62,6 +62,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -82,6 +83,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -102,6 +104,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -122,6 +125,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -142,6 +146,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -162,6 +167,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -182,6 +188,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -202,6 +209,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -222,6 +230,7 @@ presubmits:
       max_concurrency: 5
       labels:
         preset-release-build-test: "true"
+        preset-goproxy: "true"
       spec:
         containers:
           - <<: *istio_container
@@ -241,6 +250,7 @@ presubmits:
       optional: false
       labels:
         preset-release-pipeline: "true"
+        preset-goproxy: "true"
       spec:
         <<: *istio_rel_pipeline_spec
         containers:
@@ -263,6 +273,7 @@ postsubmits:
       run_if_changed: "daily/.*"
       labels:
         preset-release-pipeline: "true"
+        preset-goproxy: "true"
       spec:
         <<: *istio_rel_pipeline_spec
         containers:
@@ -281,6 +292,7 @@ postsubmits:
       run_if_changed: "monthly/.*"
       labels:
         preset-release-pipeline: "true"
+        preset-goproxy: "true"
       spec:
         <<: *istio_rel_pipeline_spec
         containers:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.3.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.3.yaml
@@ -27,6 +27,7 @@ presubmits:
       always_run: true
       labels:
         preset-service-account: "true"
+        preset-goproxy: "true"
       spec:
         <<: *test_spec
 
@@ -42,5 +43,6 @@ postsubmits:
       branches: *branch_spec
       labels:
         preset-service-account: "true"
+        preset-goproxy: "true"
       spec:
         <<: *test_spec

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.3.gen.yaml
@@ -16,6 +16,9 @@ postsubmits:
         - entrypoint
         - make
         - docker
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -45,6 +48,9 @@ postsubmits:
         - make
         - docker
         - test
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -78,6 +84,9 @@ postsubmits:
         - entrypoint
         - make
         - prow-e2e
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -125,6 +134,9 @@ postsubmits:
       - command:
         - make
         - docker
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
         name: ""
         resources:
@@ -152,6 +164,9 @@ postsubmits:
       - command:
         - make
         - lint_modern
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
         name: ""
         resources:
@@ -181,6 +196,9 @@ presubmits:
         - entrypoint
         - make
         - docker
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -209,6 +227,9 @@ presubmits:
         - make
         - docker
         - test
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -241,6 +262,9 @@ presubmits:
         - entrypoint
         - make
         - prow-e2e
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -288,6 +312,9 @@ presubmits:
       - command:
         - make
         - docker
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
         name: ""
         resources:
@@ -314,6 +341,9 @@ presubmits:
       - command:
         - make
         - lint_modern
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.3.gen.yaml
@@ -15,6 +15,9 @@ postsubmits:
       - command:
         - make
         - lint
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
         name: ""
         resources:
@@ -43,6 +46,9 @@ presubmits:
       - command:
         - make
         - lint
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.3.gen.yaml
@@ -21,6 +21,9 @@ postsubmits:
         - localTestEnv
         - test
         - binaries-test
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -52,6 +55,9 @@ postsubmits:
         - T=-v
         - localTestEnv
         - racetest
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -80,6 +86,9 @@ postsubmits:
         - entrypoint
         - make
         - coverage-diff
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -109,6 +118,9 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -138,6 +150,9 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -187,6 +202,9 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -236,6 +254,9 @@ postsubmits:
       - command:
         - entrypoint
         - prow/e2e-dashboard.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -265,6 +286,9 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -314,6 +338,9 @@ postsubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -364,6 +391,9 @@ postsubmits:
         - --use_mcp=false
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -416,6 +446,9 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -470,6 +503,9 @@ postsubmits:
         - helm
         - --variant
         - distroless
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -525,6 +561,9 @@ postsubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -633,6 +672,9 @@ postsubmits:
         - e2e_simple
         - --installer
         - helm
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -682,6 +724,9 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -710,6 +755,9 @@ postsubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -738,6 +786,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -766,6 +817,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -794,6 +848,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.mixer.local
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -822,6 +879,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -850,6 +910,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -878,6 +941,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.conformance.local
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -905,6 +971,9 @@ postsubmits:
       - command:
         - entrypoint
         - prow/istio-integ-race-native-tests.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -933,6 +1002,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -981,6 +1053,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1029,6 +1104,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1077,6 +1155,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1125,6 +1206,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1173,6 +1257,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1221,6 +1308,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1269,6 +1359,9 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.conformance.kube
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1321,6 +1414,9 @@ postsubmits:
         - --node-image
         - kindest/node:v1.13.10
         - test.integration.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1373,6 +1469,9 @@ postsubmits:
         - --node-image
         - kindest/node:v1.14.6
         - test.integration.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1425,6 +1524,9 @@ postsubmits:
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.16.0-beta.1
         - test.integration.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1479,6 +1581,9 @@ presubmits:
         - localTestEnv
         - test
         - binaries-test
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1506,6 +1611,9 @@ presubmits:
         - entrypoint
         - make
         - lint
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1536,6 +1644,9 @@ presubmits:
         - T=-v
         - localTestEnv
         - racetest
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1563,6 +1674,9 @@ presubmits:
         - entrypoint
         - make
         - shellcheck
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1590,6 +1704,9 @@ presubmits:
         - entrypoint
         - make
         - coverage-diff
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1618,6 +1735,9 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1645,6 +1765,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.framework.local.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1672,6 +1795,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.galley.local.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1699,6 +1825,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.mixer.local.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1726,6 +1855,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.pilot.local.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1753,6 +1885,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-local.sh
         - test.integration.security.local.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1780,6 +1915,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.framework.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1827,6 +1965,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.istioctl.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1874,6 +2015,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.galley.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1922,6 +2066,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.mixer.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -1969,6 +2116,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2016,6 +2166,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2063,6 +2216,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube.presubmit
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2111,6 +2267,9 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.new.installer
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2159,6 +2318,9 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_mixer
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2207,6 +2369,9 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_pilotv2_v1alpha3
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2255,6 +2420,9 @@ presubmits:
       - command:
         - entrypoint
         - prow/e2e-dashboard.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2283,6 +2451,9 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_envoyv2_v1alpha3
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2331,6 +2502,9 @@ presubmits:
         - prow/e2e-kind-suite.sh
         - --single_test
         - e2e_bookinfo_trustdomain
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2382,6 +2556,9 @@ presubmits:
         - e2e_simple
         - --installer
         - helm
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2435,6 +2612,9 @@ presubmits:
         - helm
         - --variant
         - distroless
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2489,6 +2669,9 @@ presubmits:
         - values-istio-minimal.yaml
         - --helmSetValueList
         - gateways.enabled=true,galley.enabled=false,global.useMCP=false
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2592,6 +2775,9 @@ presubmits:
       - command:
         - entrypoint
         - prow/istio-pilot-multicluster-e2e.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -2619,6 +2805,9 @@ presubmits:
         - entrypoint
         - make
         - e2e_cloudfoundry
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/operator/istio.operator.release-1.3.gen.yaml
+++ b/prow/cluster/jobs/istio/operator/istio.operator.release-1.3.gen.yaml
@@ -15,6 +15,9 @@ postsubmits:
       - command:
         - make
         - lint
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -42,6 +45,9 @@ postsubmits:
       - command:
         - make
         - mesh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -69,6 +75,9 @@ postsubmits:
       - command:
         - make
         - test
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -96,6 +105,9 @@ postsubmits:
       - command:
         - make
         - mandiff
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -124,6 +136,9 @@ postsubmits:
       - command:
         - entrypoint
         - prow/e2e_install.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:
@@ -172,6 +187,9 @@ presubmits:
       - command:
         - make
         - lint
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -198,6 +216,9 @@ presubmits:
       - command:
         - make
         - mesh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -224,6 +245,9 @@ presubmits:
       - command:
         - make
         - test
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -250,6 +274,9 @@ presubmits:
       - command:
         - make
         - mandiff
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
         name: ""
         resources:
@@ -278,6 +305,9 @@ presubmits:
       - command:
         - entrypoint
         - prow/e2e_install.sh
+        env:
+        - name: GOPROXY
+          value: https://proxy.golang.org
         image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
         name: ""
         resources:

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -73,6 +73,7 @@ type JobConfig struct {
 	Repo                    string                             `json:"repo,omitempty"`
 	Org                     string                             `json:"org,omitempty"`
 	Branches                []string                           `json:"branches,omitempty"`
+	Env                     []v1.EnvVar                        `json:"env,omitempty"`
 	Resources               map[string]v1.ResourceRequirements `json:"resources,omitempty"`
 	Image                   string                             `json:"image,omitempty"`
 	SupportReleaseBranching bool                               `json:"support_release_branching,omitempty"`
@@ -403,11 +404,16 @@ func createContainer(jobConfig JobConfig, job Job, resources map[string]v1.Resou
 		img = jobConfig.Image
 	}
 
+	envs := job.Env
+	if len(envs) == 0 {
+		envs = jobConfig.Env
+	}
+
 	c := v1.Container{
 		Image:           img,
 		SecurityContext: &v1.SecurityContext{Privileged: newTrue()},
 		Command:         job.Command,
-		Env:             job.Env,
+		Env:             envs,
 	}
 	resource := DefaultResource
 	if job.Resources != "" {

--- a/prow/config/jobs/cni-1.3.yaml
+++ b/prow/config/jobs/cni-1.3.yaml
@@ -3,6 +3,9 @@ repo: cni
 image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
 branches:
   - release-1.3
+env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"
 
 jobs:
   - name: build

--- a/prow/config/jobs/istio-1.3.yaml
+++ b/prow/config/jobs/istio-1.3.yaml
@@ -3,6 +3,9 @@ repo: istio
 image: gcr.io/istio-testing/istio-builder:v20191017-386873c9-dirty
 branches:
   - release-1.3
+env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"
 
 jobs:
   - name: unit-tests

--- a/prow/config/jobs/istio.io-1.3.yaml
+++ b/prow/config/jobs/istio.io-1.3.yaml
@@ -3,6 +3,9 @@ repo: istio.io
 image: gcr.io/istio-testing/build-tools:2019-08-31T04-48-30
 branches:
   - release-1.3
+env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"
 
 jobs:
   - name: lint

--- a/prow/config/jobs/operator-1.3.yaml
+++ b/prow/config/jobs/operator-1.3.yaml
@@ -3,6 +3,9 @@ repo: operator
 image: gcr.io/istio-testing/build-tools:2019-09-17T18-24-15
 branches:
   - release-1.3
+env:
+  - name: GOPROXY
+    value: "https://proxy.golang.org"
 
 jobs:
   - name: lint


### PR DESCRIPTION
Job(s) on `release-1.3` branch require `GOPROXY` to be set. 