### PR TITLE
Enable IPv6 on the docker daemon

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -148,6 +148,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.reachability
         env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
         - name: IP_FAMILY
           value: ipv6
         - name: TEST_SELECT
@@ -1269,6 +1271,8 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.reachability
         env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
         - name: IP_FAMILY
           value: ipv6
         - name: TEST_SELECT

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -172,6 +172,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.reachability
         env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
         - name: IP_FAMILY
           value: ipv6
         - name: TEST_SELECT
@@ -1233,6 +1235,8 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.reachability
         env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
         - name: IP_FAMILY
           value: ipv6
         - name: TEST_SELECT

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -85,6 +85,8 @@ jobs:
     requirements: [kind]
     modifiers: [optional, hidden]
     env:
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+        value: "true"
       - name: IP_FAMILY
         value: "ipv6"
       - name: TEST_SELECT


### PR DESCRIPTION
I forgot to enable ipv6 on the docker daemon for the IPv6 job