### PR TITLE
Revert "fix authorship attribution"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -387,15 +387,6 @@ tide:
     istio-releases/pipeline: squash
     istio-ecosystem/authservice: squash
     istio-private: squash
-  merge_commit_template:
-    istio:
-      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
-    istio-releases/pipeline:
-      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
-    istio-ecosystem/authservice:
-      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
-    istio-private:
-      body: "Co-authored-by: {{.Author.Login}} <{{.Author.Login}}@users.noreply.github.com>"
   target_url: https://prow.istio.io/tide
   context_options:
     from-branch-protection: true


### PR DESCRIPTION
Reverts istio/test-infra#2464

GitHub reverted the original change that made this necessary.

https://github.community/t5/How-to-use-Git-and-GitHub/Authorship-of-merge-commits-made-by-Github-Apps-changed/td-p/48797/page/2