### PR TITLE
Add strict mode to Automator

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -50,6 +50,7 @@ postsubmits:
         - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
+        - --strict
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.4.gen.yaml
@@ -51,6 +51,7 @@ postsubmits:
         - --branch=master
         - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
         - --modifier=buildtools
+        - --strict
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
         - --

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
@@ -50,6 +50,7 @@ postsubmits:
         - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
+        - --strict
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen

--- a/prow/config/jobs/common-files-1.4.yaml
+++ b/prow/config/jobs/common-files-1.4.yaml
@@ -15,6 +15,7 @@ jobs:
   - --branch=master
   - "--title=Automator: update build-tools:$AUTOMATOR_BRANCH"
   - --modifier=buildtools
+  - --strict
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-build-tools-image.sh
   - --

--- a/prow/config/jobs/common-files-1.5.yaml
+++ b/prow/config/jobs/common-files-1.5.yaml
@@ -12,6 +12,7 @@ jobs:
   - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
   - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
+  - --strict
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common gen

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -15,6 +15,7 @@ jobs:
     - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
     - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge
+    - --strict
     - --modifier=commonfiles
     - --token-path=/etc/github-token/oauth
     - --cmd=make update-common gen

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -27,7 +27,7 @@ cleanup() {
 }
 
 get_opts() {
-  if opt="$(getopt -o '' -l branch:,src-branch:,sha:,org:,repo:,title:,match-title:,body:,labels:,user:,email:,modifier:,script-path:,cmd:,token-path:,token:,verbose -n "$(basename "$0")" -- "$@")"; then
+  if opt="$(getopt -o '' -l branch:,src-branch:,sha:,org:,repo:,title:,match-title:,body:,labels:,user:,email:,modifier:,script-path:,cmd:,token-path:,token:,strict,verbose -n "$(basename "$0")" -- "$@")"; then
     eval set -- "$opt"
   else
     print_error_and_exit "unable to parse options"
@@ -110,6 +110,10 @@ get_opts() {
       shell_args+=("-x")
       shift
       ;;
+    --strict)
+      strict=true
+      shift
+      ;;
     --)
       shift
       script_args=("$@")
@@ -166,6 +170,10 @@ validate_opts() {
 
   if [ -z "${modifier:-}" ]; then
     modifier="automator"
+  fi
+
+  if [ -z "${strict:-}" ]; then
+    strict=false
   fi
 
   if [ -z "${user:-}" ]; then
@@ -236,6 +244,8 @@ work() { (
   if ! git diff --cached --quiet --exit-code; then
     fork_name="$src_branch-$branch-$modifier-$(hash "$title")"
     commit
+  elif $strict; then
+    print_error "no diff for $repo" 1
   fi
 
   popd


### PR DESCRIPTION
Add a new flag to Automator `--strict` which enables strict mode. When strict mode is _enabled_ and the command does **not** produce a diff, the command will exit with a non-zero exit code (when otherwise it would not have).

> I am enabling this **only** for jobs where a diff is _expected_.

ref: https://istio.slack.com/archives/C6FCV6WN4/p1586481765085700

cc @ericvn 