### PR TITLE
Use go caching in unit tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -69,8 +69,19 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache-pvc
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache-pvc
+          subPath: gocache
       nodeSelector:
         testing: test-pool
+      volumes:
+      - name: build-cache-pvc
+        persistentVolumeClaim:
+          claimName: build-cache-claim
   - annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -825,8 +836,19 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache-pvc
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache-pvc
+          subPath: gocache
       nodeSelector:
         testing: test-pool
+      volumes:
+      - name: build-cache-pvc
+        persistentVolumeClaim:
+          claimName: build-cache-claim
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -30,8 +30,19 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache-pvc
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache-pvc
+          subPath: gocache
       nodeSelector:
         testing: test-pool
+      volumes:
+      - name: build-cache-pvc
+        persistentVolumeClaim:
+          claimName: build-cache-claim
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -46,12 +57,11 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - make
-        - -e
-        - T=-v
-        - build
-        - racetest
-        - binaries-test
+        - prow/integ-suite-kind.sh
+        - test.integration.conformance.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,-multicluster
         image: gcr.io/istio-testing/build-tools:master-2020-03-18T15-19-34
         name: ""
         resources:
@@ -69,12 +79,30 @@ postsubmits:
         - mountPath: /gocache
           name: build-cache-pvc
           subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
       - name: build-cache-pvc
         persistentVolumeClaim:
           claimName: build-cache-claim
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -799,8 +827,19 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache-pvc
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache-pvc
+          subPath: gocache
       nodeSelector:
         testing: test-pool
+      volumes:
+      - name: build-cache-pvc
+        persistentVolumeClaim:
+          claimName: build-cache-claim
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -815,12 +854,11 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - make
-        - -e
-        - T=-v
-        - build
-        - racetest
-        - binaries-test
+        - prow/integ-suite-kind.sh
+        - test.integration.conformance.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,-multicluster
         image: gcr.io/istio-testing/build-tools:master-2020-03-18T15-19-34
         name: ""
         resources:
@@ -838,12 +876,30 @@ presubmits:
         - mountPath: /gocache
           name: build-cache-pvc
           subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: test-pool
       volumes:
       - name: build-cache-pvc
         persistentVolumeClaim:
           claimName: build-cache-claim
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -5,12 +5,16 @@ image: gcr.io/istio-testing/build-tools:master-2020-03-18T15-19-34
 
 jobs:
   - name: unit-tests
+    requirements: [cache]
     command: [entrypoint, make, -e, "T=-v", build, racetest, binaries-test]
 
   - name: cache-experiment
-    requirements: [cache]
+    requirements: [cache, kind]
     modifiers: [optional, hidden]
-    command: [entrypoint, make, -e, "T=-v", build, racetest, binaries-test]
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.conformance.kube.presubmit]
+    env:
+      - name: TEST_SELECT
+        value: "-postsubmit,-flaky,-multicluster"
 
   - name: release-test
     type: presubmit


### PR DESCRIPTION
This has been running for almost a month now with no issues. I am moving
unit tests to use the cache, and switch the experimental job to test an
integration test to see how that performs

@clarketm we probably need some way to exclude this volume mount in private? 