### PR TITLE
Ensure "get-api-resources" is rerun per distinct cluster

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -39,12 +39,12 @@ deploy-velodrome: get-cluster-credentials get-api-resources
 
 deploy-build: PROJECT=$(PROJECT_BUILD)
 deploy-build: CLUSTER=$(CLUSTER_BUILD)
-deploy-build: get-build-cluster-credentials get-api-resources
+deploy-build: get-build-cluster-credentials get-build-api-resources
 	kubectl apply -f ./cluster/build/ --prune -l app.kubernetes.io/part-of=prow-build $(PRUNE_WL)
 
 deploy-private: PROJECT=$(PROJECT_PRIVATE)
 deploy-private: CLUSTER=$(CLUSTER_PRIVATE)
-deploy-private: get-private-cluster-credentials get-api-resources
+deploy-private: get-private-cluster-credentials get-private-api-resources
 	kubectl apply -f ./cluster/private/ --prune -l app.kubernetes.io/part-of=prow-private $(PRUNE_WL)
 
 .PHONY: gen-private-jobs deploy deploy-gcsweb deploy-velodrome deploy-build deploy-private update-config update-config-dry-run

--- a/prow/Makefile.gcloud.mk
+++ b/prow/Makefile.gcloud.mk
@@ -39,8 +39,7 @@ endif
 configure-docker: activate-serviceaccount
 	gcloud auth configure-docker
 
-.PHONY: get-api-resources
-get-api-resources:
+get%api-resources:
 	$(eval PRUNE_WL=$(shell KUBECONFIG=$(KUBECONFIG) \
 	python3 "$(current_dir)/api-resources.py" \
 	  --delimiter=" " \
@@ -48,5 +47,5 @@ get-api-resources:
 	  --group-blacklist "authentication.k8s.io" "authorization.k8s.io"\
 	  ))
 
-get-%-credentials: save-kubeconfig activate-serviceaccount
+get%cluster-credentials: save-kubeconfig activate-serviceaccount
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -104,6 +104,7 @@ postsubmits:
         - prow
         - deploy
         - deploy-gcsweb
+        - deploy-velodrome
         - deploy-build
         - deploy-private
         image: gcr.io/istio-testing/build-tools:master-2020-03-12T14-20-34

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -23,6 +23,7 @@ jobs:
     - prow
     - deploy
     - deploy-gcsweb
+    - deploy-velodrome
     - deploy-build
     - deploy-private
     requirements: [deploy]


### PR DESCRIPTION
Ensure the `get-api-resources` is rerun (i.e. remade) and separate per distinct cluster. Also, add _velodrome_ to auto-deploy job. 

fix: https://prow.istio.io/view/gcs/istio-prow/logs/deploy-prow_test-infra_postsubmit/40