### PR TITLE
Fix mem and add storage for istio/{proxy,envoy}

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -38,10 +38,10 @@ postsubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
         volumeMounts:
@@ -82,10 +82,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -118,10 +118,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -154,10 +154,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -191,10 +191,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -228,10 +228,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -24,10 +24,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -55,10 +57,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -86,10 +90,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
@@ -24,10 +24,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -55,10 +57,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -86,10 +90,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
@@ -24,10 +24,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -55,10 +57,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -86,10 +90,12 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            ephemeral-storage: 400G
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            ephemeral-storage: 400G
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -24,10 +24,10 @@ postsubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
         volumeMounts:
@@ -57,10 +57,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -82,10 +82,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -107,10 +107,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -134,10 +134,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
       nodeSelector:
@@ -160,10 +160,10 @@ presubmits:
         resources:
           limits:
             cpu: "32"
-            memory: 120Gi
+            memory: 120G
           requests:
             cpu: "30"
-            memory: 100Gi
+            memory: 100G
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -34,8 +34,10 @@ jobs:
 resources:
   default:
     requests:
-      memory: "100Gi"
-      cpu: "30000m"
+      memory: "100G"
+      cpu: "30"
+      ephemeral-storage: "400G"
     limits:
-      memory: "120Gi"
-      cpu: "32000m"
+      memory: "120G"
+      cpu: "32"
+      ephemeral-storage: "400G"

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -35,8 +35,8 @@ jobs:
 resources:
   default:
     requests:
-      memory: "100Gi"
-      cpu: "30000m"
+      memory: "100G"
+      cpu: "30"
     limits:
-      memory: "120Gi"
-      cpu: "32000m"
+      memory: "120G"
+      cpu: "32"


### PR DESCRIPTION
* Fix Memory requests/limits. These should be `GB`, not `GiB` to be in accord with upper bound in GCP.
* Add Ephemeral Storage requests/limits.

fix https://github.com/istio/test-infra/issues/2385