### PR TITLE
Add retries to kubernetes postsubmit tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1084,8 +1084,11 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.14.9
+        - kindest/node:v1.14.10
         - test.integration.kube.presubmit
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
         image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
@@ -1140,8 +1143,11 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.15.6
+        - kindest/node:v1.15.7
         - test.integration.kube.presubmit
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
         image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
@@ -1196,8 +1202,11 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.16.3
+        - kindest/node:v1.16.4
         - test.integration.kube.presubmit
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
         image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -990,8 +990,11 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.14.9
+        - kindest/node:v1.14.10
         - test.integration.kube.presubmit
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
         image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
@@ -1042,8 +1045,11 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.15.6
+        - kindest/node:v1.15.7
         - test.integration.kube.presubmit
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
         image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
@@ -1094,8 +1100,11 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.16.3
+        - kindest/node:v1.16.4
         - test.integration.kube.presubmit
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
         image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -210,10 +210,13 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.14.9
+      - kindest/node:v1.14.10
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: " --istio.test.retries=1 "
 
   - name: integ-k8s-115
     type: postsubmit
@@ -221,10 +224,13 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.15.6
+      - kindest/node:v1.15.7
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: " --istio.test.retries=1 "
 
   - name: integ-k8s-116
     type: postsubmit
@@ -232,10 +238,13 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.16.3
+      - kindest/node:v1.16.4
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: " --istio.test.retries=1 "
 
   - name: lint
     command: [make, lint]


### PR DESCRIPTION
This is normally a really bad idea I think,
and just hides the problem we see. However, I think there is one use
case for it. In postsubmit, we rerun tests with different variants (ie
Kubernetes v1.13). These are the exact same tests running ~4x in
postsubmit. These tests exist to catch bugs in different environments -
it is highly unlikely that we have test flakes in different k8s versions
rather than just complete failures. Therefor, I think its appropriate to
add retries only for these redundant tests. Otherwise, we are just
making ourselves 4x more likely to have a test flake