### PR TITLE
Add update commonfiles job for istio/proxy

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=commonfiles-proxy
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-02-14T13-09-14
+        image: gcr.io/istio-testing/build-tools:master-2020-02-14T13-09-14
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
@@ -86,6 +86,51 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
+    name: update-common-proxy_common-files_release-1.5_postsubmit
+    path_alias: istio.io/common-files
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=proxy
+        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --modifier=commonfiles-proxy
+        - --token-path=/etc/github-token/oauth
+        - --cmd=make update-common
+        image: gcr.io/istio-testing/build-tools:release-1.5-2020-02-14T14-00-07
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_release-1.5_common-files_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^release-1.5$
+    decorate: true
+    extra_refs:
+    - base_ref: release-1.5
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
     name: update-build-tools-image_common-files_release-1.5_postsubmit
     path_alias: istio.io/common-files
     spec:

--- a/prow/config/jobs/common-files-1.5.yaml
+++ b/prow/config/jobs/common-files-1.5.yaml
@@ -21,6 +21,18 @@ jobs:
   requirements:
   - github
   type: postsubmit
+- name: update-common-proxy
+  type: postsubmit
+  command:
+  - ../test-infra/tools/automator/automator.sh
+  - --org=istio
+  - --repo=proxy
+  - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+  - --modifier=commonfiles-proxy
+  - --token-path=/etc/github-token/oauth
+  - --cmd=make update-common
+  requirements: [github]
+  repos: [istio/test-infra]
 - name: update-build-tools-image
   type: postsubmit
   command:

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -22,7 +22,6 @@ jobs:
     repos: [istio/test-infra]
 
   - name: update-common-proxy
-    image: gcr.io/istio-testing/build-tools-proxy:master-2020-02-14T13-09-14
     type: postsubmit
     command:
     - ../test-infra/tools/automator/automator.sh


### PR DESCRIPTION
Add/modify `update-common` job for **istio/proxy** `master` and `release-1.5` branches using *standard* **build-tools** image.

> **Note:** this will resolve the automator [job failure](https://prow.istio.io/view/gcs/istio-prow/logs/update-common-proxy_common-files_postsubmit/1) but will not fix lint issue in **istio/proxy** itself as that requires external changes (ref: https://github.com/istio/test-infra/pull/2375#issue-375055740).  

Dependent on: https://github.com/istio/proxy/pull/2682
/hold