### PR TITLE
Fix storage limit in istio/{proxy,envoy}

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -38,7 +38,6 @@ postsubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -83,7 +82,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -120,7 +118,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -157,7 +154,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -195,7 +191,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -233,7 +228,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -25,7 +25,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"
@@ -59,7 +59,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"
@@ -93,7 +93,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.4.gen.yaml
@@ -25,7 +25,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"
@@ -59,7 +59,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"
@@ -93,7 +93,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.5.gen.yaml
@@ -25,7 +25,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"
@@ -59,7 +59,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"
@@ -93,7 +93,7 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
+            ephemeral-storage: 800G
             memory: 240G
           requests:
             cpu: "30"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -24,7 +24,6 @@ postsubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -58,7 +57,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -84,7 +82,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -110,7 +107,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -138,7 +134,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"
@@ -165,7 +160,6 @@ presubmits:
         resources:
           limits:
             cpu: "64"
-            ephemeral-storage: 1024G
             memory: 240G
           requests:
             cpu: "30"

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -42,4 +42,4 @@ resources:
     limits:
       memory: "240G"
       cpu: "64"
-      ephemeral-storage: "1024G"
+      ephemeral-storage: "800G"

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -42,4 +42,3 @@ resources:
     limits:
       memory: "240G"
       cpu: "64"
-      ephemeral-storage: "1024G"


### PR DESCRIPTION
Two problem:

1. While the disk is 1024G the allocatable space is only ~860G so adjusting the limit accordingly:  `ephemeral-storage: "800G"`
2. I was not aware that a resource limit without a request defaults the request to the limit in pod. 