### PR TITLE
Migrate GitHub reporting from plank to crier

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -20,11 +20,18 @@ spec:
       - name: crier
         image: gcr.io/k8s-prow/crier:v20200225-55a0aacbd
         args:
+        - --github-workers=5
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         - --slack-workers=1
         - --slack-token-file=/etc/slack/token
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
         - name: slack
           mountPath: /etc/slack
           readOnly: true
@@ -35,6 +42,9 @@ spec:
           mountPath: /etc/job-config
           readOnly: true
       volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
       - name: slack
         secret:
           secretName: slack-token

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --kubeconfig=/etc/kubeconfig/istio-config
+        - --skip-report=true
         volumeMounts:
         - name: oauth
           mountPath: /etc/github


### PR DESCRIPTION
This fixes `open` error from original reverted attempt: #2254. 

fix https://github.com/istio/test-infra/issues/1976