### PR TITLE
Tune cpu/mem for istio/{proxy,envoy}

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -40,8 +40,8 @@ postsubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -84,8 +84,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -120,8 +120,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -156,8 +156,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -193,8 +193,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -230,8 +230,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -16,7 +16,7 @@ presubmits:
         - bazel.asan
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -24,8 +24,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -45,7 +45,7 @@ presubmits:
         - bazel.tsan
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -53,8 +53,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -74,7 +74,7 @@ presubmits:
         - bazel.release
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -82,8 +82,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
@@ -16,7 +16,7 @@ presubmits:
         - bazel.asan
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -24,8 +24,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -45,7 +45,7 @@ presubmits:
         - bazel.tsan
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -53,8 +53,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -74,7 +74,7 @@ presubmits:
         - bazel.release
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -82,8 +82,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
@@ -16,7 +16,7 @@ presubmits:
         - bazel.asan
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -24,8 +24,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -45,7 +45,7 @@ presubmits:
         - bazel.tsan
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -53,8 +53,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -74,7 +74,7 @@ presubmits:
         - bazel.release
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=14
+          value: --local_ram_resources=32768 --local_cpu_resources=12
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
@@ -82,8 +82,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -26,8 +26,8 @@ postsubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -59,8 +59,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -84,8 +84,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -109,8 +109,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -136,8 +136,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -162,8 +162,8 @@ presubmits:
             cpu: "16"
             memory: 60Gi
           requests:
-            cpu: "15"
-            memory: 55Gi
+            cpu: "14"
+            memory: 50Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -8,28 +8,28 @@ jobs:
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=32768 --local_cpu_resources=14"
+    value: "--local_ram_resources=32768 --local_cpu_resources=12"
   command: [./ci/do_circle_ci.sh, bazel.asan]
 
 - name: test-tsan
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=32768 --local_cpu_resources=14"
+    value: "--local_ram_resources=32768 --local_cpu_resources=12"
   command: [./ci/do_circle_ci.sh, bazel.tsan]
 
 - name: test-release
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=32768 --local_cpu_resources=14"
+    value: "--local_ram_resources=32768 --local_cpu_resources=12"
   command: [./ci/do_circle_ci.sh, bazel.release]
 
 resources:
   default:
     requests:
-      memory: "55Gi"
-      cpu: "15000m"
+      memory: "50Gi"
+      cpu: "14000m"
     limits:
       memory: "60Gi"
       cpu: "16000m"

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -35,8 +35,8 @@ jobs:
 resources:
   default:
     requests:
-      memory: "55Gi"
-      cpu: "15000m"
+      memory: "50Gi"
+      cpu: "14000m"
     limits:
       memory: "60Gi"
       cpu: "16000m"


### PR DESCRIPTION
This puts the jobs just within the cpu/memory allocatable limits of nodes:

![image](https://user-images.githubusercontent.com/9957358/75089186-31662380-550b-11ea-9077-b32d820065bb.png)

example: https://prow.istio.io/log?id=29&job=test-asan_envoy_release-1.5



