### PR TITLE
Stop caching go build results

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -73,9 +73,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache-pvc
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache-pvc
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -779,9 +776,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache-pvc
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache-pvc
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -34,9 +34,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache-pvc
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache-pvc
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -76,9 +73,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache-pvc
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache-pvc
-          subPath: gocache
         - mountPath: /lib/modules
           name: modules
           readOnly: true
@@ -774,9 +768,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache-pvc
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache-pvc
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -816,9 +807,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache-pvc
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache-pvc
-          subPath: gocache
         - mountPath: /lib/modules
           name: modules
           readOnly: true

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -630,11 +630,6 @@ func applyRequirements(job *config.JobBase, requirements []string) {
 					Name:      "build-cache-pvc",
 					SubPath:   "gomod",
 				},
-				v1.VolumeMount{
-					MountPath: "/gocache",
-					Name:      "build-cache-pvc",
-					SubPath:   "gocache",
-				},
 			)
 		case RequirementGitHub:
 			job.Spec.Volumes = append(job.Spec.Volumes,


### PR DESCRIPTION
This is the go build cache, which caches tests and builds. I would be
fine with having builds cached but I am pretty hesitant to be having our
tests be cached and worry that it won't properly be testing changes as
the cache is not always properly invalidated by yaml changes, etc. It
also leads to erratic test durations, which is hard to track trends. It
also is not very effective, as all the concurrent jobs invalidate the
cahce often. I also couldn't find anyone else doing this.

Once we do this I am comfortable moving every job to use the cache