### PR TITLE
Authentikos: force refresh of cached token

### DIFF
--- a/authentikos/Makefile
+++ b/authentikos/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = istio-testing
 HUB = gcr.io
-VERSION ?= 0.0.5
+VERSION ?= 0.0.6
 
 .PHONY: deploy
 deploy: image push

--- a/authentikos/README.md
+++ b/authentikos/README.md
@@ -39,6 +39,7 @@ The following is a list of supported options for `authentikos`:
   -c, --creds string           Path to a JSON credentials file.
   -k, --key string             Name of secret data key. (default "token")
   -n, --namespace strings      Namespace(s) to create the secret in. (default [default])
+  -r, --reuse                  Reuse a cached token until it is expired.
   -s, --scopes strings         Oauth scope(s) to request for token.
   -o, --secret string          Name of secret to create. (default "authentikos-token")
   -t, --template string        Template string for the token.
@@ -53,3 +54,4 @@ The following is a list of supported options for `authentikos`:
 - 0.0.3: add new `TimeToUnix`, `UnixToTime`, and `Parse` template variable and change method signature for math template variables from `(a, b time.Duration) time.Duration` to `(a, b int64) int64`.
 - 0.0.4: add `--key` option for specifying the name of the data key in the created Kubernetes secret.
 - 0.0.5: use [Sprig](http://masterminds.github.io/sprig/) as the library for template functions.
+- 0.0.6: add `--reuse` option for reusing (i.e. caching) a token until it is expired. If this option is omitted or false, credentials will be forcibly refreshed.

--- a/authentikos/examples/authentikos-deployment.yaml
+++ b/authentikos/examples/authentikos-deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: authentikos
       containers:
       - name: authentikos
-        image: gcr.io/istio-testing/authentikos:0.0.4
+        image: gcr.io/istio-testing/authentikos:0.0.6
         imagePullPolicy: Always
         args:
         - --verbose

--- a/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
+++ b/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: authentikos
       containers:
       - name: authentikos
-        image: gcr.io/istio-testing/authentikos:0.0.4
+        image: gcr.io/istio-testing/authentikos:0.0.6
         imagePullPolicy: Always
         args:
         - --verbose

--- a/authentikos/go.mod
+++ b/authentikos/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/api v0.4.0
 	k8s.io/api v0.0.0-20191005115622-2e41325d9e4b


### PR DESCRIPTION
#### History
The default token source for google oauth2 http client uses [`ReuseTokenSource`](https://github.com/roabay/util/blob/70cefad84e9cd69a508e81ff60dfa905aa2f231b/golang.org/x/oauth2/oauth2.go#L313-L340) which is employed to reuse tokens from a cache (such as a file on disk) between runs of a program, rather than obtaining new tokens unnecessarily. 

#### Change
Add a `-r`, `--reuse` option for reusing a cached token before it is expired. If this option is omitted or false, credentials will be forcibly refreshed even if not yet expired.



