### PR TITLE
Increase istio/{envoy,proxy} cpu/memory resources

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -37,11 +37,11 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -81,11 +81,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -117,11 +117,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -153,11 +153,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -190,11 +190,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -227,11 +227,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -16,18 +16,18 @@ presubmits:
         - bazel.dev
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+          value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
@@ -16,18 +16,18 @@ presubmits:
         - bazel.dev
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+          value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
@@ -16,18 +16,18 @@ presubmits:
         - bazel.dev
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
-          value: --local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+          value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -23,11 +23,11 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -56,11 +56,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -81,11 +81,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -106,11 +106,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -133,11 +133,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -159,11 +159,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "16"
-            memory: 60Gi
+            cpu: "32"
+            memory: 120Gi
           requests:
-            cpu: "14"
-            memory: 50Gi
+            cpu: "30"
+            memory: 110Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -9,7 +9,7 @@ jobs:
 #   type: presubmit
 #   env:
 #   - name: BAZEL_BUILD_EXTRA_OPTIONS
-#     value: "--local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+#     value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
 #   - name: ENVOY_SRCDIR
 #     value: "/home/prow/go/src/istio.io/envoy"
 #   command: [./ci/do_ci.sh, bazel.asan]
@@ -18,7 +18,7 @@ jobs:
 #   type: presubmit
 #   env:
 #   - name: BAZEL_BUILD_EXTRA_OPTIONS
-#     value: "--local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+#     value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
 #   - name: ENVOY_SRCDIR
 #     value: "/home/prow/go/src/istio.io/envoy"
 #   command: [./ci/do_ci.sh, bazel.tsan]
@@ -27,7 +27,7 @@ jobs:
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=32768 --local_cpu_resources=12 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
   - name: ENVOY_SRCDIR
     value: "/home/prow/go/src/istio.io/envoy"
   # TODO(change to "bazel.release" when we have enough resources)
@@ -36,8 +36,8 @@ jobs:
 resources:
   default:
     requests:
-      memory: "50Gi"
-      cpu: "14000m"
+      memory: "110Gi"
+      cpu: "30000m"
     limits:
-      memory: "60Gi"
-      cpu: "16000m"
+      memory: "120Gi"
+      cpu: "32000m"

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -35,8 +35,8 @@ jobs:
 resources:
   default:
     requests:
-      memory: "50Gi"
-      cpu: "14000m"
+      memory: "110Gi"
+      cpu: "30000m"
     limits:
-      memory: "60Gi"
-      cpu: "16000m"
+      memory: "120Gi"
+      cpu: "32000m"


### PR DESCRIPTION
I reshaped the node pool to [n1-standard-32](https://cloud.google.com/compute/docs/machine-types): 32 vCPUs; 120GB Memory; 512GB Disk.  Let me know if the following job(s) need additional tweaks or if we want even more resources.

ref: https://github.com/istio/test-infra/issues/2385





