### PR TITLE
automator: support set env variables in subprocess

### DIFF
--- a/tools/automator/scripts/update-images.sh
+++ b/tools/automator/scripts/update-images.sh
@@ -82,6 +82,11 @@ get_opts() {
   done
 }
 
+setup_env() {
+  export AUTOMATOR_NEW_TAG="$resolved_tag"
+  write_env
+}
+
 resolve() {
   image="$(evaluate_tmpl "$image")"
   tag="$(evaluate_tmpl "$tag")"
@@ -100,6 +105,7 @@ work() {
 main() {
   get_opts "$@"
   resolve
+  setup_env
   ${pre:-}
   work
   ${post:-}

--- a/tools/automator/utils.sh
+++ b/tools/automator/utils.sh
@@ -46,6 +46,20 @@ evaluate_tmpl() {
   bash -c "eval echo \"$1\""
 }
 
+print_env() {
+  env | grep -oP "^AUTOMATOR_.*$" | sort
+}
+
+write_env() {
+  print_env >"$AUTOMATOR_ENV"
+}
+
+read_env() {
+  set -o allexport
+  # shellcheck disable=SC1090
+  source "$AUTOMATOR_ENV"
+}
+
 hash() {
   local val="$1"
   echo -n "$val" | md5sum | cut -c1-8


### PR DESCRIPTION
This allows scripts to register env variables to be used in the template substitution (e.g. PR `title` and `body`).