### PR TITLE
Update build-tools updater

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -144,7 +144,7 @@ postsubmits:
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
-        - --script-args=--post=make gen
+        - --script-args=--post=make gen --source="$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh"
         image: gcr.io/istio-testing/build-tools:master-2020-03-05T18-27-04
         name: ""
         resources:

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -45,6 +45,6 @@ jobs:
     - --modifier=buildtools
     - --token-path=/etc/github-token/oauth
     - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
-    - --script-args=--post=make gen
+    - --script-args=--post=make gen --source="$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh"
     requirements: [github]
     repos: [istio/test-infra]


### PR DESCRIPTION
Needed after
https://github.com/istio/common-files/commit/dfe763eb1963f7e1205625405693c532a60f6f51

I wasn't sure if it was preferred to add `--source` here or modify the original script and add the flag to the old versions, so I just went with this