### PR TITLE
Retry flaky tests up to 9 times in istio/envoy.

### DIFF
--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -17,6 +17,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
@@ -50,6 +51,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
@@ -83,6 +85,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
@@ -17,6 +17,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
@@ -50,6 +51,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
@@ -83,6 +85,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
@@ -17,6 +17,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
@@ -50,6 +51,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
@@ -83,6 +85,7 @@ presubmits:
         env:
         - name: BAZEL_BUILD_EXTRA_OPTIONS
           value: --local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+            --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
         image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -10,7 +10,7 @@ jobs:
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only --flaky_test_attempts=9"
   - name: ENVOY_SRCDIR
     value: "/home/prow/go/src/istio.io/envoy"
   command: [./ci/do_ci.sh, bazel.asan]
@@ -19,7 +19,7 @@ jobs:
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only --flaky_test_attempts=9"
   - name: ENVOY_SRCDIR
     value: "/home/prow/go/src/istio.io/envoy"
   command: [./ci/do_ci.sh, bazel.tsan]
@@ -28,7 +28,7 @@ jobs:
   type: presubmit
   env:
   - name: BAZEL_BUILD_EXTRA_OPTIONS
-    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+    value: "--local_ram_resources=65536 --local_cpu_resources=28 --test_env=ENVOY_IP_TEST_VERSIONS=v4only --flaky_test_attempts=9"
   - name: ENVOY_SRCDIR
     value: "/home/prow/go/src/istio.io/envoy"
   command: [./ci/do_ci.sh, bazel.release]


### PR DESCRIPTION
This should only apply to tests explicitly marked as flaky, e.g.
//test/integration:protocol_integration_test.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>