### PR TITLE
Add update commonfiles job for istio/proxy

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -118,6 +118,51 @@ postsubmits:
       - name: github
         secret:
           secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_common-files_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    name: update-common-proxy_common-files_postsubmit
+    path_alias: istio.io/common-files
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=proxy
+        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --modifier=commonfiles-proxy
+        - --token-path=/etc/github-token/oauth
+        - --cmd=make update-common
+        image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-30T23-36-53
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token
 presubmits:
   istio/common-files:
   - always_run: true

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -33,3 +33,16 @@ jobs:
     - --cmd=make update-common
     requirements: [github]
     repos: [istio/test-infra]
+  - name: update-common-proxy
+    image: gcr.io/istio-testing/build-tools-proxy:master-2020-01-30T23-36-53
+    type: postsubmit
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=proxy
+    - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --modifier=commonfiles-proxy
+    - --token-path=/etc/github-token/oauth
+    - --cmd=make update-common
+    requirements: [github]
+    repos: [istio/test-infra]


### PR DESCRIPTION
The `update-common` target needs an update in **istio/proxy**. A `lint` target checks that the *proxy build-tools* and *build-tools* are the same, so we need to ensure that the *proxy build-tools* tag gets updated when `update-common` is executed.

https://github.com/istio/proxy/pull/2611
https://github.com/istio/proxy/pull/2674

Also, we may also want to run `update-common-protos` as well?

cc @bianpengyuan  

/hold