### PR TITLE
remove obsolete istio-gke dashboard

### DIFF
--- a/testgrid/default.yaml
+++ b/testgrid/default.yaml
@@ -91,7 +91,6 @@ dashboards:
 - name: istio_test-infra_periodic
 - name: istio_tools
 - name: istio_tools_postsubmit
-- name: istio-gke
 
 # Group all dashboards
 dashboard_groups:
@@ -189,4 +188,3 @@ dashboard_groups:
   - istio_proxy
   - istio_test-infra
   - istio_tools
-  - istio-gke


### PR DESCRIPTION
needed after: https://github.com/kubernetes/test-infra/pull/17213 to fix: https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_test-infra/2570/pull-test-infra-check-testgrid-config/967