### PR TITLE
Upgrade boskos

### DIFF
--- a/boskos/cluster/boskos-deployment.yaml
+++ b/boskos/cluster/boskos-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20190730-dbac84bd7
+        image: gcr.io/k8s-prow/boskos/boskos:v20200206-f88edefe8
         args:
         - --config=/etc/config/resources.yaml
         - --namespace=boskos

--- a/boskos/cluster/cleaner-deployment.yaml
+++ b/boskos/cluster/cleaner-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-cleaner
-        image: gcr.io/k8s-prow/boskos/cleaner:v20190730-dbac84bd7
+        image: gcr.io/k8s-prow/boskos/cleaner:v20200206-f88edefe8
         args:
         - --cleaner-count=3
         - --namespace=boskos

--- a/boskos/cluster/janitor-deployment.yaml
+++ b/boskos/cluster/janitor-deployment.yaml
@@ -15,11 +15,13 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20180725-c421ed4f9
+        image: gcr.io/k8s-prow/boskos/janitor:v20200206-f88edefe8
         args:
-        - --service-account=/etc/service-account/service-account.json
         - --resource-type=gcp-project,gcp-perf-test
         - --pool-size=20
+        - --
+        - --service_account=/etc/service-account/service-account.json
+        - --hours=1
         volumeMounts:
         - mountPath: /etc/service-account
           name: boskos-service-account

--- a/boskos/cluster/metrics-deployment.yaml
+++ b/boskos/cluster/metrics-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-prow/boskos/metrics:v20190730-dbac84bd7
+        image: gcr.io/k8s-prow/boskos/metrics:v20200206-f88edefe8
         args:
         - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test
         ports:

--- a/boskos/cluster/reaper-deployment.yaml
+++ b/boskos/cluster/reaper-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-prow/boskos/reaper:v20190730-dbac84bd7
+        image: gcr.io/k8s-prow/boskos/reaper:v20200206-f88edefe8
         args:
         - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test
       nodeSelector:


### PR DESCRIPTION
In addressing some issues with several boskos projects, I noticed the **janitor** was 1.5 years *outdated*. To be prudent, we should bump versions to latest to be on par with k8s stable ... unless there is a reason we are pinned to this old version?

> Choosing `v20200206-f88edefe8` here b/c it is latest stable: https://github.com/kubernetes/test-infra/pull/16260