### PR TITLE
Try out removing CPU limits on istio/istio

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -28,7 +28,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -64,7 +63,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -96,7 +94,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -131,7 +128,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -183,7 +179,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -224,7 +219,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -279,7 +273,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -334,7 +327,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -389,7 +381,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -444,7 +435,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -496,7 +486,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -555,7 +544,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -614,7 +602,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -673,7 +660,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -724,7 +710,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "3"
@@ -755,7 +740,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -794,7 +778,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -827,7 +810,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -860,7 +842,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -896,7 +877,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -952,7 +932,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1008,7 +987,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1064,7 +1042,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1120,7 +1097,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1176,7 +1152,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1229,7 +1204,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1282,7 +1256,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1320,7 +1293,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "3"
@@ -1352,7 +1324,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -24,7 +24,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -52,7 +51,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -81,7 +79,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -112,7 +109,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -160,7 +156,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -197,7 +192,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -248,7 +242,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -299,7 +292,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -350,7 +342,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -401,7 +392,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -449,7 +439,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -504,7 +493,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -559,7 +547,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -614,7 +601,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -661,7 +647,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "3"
@@ -688,7 +673,6 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -721,7 +705,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -748,7 +731,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -776,7 +758,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -806,7 +787,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -856,7 +836,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -906,7 +885,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -956,7 +934,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1006,7 +983,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1056,7 +1032,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1103,7 +1078,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1150,7 +1124,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1182,7 +1155,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "3"
@@ -1208,7 +1180,6 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "5"

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -181,11 +181,9 @@ resources:
       cpu: "5000m"
     limits:
       memory: "24Gi"
-      cpu: "8000m"
   lint:
     requests:
       memory: "16Gi"
       cpu: "3000m"
     limits:
       memory: "24Gi"
-      cpu: "5000m"


### PR DESCRIPTION
Some context:
https://github.com/istio/test-infra/pull/2419#discussion_r383018567

The goal with our configuration is just to guarantee that each job has
at least 5 CPUs (which is itself a fairly arbitrary value - may benefit
from tuning). Adding a limit just introduces needless throttling due to
kernel bugs and/or due to artificial limits. If the pod has exclusive
access to the node, I see no strong reason to not let it use all 32
cores.

If this ends up being a horrible idea we can always revert