### PR TITLE
Update to pull references docs from release-1.6

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -19,10 +19,10 @@ periodics:
       - ./tools/automator/automator.sh
       - --org=istio
       - --repo=istio.io
-      - '--title=Automator: update istio.io@$AUTOMATOR_BRANCH reference docs'
+      - '--title=Automator: update istio.io@release-1.6 reference docs'
       - --modifier=refdocs
       - --token-path=/etc/github-token/oauth
-      - --cmd=make update_ref_docs
+      - --cmd=SOURCE_BRANCH_NAME=release-1.6 make update_ref_docs
       image: gcr.io/istio-testing/build-tools:master-2020-04-22T02-05-07
       name: ""
       resources:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -28,10 +28,10 @@ jobs:
     - ./tools/automator/automator.sh
     - --org=istio
     - --repo=istio.io
-    - "--title=Automator: update istio.io@$AUTOMATOR_BRANCH reference docs"
+    - "--title=Automator: update istio.io@release-1.6 reference docs"
     - --modifier=refdocs
     - --token-path=/etc/github-token/oauth
-    - --cmd=make update_ref_docs
+    - --cmd=SOURCE_BRANCH_NAME=release-1.6 make update_ref_docs
     requirements: [github]
     repos: [istio/test-infra]
 


### PR DESCRIPTION
For the time when we are using the release-1.6 branches for the upcoming release, we want to pull the reference doc updates from the new branch. We will switch back to master when the istio.io branch is made to `master`

@frankbu Does this make sense?