### PR TITLE
Respect errexit and propogate exit code

### DIFF
--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -235,7 +235,7 @@ work() { (
 
   if ! git diff --cached --quiet --exit-code; then
     fork_name="$src_branch-$branch-$modifier-$(hash "$title")"
-    commit
+    trace commit
   fi
 
   popd

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -213,7 +213,7 @@ commit() {
   git show --shortstat
   git push --force "https://$user:$token@github.com/$user/$repo.git" "HEAD:$fork_name"
   pull_request="$(create_pr)"
-  add_labels "$pull_request"
+  add_labels
 }
 
 work() { (
@@ -229,13 +229,13 @@ work() { (
 
   AUTOMATOR_REPO_DIR="$(pwd)"
 
-  bash "${shell_args[@]}" "$script_path" "${script_args[@]}" || print_error "unable to execute command for: $repo"
+  bash "${shell_args[@]}" "$script_path" "${script_args[@]}"
 
   git add --all
 
   if ! git diff --cached --quiet --exit-code; then
     fork_name="$src_branch-$branch-$modifier-$(hash "$title")"
-    commit || print_error "unable to commit for: $repo"
+    commit
   fi
 
   popd

--- a/tools/automator/utils.sh
+++ b/tools/automator/utils.sh
@@ -47,3 +47,8 @@ hash() {
   local val="$1"
   echo -n "$val" | md5sum | cut -c1-8
 }
+
+trace() {
+  set -x
+  "$@"
+}


### PR DESCRIPTION
In modern shells like `bash` the `errexit` (ie. `set -e`) option does not extend to an arbitrary level of nested functions for command(s) to the left of the`||` or `&&` ([source](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) ; [so](https://stackoverflow.com/questions/19789102/why-is-bash-errexit-not-behaving-as-expected-in-function-calls)).

The downside here is that if the [`commit`](https://github.com/istio/test-infra/blob/7fb215c03d0c33bba022182c2f916f9b656cb721/tools/automator/automator.sh#L211) function fails then the job will _succeed_ when it should _fail_ ([example](https://prow.istio.io/view/gcs/istio-prow/logs/update-build-tools-image_common-files_release-1.5_postsubmit/5)) because the exit code from `create_pr`, for example, is not returned to the caller (`commit`) and hence the exit code is `0` when call stack pops to `work` as if no error ever occurred.

Since these _customized_ error messages I am removing are not informative anyway, I am changing this to a _generic_ error message. It can act as a sentinel in logs to quickly see the job failure point. 

In the future, if we do want custom error messages, there is a simple workaround and it is to define the function body in a subshell and run `set -e` in that subshell (similar to the `work` function); but atm this is needless complexity. 


