### PR TITLE
Disable unused dashboards

### DIFF
--- a/testgrid/default.yaml
+++ b/testgrid/default.yaml
@@ -34,7 +34,7 @@ dashboards:
 - name: istio_release-1.6_client-go
 - name: istio_release-1.6_cni
 - name: istio_release-1.6_common-files
-- name: istio_release-1.6_envoy
+#- name: istio_release-1.6_envoy
 - name: istio_release-1.6_gogo-genproto
 - name: istio_release-1.6_istio.io
 - name: istio_release-1.6_pkg
@@ -138,7 +138,7 @@ dashboard_groups:
   - istio_release-1.6_client-go
   - istio_release-1.6_cni
   - istio_release-1.6_common-files
-  - istio_release-1.6_envoy
+#  - istio_release-1.6_envoy
   - istio_release-1.6_gogo-genproto
   - istio_release-1.6_istio.io
   - istio_release-1.6_pkg


### PR DESCRIPTION
Disable these dashboards until they are used. This is an explicit error in `post-istio-test-infra-upload-testgrid-config`. We can consider ignoring/skipping in configurator under this condition but for now disabling (i.e. commenting out) is the remedy.  

https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_test-infra/2615/pull-test-infra-check-testgrid-config/1065/build-log.txt 

This was nestled in on line **4526**; it is easy to miss amongst the other output.

```console
4526: config_test.go:195: Dashboard istio_release-1.6_envoy: - Must have more than one dashboardtab
```