### PR TITLE
Automator: improve and simplify error handling

### DIFF
--- a/tools/automator/utils.sh
+++ b/tools/automator/utils.sh
@@ -16,12 +16,21 @@
 
 set -euo pipefail
 
-print_error_and_exit() {
+print_error() {
+  local last_return="$?"
+
   {
     echo
-    echo "$1"
-    exit "${2:-1}"
+    echo "${1:-unknown error}"
+    echo
   } >&2
+
+  return "${2:-$last_return}"
+}
+
+print_error_and_exit() {
+  print_error "${1:-unknown error}"
+  exit "${2:-1}"
 }
 
 split_on_commas() {


### PR DESCRIPTION
- Add `print_error()` utility function to print errors while retaining return code.
- Additional logging when are error does occur.
- PRs for a particular _repo_ will **not** be created or update if an error occurs.
- _Any_ error in `work()` returns early and execution proceeds to the next `$repo`
- General simplification of `bash` logic using `set -e` and less conditionals inside `work()`.

... otherwise the behavior is _exactly_ the same as before.
