### PR TITLE
bp: allow force push istio-private

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -281,6 +281,7 @@ branch-protection:
             master:
               protect: true
     istio-private:
+      allow_force_pushes: true
       required_pull_request_reviews:
         <<: *protection_required_pull_request_reviews
         require_code_owner_reviews: false


### PR DESCRIPTION
**feature:** 
https://github.com/kubernetes/test-infra/pull/16669

**rationale:** 
https://github.com/kubernetes/test-infra/issues/16077

More specifically, the motivation is to simplify the private repository syncing process: 

> [Synching Repositories](https://github.com/istio-private/istio/wiki#synching-repositories)

> [Managing Private/Security Build Branches](https://docs.google.com/document/d/19qf0-0GIopEZZWuG-lj8_VpyQF4N9nIKXiZgcJHwBRM/edit?usp=sharing)

---

The preferred approach to keep the private repositories updated is to clone a bare copy of the public repo and mirror it to the private repo. There is a script to do this.

> Note: this will overwrite a private repo to the current state of the public repo for every ref.

> Note: prow turns on branch protection automagically which prevents this script from working. Before one needed to first visit the branch protection pages of all the istio-private repos (e.g., https://github.com/istio-private/release-builder/settings/branches) and turn off branch protection on master and on the release-1.* branches. 