### PR TITLE
Refine script to create-deps-cm for istio-private dependency overrides

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -37,14 +37,37 @@ deploy-gcsweb: get-cluster-credentials get-api-resources
 deploy-velodrome: get-cluster-credentials get-api-resources
 	kubectl apply -f ./cluster/velodrome/ --prune -l app.kubernetes.io/part-of=velodrome $(PRUNE_WL)
 
-deploy-build: PROJECT=$(PROJECT_BUILD)
-deploy-build: CLUSTER=$(CLUSTER_BUILD)
+get-build-cluster-credentials: PROJECT=$(PROJECT_BUILD)
+get-build-cluster-credentials: CLUSTER=$(CLUSTER_BUILD)
+
 deploy-build: get-build-cluster-credentials get-build-api-resources
 	kubectl apply -f ./cluster/build/ --prune -l app.kubernetes.io/part-of=prow-build $(PRUNE_WL)
 
-deploy-private: PROJECT=$(PROJECT_PRIVATE)
-deploy-private: CLUSTER=$(CLUSTER_PRIVATE)
+get-private-cluster-credentials: PROJECT=$(PROJECT_PRIVATE)
+get-private-cluster-credentials: CLUSTER=$(CLUSTER_PRIVATE)
+
 deploy-private: get-private-cluster-credentials get-private-api-resources
 	kubectl apply -f ./cluster/private/ --prune -l app.kubernetes.io/part-of=prow-private $(PRUNE_WL)
 
-.PHONY: gen-private-jobs deploy deploy-gcsweb deploy-velodrome deploy-build deploy-private update-config update-config-dry-run
+create-istio-deps-configmap: branch ?= master
+create-istio-deps-configmap: get-private-cluster-credentials
+	@bash ./create-deps-cm.sh \
+	--local \
+	--branch="$(branch)" \
+  	--namespace=test-pods \
+	--key=dependencies \
+	$(if $(filter %,$(dry_run)),--dry-run,) \
+	"$(branch)-istio-deps"
+
+create-release-deps-configmap: branch ?= master
+create-release-deps-configmap: get-private-cluster-credentials
+	@bash ./create-deps-cm.sh \
+	--branch="$(branch)" \
+  	--namespace=test-pods \
+	--key=dependencies \
+	$(if $(filter %,$(dry_run)),--dry-run,) \
+	"$(branch)-release-deps"
+
+create-deps-configmaps: create-istio-deps-configmap create-release-deps-configmap
+
+.PHONY: gen-private-jobs deploy deploy-gcsweb deploy-velodrome deploy-build deploy-private update-config update-config-dry-run create-istio-deps-configmap create-release-deps-configmap create-deps-configmaps


### PR DESCRIPTION
To create a _configmap_ in order to override dependencies for `istio@release-1.5` and `release-builder@release-1.5` in `istio-private`  run:
```
$ make -C prow create-deps-configmaps branch=release-1.5
```

Then, add the yaml snippets that the command outputs to stdout to the jobs (or encapsulate in a [preset](https://github.com/istio/test-infra/blob/e05abff488b2245187dc878cb90ab093e7c9b617/prow/cluster/jobs/all-presets.yaml#L161-L176))

```yaml
---
  env:
  - name: DEPENDENCIES
    valueFrom:
      configMapKeyRef:
        name: release-1.5-istio-deps
        key: dependencies
---
  env:
  - name: DEPENDENCIES
    valueFrom:
      configMapKeyRef:
        name: release-1.5-release-deps
        key: dependencies

```
