### PR TITLE
Update gcsweb/velodrome static ip references

### DIFF
--- a/prow/cluster/gcsweb/gcsweb_ing.yaml
+++ b/prow/cluster/gcsweb/gcsweb_ing.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcsweb-ing
   namespace: gcs
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: gcs
+    kubernetes.io/ingress.global-static-ip-name: k8s-fw-gcs-gcsweb-ing--c44bd72f22c73d37
     networking.gke.io/managed-certificates: gcs-istio-io
     kubernetes.io/ingress.class: "gce"
 spec:

--- a/prow/cluster/velodrome/velodrome_ing.yaml
+++ b/prow/cluster/velodrome/velodrome_ing.yaml
@@ -4,7 +4,7 @@ metadata:
   name: velodrome-ing
   namespace: velodrome
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: velodrome
+    kubernetes.io/ingress.global-static-ip-name: k8s-fw-velodrome-velodrome-ing--c44bd72f22c73d37
     networking.gke.io/managed-certificates: velodrome-istio-io
     kubernetes.io/ingress.class: "gce"
 spec:


### PR DESCRIPTION
When I originally set these up, I reserved regional (rather than global) IPs ([xref](https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip#step_2b_using_an_ingress)), so GCP generated global IPs for the `gcsweb` and `velodrome` ingress(es) with these verbose names. This change is to reconcile declaration with deployment.  