### PR TITLE
Upgrade gke-e2e-test GKE version

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -13,7 +13,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.13
+            version: 1.14
             networkpolicy:
               enabled: true
               provider: CALICO
@@ -22,7 +22,7 @@ resources:
             - https://www.googleapis.com/auth/trace.append
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.13
+            version: 1.14
             networkpolicy:
               enabled: true
               provider: CALICO


### PR DESCRIPTION
@carolynhu / @richardwxn / @howardjohn

The *default* for new clusters is now **1.14**. Can one of you please confirm the test(s) using these boskos resources do not explicitly require k8s features exclusive to **1.13** (and approve if safe).
