### PR TITLE
Update build-image and automator jobs for release-1.6

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -81,7 +81,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -96,6 +96,7 @@ postsubmits:
         - --org=istio
         - --repo=test-infra
         - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
+        - --branch=master
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -36,7 +36,7 @@ postsubmits:
     - ^release-1.6$
     decorate: true
     extra_refs:
-    - base_ref: release-1.6
+    - base_ref: master
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
@@ -54,7 +54,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -83,7 +83,7 @@ postsubmits:
     - ^release-1.6$
     decorate: true
     extra_refs:
-    - base_ref: release-1.6
+    - base_ref: master
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
@@ -96,6 +96,7 @@ postsubmits:
         - --org=istio
         - --repo=test-infra
         - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
+        - --branch=master
         - --modifier=buildtools
         - --token-path=/etc/github-token/oauth
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh
@@ -103,7 +104,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -139,7 +140,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -72,7 +72,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -174,7 +174,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.6.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -59,7 +59,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -113,7 +113,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -231,7 +231,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -281,7 +281,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -331,7 +331,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -381,7 +381,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -431,7 +431,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -481,7 +481,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -537,7 +537,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -593,7 +593,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -647,7 +647,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -702,7 +702,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -754,7 +754,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -793,7 +793,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -846,7 +846,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -875,7 +875,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -924,7 +924,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -973,7 +973,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1022,7 +1022,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1071,7 +1071,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1122,7 +1122,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1173,7 +1173,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1222,7 +1222,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1273,7 +1273,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1322,7 +1322,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1353,7 +1353,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -1378,7 +1378,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.6.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -52,7 +52,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -77,7 +77,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -102,7 +102,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -155,7 +155,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -213,7 +213,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -268,7 +268,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -295,7 +295,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -322,7 +322,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -42,7 +42,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -166,7 +166,7 @@ postsubmits:
         - -C
         - perf_dashboard
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -200,7 +200,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -226,7 +226,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -252,7 +252,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -311,7 +311,7 @@ presubmits:
         env:
         - name: TRIALRUN
           value: "True"
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:
@@ -341,7 +341,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.6.yaml
+++ b/prow/config/jobs/api-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.6.yaml
+++ b/prow/config/jobs/client-go-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.6.yaml
+++ b/prow/config/jobs/common-files-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make
@@ -18,7 +18,7 @@ jobs:
   - --cmd=make update-common gen
   name: update-common
   repos:
-  - istio/test-infra
+  - istio/test-infra@master
   requirements:
   - github
   type: postsubmit
@@ -27,6 +27,7 @@ jobs:
   - --org=istio
   - --repo=test-infra
   - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
+  - --branch=master
   - --modifier=buildtools
   - --token-path=/etc/github-token/oauth
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh
@@ -36,7 +37,7 @@ jobs:
   - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
   name: update-build-tools-image
   repos:
-  - istio/test-infra
+  - istio/test-infra@master
   requirements:
   - github
   type: postsubmit

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -1,6 +1,5 @@
 org: istio
 repo: common-files
-support_release_branching: true
 image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
     - --token-path=/etc/github-token/oauth
     - --cmd=make update-common gen
     requirements: [github]
-    repos: [istio/test-infra]
+    repos: [istio/test-infra@master]
 
   - name: update-build-tools-image
     type: postsubmit
@@ -29,6 +28,7 @@ jobs:
     - --org=istio
     - --repo=test-infra
     - "--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH"
+    - --branch=master
     - --modifier=buildtools
     - --token-path=/etc/github-token/oauth
     - --script-path=../test-infra/tools/automator/scripts/update-images.sh
@@ -37,4 +37,4 @@ jobs:
     - --post=make gen
     - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
     requirements: [github]
-    repos: [istio/test-infra]
+    repos: [istio/test-infra@master]

--- a/prow/config/jobs/gogo-genproto-1.6.yaml
+++ b/prow/config/jobs/gogo-genproto-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.6.yaml
+++ b/prow/config/jobs/istio-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.6.yaml
+++ b/prow/config/jobs/istio.io-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.6.yaml
+++ b/prow/config/jobs/pkg-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.6.yaml
+++ b/prow/config/jobs/proxy-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools-proxy:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh

--- a/prow/config/jobs/release-builder-1.6.yaml
+++ b/prow/config/jobs/release-builder-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.6.yaml
+++ b/prow/config/jobs/tools-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-04-28T21-48-12
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-01T18-02-13
 jobs:
 - command:
   - make


### PR DESCRIPTION
release-1.6 were incorrectly pointing at `master-` images. 

> Note: the release-branching feature should probably use another release branch as a base instead of `master` (it should work out of the box. I will configure this in a follow-up). There should also be logic to change `image`.