### PR TITLE
Avoid potential conflicts in fork branch name

### DIFF
--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -198,7 +198,7 @@ create_pr() {
     --title="$title" \
     --match-title="\"$match_title\"" \
     --body="$body" \
-    --source="$user:$src_branch-$modifier" \
+    --source="$user:$fork_name" \
     --confirm
 }
 
@@ -211,7 +211,7 @@ add_labels() {
 commit() {
   git -c "user.name=$user" -c "user.email=$email" commit --message "$title" --author="$user <$email>"
   git show --shortstat
-  git push --force "https://$user:$token@github.com/$user/$repo.git" "HEAD:$branch-$modifier"
+  git push --force "https://$user:$token@github.com/$user/$repo.git" "HEAD:$fork_name"
   pull_request="$(create_pr)"
   add_labels "$pull_request"
 }
@@ -234,6 +234,7 @@ work() { (
   git add --all
 
   if ! git diff --cached --quiet --exit-code; then
+    fork_name="$src_branch-$branch-$modifier-$(hash "$title")"
     commit || print_error "unable to commit for: $repo"
   fi
 

--- a/tools/automator/utils.sh
+++ b/tools/automator/utils.sh
@@ -42,3 +42,8 @@ split_on_commas() {
 evaluate_tmpl() {
   bash -c "eval echo \"$1\""
 }
+
+hash() {
+  local val="$1"
+  echo -n "$val" | md5sum | cut -c1-8
+}


### PR DESCRIPTION
The current heuristic of using `branch`, and `modifier` per `org/repo` fork as the **branchname** is **not** sufficient to _avoid naming conflict_.  This has be a reoccurring problem with automator.

To eliminate this issue for good, I am including all _identifying_ fields in the **branchname**. Note that `title` is additionally being hashed to comply with git branchname restrictions: https://git-scm.com/docs/git-check-ref-format. 
