### PR TITLE
Cleanup gcsweb and velodrome ing object configs: part 1

### DIFF
--- a/prow/cluster/gcsweb/gcsweb_ing.yaml
+++ b/prow/cluster/gcsweb/gcsweb_ing.yaml
@@ -6,15 +6,10 @@ metadata:
   name: gcsweb-ing
   namespace: gcs
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: k8s-fw-gcs-gcsweb-ing--c44bd72f22c73d37
+    kubernetes.io/ingress.global-static-ip-name: k8s-fw-gcs-gcsweb-ing--c44bd72f22c73d37, gcsweb
     networking.gke.io/managed-certificates: gcs-istio-io
     kubernetes.io/ingress.class: "gce"
 spec:
-  rules:
-  - host: gcsweb.istio.io
-    http:
-      paths:
-      - path: /*
-        backend:
-          serviceName: gcsweb
-          servicePort: 80
+  backend:
+    serviceName: gcsweb
+    servicePort: 80

--- a/prow/cluster/velodrome/velodrome_ing.yaml
+++ b/prow/cluster/velodrome/velodrome_ing.yaml
@@ -6,7 +6,7 @@ metadata:
   name: velodrome-ing
   namespace: velodrome
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: k8s-fw-velodrome-velodrome-ing--c44bd72f22c73d37
+    kubernetes.io/ingress.global-static-ip-name: k8s-fw-velodrome-velodrome-ing--c44bd72f22c73d37, velodrome
     networking.gke.io/managed-certificates: velodrome-istio-io
     kubernetes.io/ingress.class: "gce"
 spec:


### PR DESCRIPTION
Cleanup ingress object configs for `gcsweb` and `velodrome` to use _default_ backend and human-readable static ips.

> ~Verify configuring of both current and new ips (i.e. DNS failover).~ Cloud DNS supports failover. 

- [x] Create global ips (`velodrome`, `gcsweb`)
- [x] ~This PR (part 1: https://github.com/istio/test-infra/pull/2524).~
- [x] This PR (part 1.5: https://github.com/istio/test-infra/pull/2548).
- [x] Update DNS A record (switch to new ip). 
- [x] Cleanup PR (part 2: https://github.com/istio/test-infra/pull/2525).

/hold
