### PR TITLE
Automator: src/dst branches can be configured independently

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GOARCH ?= $(TARGET_ARCH)
-GOOS ?= $(TARGET_OS)
-
 lint: lint-all
 
 lint-buildifier:
@@ -31,7 +28,7 @@ gen-check: gen check-clean-repo
 
 generate-config:
 	@rm -fr prow/cluster/jobs/istio/*/*.gen.yaml
-	@(cd prow/config/cmd; GOARCH=$(GOARCH) GOOS=$(GOOS) go run generate.go write)
+	@(cd prow/config/cmd; go run generate.go write)
 	@go run prow/genjobs/main.go --configs=./prow/config/istio-private_jobs
 
 diff-config:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.4.gen.yaml
@@ -48,12 +48,14 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=test-infra
+        - --branch=master
         - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
         - --
         - --post=make gen
+        - --var=IMG
         image: gcr.io/istio-testing/build-tools:release-1.4-2020-02-14T15-30-45
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
@@ -94,12 +94,14 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=test-infra
+        - --branch=master
         - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
         - --
         - --post=make gen
+        - --var=IMG
         image: gcr.io/istio-testing/build-tools:release-1.5-2020-02-14T14-00-07
         name: ""
         resources:

--- a/prow/config/jobs/common-files-1.4.yaml
+++ b/prow/config/jobs/common-files-1.4.yaml
@@ -12,12 +12,14 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=test-infra
+  - --branch=master
   - "--title=Automator: update build-tools:$AUTOMATOR_BRANCH"
   - --modifier=buildtools
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
   - --
   - --post=make gen
+  - --var=IMG
   requirements: [github]
   repos: [istio/test-infra]
 org: istio

--- a/prow/config/jobs/common-files-1.5.yaml
+++ b/prow/config/jobs/common-files-1.5.yaml
@@ -27,12 +27,14 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=test-infra
+  - --branch=master
   - "--title=Automator: update build-tools:$AUTOMATOR_BRANCH"
   - --modifier=buildtools
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
   - --
   - --post=make gen
+  - --var=IMG
   requirements: [github]
   repos: [istio/test-infra]
 org: istio

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -27,7 +27,7 @@ cleanup() {
 }
 
 get_opts() {
-  if opt="$(getopt -o '' -l branch:,sha:,org:,repo:,title:,match-title:,body:,labels:,user:,email:,modifier:,script-path:,cmd:,token-path:,token:,verbose -n "$(basename "$0")" -- "$@")"; then
+  if opt="$(getopt -o '' -l branch:,src-branch:,sha:,org:,repo:,title:,match-title:,body:,labels:,user:,email:,modifier:,script-path:,cmd:,token-path:,token:,verbose -n "$(basename "$0")" -- "$@")"; then
     eval set -- "$opt"
   else
     print_error_and_exit "unable to parse options"
@@ -37,6 +37,10 @@ get_opts() {
     case "$1" in
     --branch)
       branch="$2"
+      shift 2
+      ;;
+    --src-branch)
+      src_branch="$2"
       shift 2
       ;;
     --sha)
@@ -123,6 +127,10 @@ validate_opts() {
     branch="$(git describe --contains --all HEAD)"
   fi
 
+  if [ -z "${src_branch:-}" ]; then
+    src_branch="$(git describe --contains --all HEAD)"
+  fi
+
   if [ -z "${sha:-}" ]; then
     sha="$(git rev-parse HEAD)"
     sha_short="$(git rev-parse --short HEAD)"
@@ -170,7 +178,7 @@ validate_opts() {
 }
 
 evaluate_opts() {
-  AUTOMATOR_ORG="$org" AUTOMATOR_REPO="$repo" AUTOMATOR_BRANCH="$branch" AUTOMATOR_SHA="$sha" AUTOMATOR_SHA_SHORT="$sha_short" AUTOMATOR_MODIFIER="$modifier"
+  AUTOMATOR_ORG="$org" AUTOMATOR_REPO="$repo" AUTOMATOR_BRANCH="$src_branch" AUTOMATOR_SHA="$sha" AUTOMATOR_SHA_SHORT="$sha_short" AUTOMATOR_MODIFIER="$modifier"
 
   title="$(evaluate_tmpl "$title_tmpl")"
   match_title="$(evaluate_tmpl "$match_title_tmpl")"
@@ -190,7 +198,7 @@ create_pr() {
     --title="$title" \
     --match-title="\"$match_title\"" \
     --body="$body" \
-    --source="$user:$branch-$modifier" \
+    --source="$user:$src_branch-$modifier" \
     --confirm
 }
 


### PR DESCRIPTION
* In older branches of commonfiles (e.g. `release-1.4`, `release-1.5`), the build-tools image version is in the `IMG` variable.
* Add support for specifying both the src (`--src-branch`) and dst (`--branch`) branches independently (keeping same defaults for backwards compat)

fix: https://prow.istio.io/view/gcs/istio-prow/logs/update-build-tools-image_common-files_release-1.5_postsubmit/2
