### PR TITLE
Restore istio.io presubmit tests as optional

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -151,3 +151,51 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio.io
+    branches:
+    - ^master$
+    decorate: true
+    name: k8s-tests_istio.io
+    optional: true
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.kube.presubmit
+        image: gcr.io/istio-testing/build-tools:master-2020-03-24T16-16-03
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -8,6 +8,12 @@ jobs:
     command: [make, lint]
 
   - name: k8s-tests
+    type: presubmit
+    command: [entrypoint, prow/integ-suite-kind.sh, test.kube.presubmit]
+    requirements: [kind]
+    modifiers: [optional]
+
+  - name: k8s-tests
     type: postsubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.kube.postsubmit]
     requirements: [kind, gcp]


### PR DESCRIPTION
This is useful for recognizing and addressing broken tests more quickly.