### PR TITLE
Some fixes and improvements to recreate_prow_configmaps.py

### DIFF
--- a/prow/recreate_prow_configmaps.py
+++ b/prow/recreate_prow_configmaps.py
@@ -14,14 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script deletes and recreates the prow configmaps
-# USE AT YOUR OWN RISK! This is a break-glass tool.
-# See September 25th, 2018 in docs/post-mortems.md
-
 #
 # USAGE: have KUBECONFIG pointed at your prow cluster then from test-infra root:
 #
-# hack/recreate_prow_configmaps.py [--wet]
+# prow/recreate_prow_configmaps.py [--wet]
 #
 
 from __future__ import print_function

--- a/prow/recreate_prow_configmaps.py
+++ b/prow/recreate_prow_configmaps.py
@@ -110,7 +110,7 @@ def main():
 
     # debug the current context
     out = subprocess.check_output(['kubectl', 'config', 'current-context'])
-    print('Current KUBECONFIG context: ' + out)
+    print('Current KUBECONFIG context: ' + out.decode("utf-8"))
 
     # require additional confirmation in --wet mode
     prompt = '!' * 65 + (
@@ -118,7 +118,7 @@ def main():
         "\n!!    ARE YOU SURE YOU WANT TO DO THIS? IF SO, ENTER 'YES'.    !! "
     ) + '\n' + '!' * 65 + '\n\n: '
     if args.wet and not args.silent:
-        if raw_input(prompt) != "YES":
+        if input(prompt) != "YES":
             print("you did not enter 'YES'")
             sys.exit(-1)
 


### PR DESCRIPTION
1. Also use `replace` to update the prow job config configmap, this can avoid downtime.
2. Add a new `--silent` flag to allow users skip the confirmation step in updating configmaps.

/cc @clarketm 