### PR TITLE
Restrict update-common job to applicable repos

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -73,6 +73,51 @@ postsubmits:
       - name: github
         secret:
           secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_common-files_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    name: update-common-proxy_common-files_postsubmit
+    path_alias: istio.io/common-files
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=proxy
+        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --modifier=commonfiles-proxy
+        - --token-path=/etc/github-token/oauth
+        - --cmd=make update-common
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-30T23-36-53
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token
 presubmits:
   istio/common-files:
   - always_run: true

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -47,7 +47,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,istio.io,common-files,api,proxy,test-infra,tools,bots,release-builder,pkg,cni,cri,community,client-go,gogo-genproto
+        - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto
         - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
@@ -47,7 +47,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,istio.io,common-files,api,proxy,test-infra,tools,bots,release-builder,pkg,cni,cri,community,client-go,gogo-genproto
+        - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto
         - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth

--- a/prow/config/jobs/common-files-1.5.yaml
+++ b/prow/config/jobs/common-files-1.5.yaml
@@ -9,7 +9,7 @@ jobs:
 - command:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
-  - --repo=istio,istio.io,common-files,api,proxy,test-infra,tools,bots,release-builder,pkg,cni,cri,community,client-go,gogo-genproto
+  - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto
   - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -19,3 +19,17 @@ jobs:
     - --cmd=make update-common gen
     requirements: [github]
     repos: [istio/test-infra]
+
+  - name: update-common-proxy
+    image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-30T23-36-53
+    type: postsubmit
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=proxy
+    - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --modifier=commonfiles-proxy
+    - --token-path=/etc/github-token/oauth
+    - --cmd=make update-common
+    requirements: [github]
+    repos: [istio/test-infra]

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -12,7 +12,7 @@ jobs:
     command:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
-    - --repo=istio,istio.io,common-files,api,proxy,test-infra,tools,bots,release-builder,pkg,cni,cri,community,client-go,gogo-genproto
+    - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto
     - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --modifier=commonfiles
     - --token-path=/etc/github-token/oauth


### PR DESCRIPTION
1. Removing `community` because it does not use common files.
1. Removing `proxy` because it requires a different procedure (follow-up job needed).
1. Removing `common-files` for obvious reasons.