### PR TITLE
Refine prune logic

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -32,10 +32,10 @@ deploy: get-cluster-credentials get-api-resources
 	kubectl apply -f ./cluster/ --prune -l app.kubernetes.io/part-of=prow $(PRUNE_WL)
 
 deploy-gcsweb: get-cluster-credentials get-api-resources
-	kubectl apply -f ./cluster/gcsweb/ --prune -l app.kubernetes.io/part-of=gcsweb $(PRUNE_WL)
+	kubectl apply -f ./cluster/gcsweb/ --prune -l app.kubernetes.io/part-of=gcsweb -n gcs $(PRUNE_WL)
 
 deploy-velodrome: get-cluster-credentials get-api-resources
-	kubectl apply -f ./cluster/velodrome/ --prune -l app.kubernetes.io/part-of=velodrome $(PRUNE_WL)
+	kubectl apply -f ./cluster/velodrome/ --prune -l app.kubernetes.io/part-of=velodrome -n velodrome $(PRUNE_WL)
 
 deploy-build: PROJECT=$(PROJECT_BUILD)
 deploy-build: CLUSTER=$(CLUSTER_BUILD)

--- a/prow/api-resources.py
+++ b/prow/api-resources.py
@@ -16,10 +16,9 @@
 
 from argparse import ArgumentParser
 from collections import defaultdict
+from itertools import accumulate
 from re import findall
 from subprocess import run, PIPE, CalledProcessError
-
-from itertools import accumulate
 
 
 def fetch_resources():
@@ -86,14 +85,12 @@ def main(delimiter, format, group_blacklist):
     r = []
 
     for name, _, group, _, kind in resources:
-        group = group or "core"
-
         if group in group_blacklist:
             continue
 
         for version in versions.get(group, []):
             if fetch_version(name, f"{group}/{version}"):
-                r.append(f"{group}/{version}/{kind}")
+                r.append(f"{group or 'core'}/{version}/{kind}")
 
     return delimiter.join([format % v for v in r])
 


### PR DESCRIPTION
It appears that newer `kubectl` clients are broken and can only prune a _single_ namespace for namespaced objects (probably a bug introduced by: https://github.com/kubernetes/kubernetes/pull/83084), so we need to set the namespace explicitly for `gcsweb` and `velodrome` in order to benefit from pruning (e.g. https://github.com/istio/test-infra/pull/2525 when the tmp ingresses are deleted). 

This also includes a small tweak to `api-resources.py` – as resources in the `core` group where **not** being included in the prune whitelist.

K8s issue reported by @howardjohn ~2 months ago: https://github.com/kubernetes/kubernetes/issues/87756