### PR TITLE
export bash opts to subshells

### DIFF
--- a/tools/automator/utils.sh
+++ b/tools/automator/utils.sh
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 set -euo pipefail
-shopt -s globstar nullglob dotglob extglob
+shopt -s globstar dotglob extglob
+
+export BASHOPTS
 
 print_error() {
   local last_return="$?"


### PR DESCRIPTION
Template evaluation and subshells should use these _common_ shell options. Also, disabling `nullglob` since it has undesired side-effects when evaluating globs.

fix: https://prow.istio.io/view/gcs/istio-prow/logs/bump-k8s-prow-images_test-infra_periodic/6