### PR TITLE
Boskos: add toleration for exclusivity

### DIFF
--- a/boskos/cluster/boskos-deployment.yaml
+++ b/boskos/cluster/boskos-deployment.yaml
@@ -14,14 +14,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: boskos-crd-admin
 rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    verbs: ["*"]
-    resources:
-      - customresourcedefinitions
-  - apiGroups: ["boskos.k8s.io"]
-    verbs: ["*"]
-    resources: ["*"]
+- apiGroups:
+  - apiextensions.k8s.io
+  verbs: ["*"]
+  resources:
+  - customresourcedefinitions
+- apiGroups: ["boskos.k8s.io"]
+  verbs: ["*"]
+  resources: ["*"]
 
 ---
 kind: ClusterRoleBinding
@@ -29,9 +29,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: boskos-crd-admin-binding
 subjects:
-  - kind: ServiceAccount
-    name: boskos-admin
-    namespace: boskos
+- kind: ServiceAccount
+  name: boskos-admin
+  namespace: boskos
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
@@ -63,8 +63,8 @@ spec:
         - --config=/etc/config/resources.yaml
         - --namespace=boskos
         ports:
-          - containerPort: 8080
-            protocol: TCP
+        - containerPort: 8080
+          protocol: TCP
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -73,5 +73,10 @@ spec:
       - name: config
         configMap:
           name: boskos-config
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: boskos
+        effect: NoSchedule
       nodeSelector:
         prod: boskos

--- a/boskos/cluster/cleaner-deployment.yaml
+++ b/boskos/cluster/cleaner-deployment.yaml
@@ -11,15 +11,15 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    verbs: ["create"]
-    resources:
-      - customresourcedefinitions
-  - apiGroups:
-      - boskos.k8s.io
-    verbs: ["get", "list"]
-    resources: ["*"]
+- apiGroups:
+  - apiextensions.k8s.io
+  verbs: ["create"]
+  resources:
+  - customresourcedefinitions
+- apiGroups:
+  - boskos.k8s.io
+  verbs: ["get", "list"]
+  resources: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -27,9 +27,9 @@ metadata:
   name: boskos-crd-reader-binding
   namespace: boskos
 subjects:
-  - kind: ServiceAccount
-    name: boskos-reader
-    namespace: boskos
+- kind: ServiceAccount
+  name: boskos-reader
+  namespace: boskos
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
@@ -60,6 +60,11 @@ spec:
         args:
         - --cleaner-count=3
         - --namespace=boskos
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: boskos
+        effect: NoSchedule
       nodeSelector:
         prod: boskos
 

--- a/boskos/cluster/janitor-deployment.yaml
+++ b/boskos/cluster/janitor-deployment.yaml
@@ -28,5 +28,10 @@ spec:
       - name: boskos-service-account
         secret:
           secretName: boskos-service-account
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: boskos
+        effect: NoSchedule
       nodeSelector:
         prod: boskos

--- a/boskos/cluster/mason-deployment.yaml
+++ b/boskos/cluster/mason-deployment.yaml
@@ -29,5 +29,10 @@ spec:
       - name: service-account
         secret:
           secretName: boskos-service-account
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: boskos
+        effect: NoSchedule
       nodeSelector:
         prod: boskos

--- a/boskos/cluster/metrics-deployment.yaml
+++ b/boskos/cluster/metrics-deployment.yaml
@@ -30,5 +30,10 @@ spec:
           timeoutSeconds: 1
           successThreshold: 1
           failureThreshold: 10
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: boskos
+        effect: NoSchedule
       nodeSelector:
         prod: boskos

--- a/boskos/cluster/reaper-deployment.yaml
+++ b/boskos/cluster/reaper-deployment.yaml
@@ -18,6 +18,11 @@ spec:
         image: gcr.io/k8s-prow/boskos/reaper:v20190730-dbac84bd7
         args:
         - --resource-type=gke-perf-preset,gcp-perf-test,gcp-project,gke-e2e-test
+      tolerations:
+      - key: dedicated
+        operator: Equal
+        value: boskos
+        effect: NoSchedule
       nodeSelector:
         prod: boskos
 


### PR DESCRIPTION
Add a toleration for taint (_added after merge_) on components running in `boskos-pool` for ensured exclusivity. 

> Currently, some of the `periodic`s without `nodeSelector`s are being scheduled on these nodes. 