### PR TITLE
Update build-tools image for common-files

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-09T23-37-05
+        image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
           limits:
@@ -52,7 +52,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:master-2019-12-09T23-37-05
+        image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2019-12-09T23-37-05
+        image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: common-files
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2019-12-09T23-37-05
+image: gcr.io/istio-testing/build-tools:master-2020-01-30T23-36-53
 
 jobs:
   - name: lint


### PR DESCRIPTION
~Maybe why istio/api#1271 file generation is faulty or could be an issue/conflict with protobuf version?~

I confirmed that a stale image is why https://github.com/istio/api/pull/1271 file generation is faulty. 

Also, @sdake reminded me that *build-tools image updates* like this are still not automated https://github.com/istio/test-infra/issues/1627#issuecomment-552665234. I will automate this in a follow-up. 