### PR TITLE
Correct https for monitoring.prow.istio.io

### DIFF
--- a/prow/cluster/monitoring/grafana_expose.yaml
+++ b/prow/cluster/monitoring/grafana_expose.yaml
@@ -25,14 +25,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: prow-monitoring-grafana
     kubernetes.io/ingress.class: "gce"
-    networking.gke.io/managed-certificates: monitoring-prow-k8s-io
+    networking.gke.io/managed-certificates: monitoring-prow-istio-io
   name: grafana
   namespace: prow-monitoring
 spec:
-  rules:
-  - host: monitoring.prow.istio.io
-    http:
-      paths:
-      - backend:
-          serviceName: grafana
-          servicePort: 80
+  backend:
+    serviceName: grafana
+    servicePort: 80

--- a/prow/cluster/monitoring/monitoring-prow-istio-io_managedcertificate.yaml
+++ b/prow/cluster/monitoring/monitoring-prow-istio-io_managedcertificate.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  labels:
+    app.kubernetes.io/part-of: prow
+  name: monitoring-prow-istio-io
+  namespace: prow-monitoring
+spec:
+  domains:
+  - monitoring.prow.istio.io


### PR DESCRIPTION
Fix cert issue (and set _default_ backend) for Prow monitoring: https://monitoring.prow.istio.io/