### PR TITLE
Use ci/do_ci.sh in istio/envoy.

### DIFF
--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -12,11 +12,11 @@ presubmits:
     spec:
       containers:
       - command:
-        - ./ci/do_circle_ci.sh
+        - ./ci/do_ci.sh
         - bazel.release
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=12
+          value: --local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
@@ -12,11 +12,11 @@ presubmits:
     spec:
       containers:
       - command:
-        - ./ci/do_circle_ci.sh
+        - ./ci/do_ci.sh
         - bazel.release
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=12
+          value: --local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
@@ -12,11 +12,11 @@ presubmits:
     spec:
       containers:
       - command:
-        - ./ci/do_circle_ci.sh
+        - ./ci/do_ci.sh
         - bazel.release
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=12
+          value: --local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -9,22 +9,22 @@ jobs:
 #   type: presubmit
 #   env:
 #   - name: BAZEL_BUILD_EXTRA_OPTIONS
-#     value: "--local_ram_resources=32768 --local_cpu_resources=12"
-#   command: [./ci/do_circle_ci.sh, bazel.asan]
+#     value: "--local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+#   command: [./ci/do_ci.sh, bazel.asan]
 
 # - name: test-tsan
 #   type: presubmit
 #   env:
 #   - name: BAZEL_BUILD_EXTRA_OPTIONS
-#     value: "--local_ram_resources=32768 --local_cpu_resources=12"
-#   command: [./ci/do_circle_ci.sh, bazel.tsan]
+#     value: "--local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+#   command: [./ci/do_ci.sh, bazel.tsan]
 
 - name: test-release
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=32768 --local_cpu_resources=12"
-  command: [./ci/do_circle_ci.sh, bazel.release]
+    value: "--local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+  command: [./ci/do_ci.sh, bazel.release]
 
 resources:
   default:


### PR DESCRIPTION
ci/do_circle_ci.sh is a convenient wrapper around ci/do_ci.sh,
but it hardcodes the number of CPUs to 8, so we have to skip it.

Lift "--test_env=ENVOY_IP_TEST_VERSIONS=v4only" from there,
otherwise a lot of IPv6 tests will fail.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>