### PR TITLE
fix authorship attribution

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -387,6 +387,15 @@ tide:
     istio-releases/pipeline: squash
     istio-ecosystem/authservice: squash
     istio-private: squash
+  merge_commit_template:
+    istio:
+      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
+    istio-releases/pipeline:
+      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
+    istio-ecosystem/authservice:
+      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
+    istio-private:
+      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
   target_url: https://prow.istio.io/tide
   context_options:
     from-branch-protection: true


### PR DESCRIPTION
This is a solution for: https://github.com/kubernetes/test-infra/issues/16618 where authorship attribution is given to the bot and not the PR author for merge squash commits.

https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors

<img width="1792" alt="Screen Shot 2020-03-05 at 12 37 32 AM" src="https://user-images.githubusercontent.com/9957358/75963113-cce78480-5e79-11ea-81bc-148cd734c9a0.png">


 

