### PR TITLE
raw_input() was removed from Python on 1/1/2020

### DIFF
--- a/prow/recreate_prow_configmaps.py
+++ b/prow/recreate_prow_configmaps.py
@@ -123,7 +123,7 @@ def main():
         "\n!!    ARE YOU SURE YOU WANT TO DO THIS? IF SO, ENTER 'YES'.    !! "
     ) + '\n' + '!' * 65 + '\n\n: '
     if args.wet:
-        if raw_input(prompt) != "YES":
+        if input(prompt) != "YES":
             print("you did not enter 'YES'")
             sys.exit(-1)
 


### PR DESCRIPTION
`raw_input()` was remove from Python in favor of `input()`.