### PR TITLE
Increase timeout for proxy asan test in release 1.4

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.4.yaml
@@ -44,7 +44,7 @@ presubmits:
     always_run: true
     decorate: true
     path_alias: istio.io/proxy
-    timeout: 60m
+    timeout: 120m
     extra_refs:
     - org: istio
       repo: istio


### PR DESCRIPTION
Proxy Asan test in release-1.4 has been consistently timeout, example:
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_proxy/2694/proxy-presubmit-asan/3053