### PR TITLE
Add a third boskos perf project

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -61,6 +61,7 @@ resources:
   names:
   - istio-boskos-perf-01
   - istio-boskos-perf-02
+  - istio-boskos-perf-05
 - type: gcp-project
   state: dirty
   names:


### PR DESCRIPTION
There are [**three**](https://github.com/istio/test-infra/blob/daf1de25471dba3f4b76115e591e04ce7bf99b9f/prow/cluster/jobs/all-periodics.yaml#L130-L212) different daily performance benchmark jobs now (concurrently) so we are hitting [`failed to get a Boskos resource`](https://storage.googleapis.com/istio-prow/logs/daily-performance-benchmark-release-1.5/2/build-log.txt) issues in job. 

> Unfortunately `istio-boskos-perf-03` and `istio-boskos-perf-04` ids are unavailable (because they existed before and were deleted) ([xref](https://cloud.google.com/resource-manager/docs/creating-managing-projects?hl=en&visit_id=637170674974407683-3012621339&rd=1#get_an_existing_project)), so adding `istio-boskos-perf-05`

https://velodrome.istio.io/dashboard/db/boskos-dashboard?orgId=1&panelId=6&fullscreen&from=now-2d&to=now

cc @carolynhu @howardjohn 
