### PR TITLE
add timeout for benchmark job

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -35,9 +35,9 @@ periodics:
   name: daily-performance-benchmark
   branches: master
   decorate: true
-  timeout: 17h
+  timeout: 24h
   decoration_config:
-    timeout: 17h0m0s
+    timeout: 24h0m0s
   extra_refs:
     - org: istio
       repo: tools
@@ -63,9 +63,9 @@ periodics:
   name: daily-performance-benchmark-release-1.5
   branches: release-1.5
   decorate: true
-  timeout: 17h
+  timeout: 24h
   decoration_config:
-    timeout: 17h0m0s
+    timeout: 24h0m0s
   extra_refs:
     - org: istio
       repo: tools


### PR DESCRIPTION
now since we have more configs including stackdriver filters, we need more time for the job. However at the same time I will try to investigate how to parallel the different configs to reduce running time.