### PR TITLE
genjobs: replace refs when extra refs are used

### DIFF
--- a/prow/genjobs/Makefile
+++ b/prow/genjobs/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = istio-testing
 HUB = gcr.io
-VERSION ?= 0.0.5
+VERSION ?= 0.0.6
 
 .PHONY: deploy
 deploy: image push

--- a/prow/genjobs/README.md
+++ b/prow/genjobs/README.md
@@ -158,3 +158,4 @@ genjobs --mapping istio=istio-private --clean
 - 0.0.3: add `--verbose` option to enable verbose output and `--configs` option for specifying transforms via a yaml configuration file(s).
 - 0.0.4: add `defaults` key for specifying _file-level_ defaults, support a `.defaults.yaml` file for _local_ defaults, and add `--global` option for _global_ defaults.
 - 0.0.5: rename `--extra-refs` option to `--refs` and designate `extra-refs` key for specifying a list of extra refs to append to job.
+- 0.0.6: `--extra-refs` will now replace existing refs, rather than adding to them.

--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -713,7 +713,9 @@ func updateExtraRefs(o options, job *config.UtilityConfig) {
 			}
 		}
 	}
-	job.ExtraRefs = append(job.ExtraRefs, o.ExtraRefs...)
+	if len(o.ExtraRefs) > 0 {
+		job.ExtraRefs = o.ExtraRefs
+	}
 }
 
 // sortJobs sorts jobs based on a provided sort order.


### PR DESCRIPTION
Otherwise, there is no way to override a ref