### PR TITLE
Update branch for "update-build-tools-image" jobs on non-master branches

### DIFF
--- a/tools/automator/scripts/update-images.sh
+++ b/tools/automator/scripts/update-images.sh
@@ -24,7 +24,7 @@ source "$ROOT/../utils.sh"
 
 # Defaults
 image='gcr.io/istio-testing/build-tools.*'
-tag='$AUTOMATOR_BRANCH-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}'
+tag='$AUTOMATOR_SRC_BRANCH-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}'
 paths='$AUTOMATOR_REPO_DIR/prow/cluster/jobs/**/*.yaml,$AUTOMATOR_REPO_DIR/prow/config/jobs/**/*.yaml'
 key="image"
 var="IMAGE_VERSION"


### PR DESCRIPTION
Missed this reference in the refactor: https://github.com/istio/test-infra/pull/2619

fix: https://prow.istio.io/view/gcs/istio-prow/logs/update-build-tools-image_common-files_release-1.6_postsubmit/3