### PR TITLE
Reserve rerun perms for periodics

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -75,7 +75,7 @@ deck:
 
   tide_update_period: 1s
   rerun_auth_configs:
-    istio:
+    '*':
       github_users:
       - cjwagner
       - fejta


### PR DESCRIPTION
Periodics do not have an org, so using `"*"` allows this rerun config to apply to both **istio** and all the periodics.