### PR TITLE
Automator: repos should be split

### DIFF
--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -228,7 +228,7 @@ main() {
 
   pushd "$tmp_dir" || print_error_and_exit "invalid dir: $tmp_dir"
 
-  for repo in "${repos[@]}"; do
+  for repo in $repos; do
     work || continue
   done
 


### PR DESCRIPTION
`repos` needs to be properly split: https://prow.istio.io/view/gcs/istio-prow/logs/update-common_common-files_postsubmit/22