### PR TITLE
use correct requirements for mason image push

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -196,7 +196,7 @@ postsubmits:
     cluster: test-infra-trusted
     decorate: true
     labels:
-      preset-prow-deployer-service-account: "true"
+      preset-service-account: "true"
     max_concurrency: 1
     name: push-mason_test-infra_postsubmit
     path_alias: istio.io/test-infra
@@ -219,8 +219,14 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         prod: prow
+      volumes:
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_test-infra_postsubmit

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -67,7 +67,7 @@ jobs:
     - -C
     - boskos
     - mason-image
-    requirements: [deploy]
+    requirements: [docker, gcp]
     node_selector:
         prod: prow
 


### PR DESCRIPTION
Pushing the `mason` image requires _docker_ and _GCR access_. 🤦‍♂ 