### PR TITLE
reduce perf benchmark job timeout

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -35,9 +35,9 @@ periodics:
   name: daily-performance-benchmark
   branches: master
   decorate: true
-  timeout: 24h
+  timeout: 12h
   decoration_config:
-    timeout: 24h0m0s
+    timeout: 12h0m0s
   extra_refs:
     - org: istio
       repo: tools
@@ -63,9 +63,9 @@ periodics:
   name: daily-performance-benchmark-release-1.5
   branches: release-1.5
   decorate: true
-  timeout: 24h
+  timeout: 12h
   decoration_config:
-    timeout: 24h0m0s
+    timeout: 12h0m0s
   extra_refs:
     - org: istio
       repo: tools


### PR DESCRIPTION
since we are reducing the number of perf config runs, we only run both mode, and there are 6 configs, each config we will run cpu/mem (24min) and latency (24min) which is totally at most 6 hours. here, i reduced it to be 12 h in case we have other configs need to run, like in perf_record and linkerd.