### PR TITLE
Enable allow_disabled_job_policies for istio/envoy@master

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -106,6 +106,7 @@ github_reporter:
 
 branch-protection:
   allow_disabled_policies: true
+  allow_disabled_job_policies: true
   protect: false
   orgs:
     istio:


### PR DESCRIPTION
The current options are this or remove/optional `istio/envoy@master` jobs.

https://prow.istio.io/view/gcs/istio-prow/logs/ci-test-infra-branchprotector/1168990827033141386

```console
update envoy: [update master from protected=true: get policy: required prow jobs require branch protection]
```