### PR TITLE
Bump gke version to 1.15

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -13,7 +13,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.14
+            version: 1.15
             networkpolicy:
               enabled: true
               provider: CALICO
@@ -22,7 +22,7 @@ resources:
             - https://www.googleapis.com/auth/trace.append
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.14
+            version: 1.15
             networkpolicy:
               enabled: true
               provider: CALICO
@@ -44,7 +44,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-32
             numnodes: 3
-            version: 1.14
+            version: 1.15
             zone: us-central1-f
             scopes:
             - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
Bumping to latest version on *regular* channel to get additional *default* software and security patches. https://cloud.google.com/kubernetes-engine/docs/release-notes. 

> supersedes https://github.com/istio/test-infra/pull/2359 

cc @carolynhu @richardwxn @howardjohn 