### PR TITLE
Current image kubectl client does not support --dry-run=client

### DIFF
--- a/prow/cluster/monitoring/mixins/Makefile
+++ b/prow/cluster/monitoring/mixins/Makefile
@@ -34,7 +34,7 @@ apply-configmaps: grafana-dashboards
 	@for input in $(shell ls dashboards_out); do \
 		dashboard_name="grafana-dashboard-$${input%.*}"; \
 		echo "Generating dashboard $${dashboard_name} from $${input} ..."; \
-		kubectl create configmap -n prow-monitoring "$${dashboard_name}" --from-file="$${input}=dashboards_out/$${input}" --dry-run=client -o yaml | kubectl apply -f -; \
+		kubectl create configmap -n prow-monitoring "$${dashboard_name}" --from-file="$${input}=dashboards_out/$${input}" --dry-run -o yaml | kubectl apply -f -; \
 	done
 
 apply-prow-prometheusrule: prow_prometheusrule.yaml


### PR DESCRIPTION
`--dry-run=client` not available in kubectl@v1.15

fix https://prow.istio.io/view/gcs/istio-prow/logs/deploy-prow_test-infra_postsubmit/53