### PR TITLE
Authentikos: intelligent token refresh

### DIFF
--- a/authentikos/Makefile
+++ b/authentikos/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = istio-testing
 HUB = gcr.io
-VERSION ?= 0.0.5
+VERSION ?= 0.0.6
 
 .PHONY: deploy
 deploy: image push

--- a/authentikos/README.md
+++ b/authentikos/README.md
@@ -37,9 +37,11 @@ The following is a list of supported options for `authentikos`:
 
 ```console
   -c, --creds string           Path to a JSON credentials file.
+  -r, --force-refresh          Force a token refresh. Otherwise, the token will only refresh when necessary.
+  -i, --interval duration      Token refresh interval [1m0s - 50m0s). (default 30m0s)
   -k, --key string             Name of secret data key. (default "token")
   -n, --namespace strings      Namespace(s) to create the secret in. (default [default])
-  -s, --scopes strings         Oauth scope(s) to request for token.
+  -s, --scopes strings         Oauth scope(s) to request for token (see: https://developers.google.com/identity/protocols/oauth2/scopes).
   -o, --secret string          Name of secret to create. (default "authentikos-token")
   -t, --template string        Template string for the token.
   -f, --template-file string   Path to a template string for the token.
@@ -48,8 +50,9 @@ The following is a list of supported options for `authentikos`:
 
 ## Changelog
 
-- 0.0.1: initial release
-- 0.0.2: remove `--format` option and add `--template` and `--template-file` options.
-- 0.0.3: add new `TimeToUnix`, `UnixToTime`, and `Parse` template variable and change method signature for math template variables from `(a, b time.Duration) time.Duration` to `(a, b int64) int64`.
-- 0.0.4: add `--key` option for specifying the name of the data key in the created Kubernetes secret.
-- 0.0.5: use [Sprig](http://masterminds.github.io/sprig/) as the library for template functions.
+- 0.0.1: Initial release
+- 0.0.2: Remove `--format` option and add `--template` and `--template-file` options.
+- 0.0.3: Add new `TimeToUnix`, `UnixToTime`, and `Parse` template variable and change method signature for math template variables from `(a, b time.Duration) time.Duration` to `(a, b int64) int64`.
+- 0.0.4: Add `--key` option for specifying the name of the data key in the created Kubernetes secret.
+- 0.0.5: Use [Sprig](http://masterminds.github.io/sprig/) as the library for template functions.
+- 0.0.6: Add `--force-refresh` option for forcing a token refresh. If this option is omitted or false, the token will only refresh when necessary. Add `--interval` option for customizing the token refresh interval. If unspecified, default scopes to _userinfo.email_, _cloud-platform_, and _openid_.

--- a/authentikos/authentikos_test.go
+++ b/authentikos/authentikos_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2020 Istio Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/oauth2"
+)
+
+func makeFile(data string, readable bool) string {
+	f, _ := ioutil.TempFile("", "")
+	fname := f.Name()
+
+	_ = ioutil.WriteFile(fname, []byte(data), 0644)
+
+	if !readable {
+		_ = os.Chmod(fname, 0000)
+	}
+
+	return fname
+}
+
+func TestValidateFlags(t *testing.T) {
+	creds := "super secret data"
+	template := "{{.Token}}"
+
+	deletedCredsFile := makeFile(creds, true)
+	validTFile := makeFile(template, true)
+	invalidTFile := makeFile(template, false)
+
+	os.Remove(deletedCredsFile)
+	defer os.Remove(validTFile)
+	defer os.Remove(invalidTFile)
+
+	testCases := []struct {
+		name         string
+		args         []string
+		expectedErr  bool
+		postValidate func(options) bool
+	}{
+		{
+			name: "template defaults to defaultTemplate if is zero",
+			args: []string{"--template="},
+			postValidate: func(o options) bool {
+				return o.template == defaultTemplate
+			},
+		},
+		{
+			name: "template (if unset) should be set to contents of template-file",
+			args: []string{"--template=", "--template-file=" + validTFile},
+			postValidate: func(o options) bool {
+				return o.template == template
+			},
+		},
+		{
+			name: "scopes defaults to defaultScopes if is zero",
+			args: []string{"--scopes="},
+			postValidate: func(o options) bool {
+				return reflect.DeepEqual(o.scopes, defaultScopes)
+			},
+		},
+		{
+			name: "secret defaults to defaultSecret if is zero",
+			args: []string{"--secret="},
+			postValidate: func(o options) bool {
+				return o.secret == defaultSecret
+			},
+		},
+		{
+			name: "key default to defaultKey if is zero",
+			args: []string{"--key="},
+			postValidate: func(o options) bool {
+				return o.key == defaultKey
+			},
+		},
+		{
+			name: "namespace default to defaultNamespace if is zero",
+			args: []string{"--namespace="},
+			postValidate: func(o options) bool {
+				return reflect.DeepEqual(o.namespace, []string{defaultNamespace})
+			},
+		},
+		{
+			name:        "error: template and template-file are mutually exclusive",
+			args:        []string{"--template=" + template, "--template-file=/path/to/file"},
+			expectedErr: true,
+		},
+		{
+			name:        "error: template-file unreadable",
+			args:        []string{"--template-file=" + invalidTFile},
+			expectedErr: true,
+		},
+		{
+			name:        "error: creds does not exist",
+			args:        []string{"--creds=" + deletedCredsFile},
+			expectedErr: true,
+		},
+		{
+			name:        fmt.Sprintf("error: interval < minInterval(%v)", minInterval),
+			args:        []string{"--interval=0m"},
+			expectedErr: true,
+		},
+		{
+			name:        fmt.Sprintf("error: interval == maxInterval(%v)", maxInterval),
+			args:        []string{"--interval=50m"},
+			expectedErr: true,
+		},
+		{
+			name:        fmt.Sprintf("error: interval >= maxInterval(%v)", maxInterval),
+			args:        []string{"--interval=51m"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var o options
+
+			os.Args = []string{"authentikos"}
+			os.Args = append(os.Args, tc.args...)
+			pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+			o.parseFlags()
+
+			if err := o.validateFlags(); (err != nil) != tc.expectedErr {
+				t.Fatalf("expected error: %t != actual error: %t: %v", tc.expectedErr, err != nil, err)
+			}
+
+			if tc.postValidate != nil {
+				if !tc.postValidate(o) {
+					t.Fatalf("validation failed")
+				}
+			}
+		})
+	}
+}
+
+func TestIsExpired(t *testing.T) {
+	now := time.Now()
+	timeNow = func() time.Time {
+		return now
+	}
+
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		token    func(interval time.Duration) *oauth2.Token
+		expected bool
+	}{
+		{
+			name:     "Expired because token expiry is in the past",
+			interval: defaultInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(-(100 * time.Minute))}
+			},
+			expected: true,
+		},
+		{
+			name:     "Expired because token expiry plus expiryDelta is before the next reconciliation",
+			interval: defaultInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta).Add(defaultInterval).Add(-(1 * time.Minute))}
+			},
+			expected: true,
+		},
+		{
+			name:     "Expired because token expiry is within the expiryDelta of the next reconciliation",
+			interval: defaultInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta / 2).Add(defaultInterval)}
+			},
+			expected: true,
+		},
+		{
+			name:     "Not expired because token expiry plus expiryDelta is equal to the next reconciliation",
+			interval: defaultInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta).Add(defaultInterval)}
+			},
+			expected: false,
+		},
+		{
+			name:     "Not expired because token expiry plus expiryDelta is after the next reconciliation",
+			interval: defaultInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta).Add(defaultInterval).Add(1 * time.Minute)}
+			},
+			expected: false,
+		},
+		{
+			name:     "Expired if token expiry is < maxInterval",
+			interval: maxInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta).Add(maxInterval).Add(-(1 * time.Minute))}
+			},
+			expected: true,
+		},
+		{
+			name:     "Not expired if token expiry is == maxInterval",
+			interval: maxInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta).Add(maxInterval)}
+			},
+			expected: false,
+		},
+		{
+			name:     "Not expired if token expiry is >= maxInterval",
+			interval: maxInterval,
+			token: func(interval time.Duration) *oauth2.Token {
+				return &oauth2.Token{Expiry: timeNow().Add(expiryDelta).Add(maxInterval).Add(1 * time.Minute)}
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := options{interval: tc.interval, verbose: true}
+			actual := isExpired(o, tc.token(tc.interval))
+			if tc.expected != actual {
+				t.Errorf("expected: %v != actual: %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetBackoffTime(t *testing.T) {
+	testCases := []struct {
+		name          string
+		retry         int
+		backoffFactor float64
+		expected      time.Duration
+	}{
+		{
+			name:          "Retry 0 (i.e. try 1) with a backoff factor 1 should backoff for 1 seconds",
+			retry:         0,
+			backoffFactor: 1,
+			expected:      1 * time.Second,
+		},
+		{
+			name:          "Retry 4 with a backoff factor 1 should backoff for 16 seconds",
+			retry:         4,
+			backoffFactor: 1,
+			expected:      16 * time.Second,
+		},
+		{
+			name:          "Retry 2 with a backoff factor 0.5 should backoff for 2 seconds",
+			retry:         2,
+			backoffFactor: 0.5,
+			expected:      2 * time.Second,
+		},
+		{
+			name:          "Negative backoff factor should return 0 backoff time",
+			retry:         3,
+			backoffFactor: -2,
+			expected:      0,
+		},
+		{
+			name:          "Negative retry number should return 0 backoff time",
+			retry:         -5,
+			backoffFactor: 1,
+			expected:      0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getBackoffTime(tc.backoffFactor, tc.retry)
+			if tc.expected != actual {
+				t.Errorf("expected: %v != actual: %v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/authentikos/examples/authentikos-deployment.yaml
+++ b/authentikos/examples/authentikos-deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: authentikos
       containers:
       - name: authentikos
-        image: gcr.io/istio-testing/authentikos:0.0.4
+        image: gcr.io/istio-testing/authentikos:0.0.6
         imagePullPolicy: Always
         args:
         - --verbose

--- a/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
+++ b/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: authentikos
       containers:
       - name: authentikos
-        image: gcr.io/istio-testing/authentikos:0.0.4
+        image: gcr.io/istio-testing/authentikos:0.0.6
         imagePullPolicy: Always
         args:
         - --verbose

--- a/authentikos/go.mod
+++ b/authentikos/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/api v0.4.0
 	k8s.io/api v0.0.0-20191005115622-2e41325d9e4b


### PR DESCRIPTION
#### Background
The default token source for google oauth2 http client uses [`ReuseTokenSource`](https://github.com/golang/oauth2/blob/aaccbc9213b0974828f81aaac109d194880e3014/oauth2.go#L354-L381) which is employed to reuse tokens from a cache (such as a file on disk) between runs of a program, rather than obtaining new tokens unnecessarily. 

Unfortunately, in **Authentikos**, this _will_ result in a token expiring before it has been refreshed in the k8s secrets due to the tick-based reconciliation loop. Currently, since the refresh interval is `30m` and the default oauth2 token expiration is `60m` (w/ a `10s` delta), in most cases the token will only be expired for ~seconds before being refreshed, minimizing the impact. Regardless, this can easily be fixed by introspecting the token expiry and force refreshing the token as needed (see below). 

#### Changes

1. Add a `-r`, `--force-refresh` option for forcing a token refresh. (_default_: credentials will only refresh when necessary (i.e. cached tokens will be returned when possible)).

> **NOTE:** the default here is also _new_, improved behavior. The token will refresh as needed by inspecting the expiry of the token and comparing it with the time of next token refresh (i.e. reconciliation interval).

2. Add. a `-i`, `--interval` option for customizing the token refresh interval (_default_: 30).

3. Set reasonable default scopes (i.e. the same ones as `gcloud auth application-default print-access-token`).

4. Tests are in a companion PR: https://github.com/istio/test-infra/pull/2512.


**Dependent on: https://github.com/istio/test-infra/pull/2512**