### PR TITLE
Removing defunct E2E tests from CNI

### DIFF
--- a/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.master.gen.yaml
@@ -65,59 +65,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    extra_refs:
-    - base_ref: master
-      org: istio
-      path_alias: istio.io/istio
-      repo: istio
-    name: e2e_cni_postsubmit
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - e2e
-        image: gcr.io/istio-testing/build-tools:master-2020-02-14T13-09-14
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_cni_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: lint_cni_postsubmit
     path_alias: istio.io/cni
     spec:
@@ -222,58 +169,6 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_cni
-    branches:
-    - ^master$
-    decorate: true
-    extra_refs:
-    - base_ref: master
-      org: istio
-      path_alias: istio.io/istio
-      repo: istio
-    name: e2e_cni
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - e2e
-        image: gcr.io/istio-testing/build-tools:master-2020-02-14T13-09-14
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_cni

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.5.gen.yaml
@@ -65,59 +65,6 @@ postsubmits:
     branches:
     - ^release-1.5$
     decorate: true
-    extra_refs:
-    - base_ref: release-1.5
-      org: istio
-      path_alias: istio.io/istio
-      repo: istio
-    name: e2e_cni_release-1.5_postsubmit
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - e2e
-        image: gcr.io/istio-testing/build-tools:release-1.5-2020-02-14T14-00-07
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_release-1.5_cni_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^release-1.5$
-    decorate: true
     name: lint_cni_release-1.5_postsubmit
     path_alias: istio.io/cni
     spec:
@@ -222,58 +169,6 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_release-1.5_cni
-    branches:
-    - ^release-1.5$
-    decorate: true
-    extra_refs:
-    - base_ref: release-1.5
-      org: istio
-      path_alias: istio.io/istio
-      repo: istio
-    name: e2e_cni_release-1.5
-    path_alias: istio.io/cni
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - e2e
-        image: gcr.io/istio-testing/build-tools:release-1.5-2020-02-14T14-00-07
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: 500m
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.5_cni

--- a/prow/config/jobs/cni-1.5.yaml
+++ b/prow/config/jobs/cni-1.5.yaml
@@ -14,15 +14,6 @@ jobs:
   - test
   name: install
 - command:
-  - entrypoint
-  - make
-  - e2e
-  name: e2e
-  repos:
-  - istio/istio
-  requirements:
-  - kind
-- command:
   - make
   - lint
   name: lint

--- a/prow/config/jobs/cni.yaml
+++ b/prow/config/jobs/cni.yaml
@@ -10,11 +10,6 @@ jobs:
   - name: install
     command: [entrypoint, make, docker, test]
 
-  - name: e2e
-    command: [entrypoint, make, e2e]
-    requirements: [kind]
-    repos: [istio/istio]
-
   - name: lint
     command: [make, lint]
 


### PR DESCRIPTION
These E2E tests were broken by upstream changes, and are duplicated in upstream istio/istio tests anyways. Fixing them would require some significant changes in 1.5 and the helm chart they are testing will be removed shortly in master (1.6).