### PR TITLE
automator: dry-run mode

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1390,3 +1390,46 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    name: update-ref-docs-dry-run_istio
+    optional: true
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=istio.io
+        - --token-path=/etc/github-token/oauth
+        - --cmd=make update_ref_docs
+        - --dry-run
+        image: gcr.io/istio-testing/build-tools:master-2020-04-16T19-28-05
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token

--- a/prow/config/istio-private_jobs/istio.yaml
+++ b/prow/config/istio-private_jobs/istio.yaml
@@ -21,4 +21,4 @@ transforms:
     preset-override-envoy: "true"
     preset-override-deps: release-1.4-istio
   job-type: [presubmit, postsubmit]
-  job-blacklist: [release_istio_postsubmit, cache-experiment_istio_postsubmit, cache-experiment_istio]
+  job-blacklist: [release_istio_postsubmit, cache-experiment_istio_postsubmit, cache-experiment_istio, update-ref-docs-dry-run_istio]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -245,6 +245,19 @@ jobs:
     type: presubmit
     command: [make, gen-check]
 
+  - name: update-ref-docs-dry-run
+    type: presubmit
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=istio.io
+    - --token-path=/etc/github-token/oauth
+    - --cmd=make update_ref_docs
+    - --dry-run
+    requirements: [github]
+    modifiers: [optional]
+    repos: [istio/test-infra]
+
 resources:
   default:
     requests:


### PR DESCRIPTION
Add support for `dry-run` in Automator, which basically means do everything _except_ for commit (and PR creation). This is beneficial when all we care about is _success_ or _failure_ (i.e. exit code) of a command. 

I am also adding the first implementation of this – a presubmit on `istio/istio@master` to check if the `istio.io` docs can be generated (i.e. `make update-ref-docs`). The job is set as _optional_ (since the [job is failing](https://istio.slack.com/archives/CNWHGSBHA/p1587089000027500)).