### PR TITLE
automator: assign AUTOMATOR_BRANCH=$branch

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -75,7 +75,8 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio,client-go
-        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
+          $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.5.gen.yaml
@@ -75,7 +75,8 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=client-go
-        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
+          $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --modifier=client-go_update_api
         - --token-path=/etc/github-token/oauth
@@ -121,7 +122,8 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio
-        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
+          $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --modifier=istio_update_api
         - --token-path=/etc/github-token/oauth

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
@@ -75,7 +75,8 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio,client-go
-        - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
+          $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
-        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --strict
         - --modifier=commonfiles
@@ -95,7 +95,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=test-infra
-        - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
+        - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.4.gen.yaml
@@ -49,7 +49,7 @@ postsubmits:
         - --org=istio
         - --repo=test-infra
         - --branch=master
-        - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
+        - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.5.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
-        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --strict
         - --modifier=commonfiles
@@ -96,7 +96,7 @@ postsubmits:
         - --org=istio
         - --repo=test-infra
         - --branch=master
-        - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
+        - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
-        - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --strict
         - --modifier=commonfiles
@@ -95,7 +95,7 @@ postsubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=test-infra
-        - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
+        - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/config/jobs/api-1.5.yaml
+++ b/prow/config/jobs/api-1.5.yaml
@@ -14,7 +14,7 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=client-go
-  - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+  - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
   - --modifier=client-go_update_api
   - --token-path=/etc/github-token/oauth
@@ -29,7 +29,7 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio
-  - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+  - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
   - --modifier=istio_update_api
   - --token-path=/etc/github-token/oauth

--- a/prow/config/jobs/api-1.6.yaml
+++ b/prow/config/jobs/api-1.6.yaml
@@ -14,7 +14,7 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio,client-go
-  - '--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+  - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
   - --modifier=update_api_dep
   - --token-path=/etc/github-token/oauth

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -16,7 +16,7 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio,client-go
-    - "--title=Automator: update istio/api@$AUTOMATOR_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - "--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge
     - --modifier=update_api_dep
     - --token-path=/etc/github-token/oauth

--- a/prow/config/jobs/common-files-1.4.yaml
+++ b/prow/config/jobs/common-files-1.4.yaml
@@ -13,7 +13,7 @@ jobs:
   - --org=istio
   - --repo=test-infra
   - --branch=master
-  - "--title=Automator: update build-tools:$AUTOMATOR_BRANCH"
+  - "--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH"
   - --modifier=buildtools
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/config/jobs/common-files-1.5.yaml
+++ b/prow/config/jobs/common-files-1.5.yaml
@@ -10,7 +10,7 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
-  - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+  - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
   - --strict
   - --modifier=commonfiles
@@ -29,7 +29,7 @@ jobs:
   - --org=istio
   - --repo=test-infra
   - --branch=master
-  - "--title=Automator: update build-tools:$AUTOMATOR_BRANCH"
+  - "--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH"
   - --modifier=buildtools
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/config/jobs/common-files-1.6.yaml
+++ b/prow/config/jobs/common-files-1.6.yaml
@@ -10,7 +10,7 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
-  - '--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+  - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
   - --strict
   - --modifier=commonfiles
@@ -26,7 +26,7 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=test-infra
-  - '--title=Automator: update build-tools:$AUTOMATOR_BRANCH'
+  - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
   - --modifier=buildtools
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -13,7 +13,7 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
-    - "--title=Automator: update common-files@$AUTOMATOR_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge
     - --strict
     - --modifier=commonfiles
@@ -28,7 +28,7 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=test-infra
-    - "--title=Automator: update build-tools:$AUTOMATOR_BRANCH"
+    - "--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH"
     - --modifier=buildtools
     - --token-path=/etc/github-token/oauth
     - --script-path=../test-infra/tools/automator/scripts/update-images.sh


### PR DESCRIPTION
`AUTOMATOR_BRANCH` should equal `$branch` which is the _destination_ branch (i.e. what is cloned in `automator` and PRed against).

To be comprehensive, I am adding several _source_ env variables (which are set to existing [Prow variables](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables)):
* `AUTOMATOR_SRC_ORG` –  _source_ organization.
* `AUTOMATOR_SRC_REPO` –  _source_ repository.
* `AUTOMATOR_SRC_BRANCH` –  _source_ branch.

and removing futile options (`--sha` and `--src_branch`) which do not have a purpose.