### PR TITLE
Add sa to GCR deploy jobs

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -127,6 +127,8 @@ postsubmits:
     - ^master$
     cluster: test-infra-trusted
     decorate: true
+    labels:
+      preset-service-account: "true"
     max_concurrency: 1
     name: push-authentikos_test-infra_postsubmit
     path_alias: istio.io/test-infra
@@ -166,6 +168,8 @@ postsubmits:
     - ^master$
     cluster: test-infra-trusted
     decorate: true
+    labels:
+      preset-service-account: "true"
     max_concurrency: 1
     name: push-genjobs_test-infra_postsubmit
     path_alias: istio.io/test-infra

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -25,8 +25,7 @@ jobs:
     - deploy-gcsweb
     - deploy-build
     - deploy-private
-    requirements:
-    - deploy
+    requirements: [deploy]
     node_selector:
       prod: prow
 
@@ -41,8 +40,7 @@ jobs:
     - -C
     - authentikos
     - deploy
-    requirements:
-    - docker
+    requirements: [docker, gcp]
     node_selector:
       prod: prow
 
@@ -57,7 +55,6 @@ jobs:
     - -C
     - prow/genjobs
     - deploy
-    requirements:
-    - docker
+    requirements: [docker, gcp]
     node_selector:
       prod: prow


### PR DESCRIPTION
Fix auth when pushing images to GCR by adding serviceaccount (SA).

e.g.
https://prow.istio.io/view/gcs/istio-prow/logs/push-genjobs_test-infra_postsubmit/1