### PR TITLE
Expose metrics endpoints for various Prow services

### DIFF
--- a/prow/cluster/deck_service.yaml
+++ b/prow/cluster/deck_service.yaml
@@ -2,12 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: deck
     app.kubernetes.io/part-of: prow
   name: deck
 spec:
   selector:
     app: deck
   ports:
-  - port: 80
+  - name: main
+    port: 80
     targetPort: 8080
+  - name: metrics
+    port: 9090
   type: NodePort

--- a/prow/cluster/plank_service.yaml
+++ b/prow/cluster/plank_service.yaml
@@ -2,15 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: hook
+    app: plank
     app.kubernetes.io/part-of: prow
-  name: hook
+  name: plank
 spec:
   selector:
-    app: hook
+    app: plank
   ports:
-  - name: main
-    port: 8888
   - name: metrics
     port: 9090
-  type: NodePort

--- a/prow/cluster/sinker_service.yaml
+++ b/prow/cluster/sinker_service.yaml
@@ -2,15 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: hook
+    app: sinker
     app.kubernetes.io/part-of: prow
-  name: hook
+  name: sinker
 spec:
   selector:
-    app: hook
+    app: sinker
   ports:
-  - name: main
-    port: 8888
   - name: metrics
     port: 9090
-  type: NodePort

--- a/prow/cluster/tide_service.yaml
+++ b/prow/cluster/tide_service.yaml
@@ -2,12 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: deck
     app.kubernetes.io/part-of: prow
   name: tide
 spec:
   selector:
     app: tide
   ports:
-  - port: 80
+  - name: main
+    port: 80
     targetPort: 8888
+  - name: metrics
+    port: 9090
   type: NodePort


### PR DESCRIPTION
Currently, metrics for Prow services are unavailable to the monitoring/alerting service(s) and thus they are deemed unreachable.

Analog to kubernetes/test-infra@b519effbcabf916b2d472d141ad1e818d749627d