### PR TITLE
Tide: no approval required for auto-merge by istio-testing

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -341,6 +341,30 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     reviewApprovedRequired: true
+  - repos:
+    - istio/istio
+    - istio/proxy
+    - istio/operator
+    - istio/pkg
+    - istio/tools
+    - istio/bots
+    - istio/api
+    - istio/common-files
+    - istio/community
+    - istio/istio.io
+    - istio/gogo-genproto
+    - istio/test-infra
+    - istio/cni
+    - istio/installer
+    - istio/cri
+    - istio/client-go
+    - istio/release-builder
+    labels:
+    - "cla: yes"
+    - auto-merge
+    missingLabels: *istio_tide_missing_labels
+    author: istio-testing
+    reviewApprovedRequired: false
   - orgs:
     - istio-private
     missingLabels: *istio_tide_missing_labels


### PR DESCRIPTION
Any PR with the label `auto-merge` authored by `istio-testing` should **not** require approval to merge.

fix https://github.com/istio/test-infra/issues/2304