### PR TITLE
Update daily perf job to run on release-1.6 and master

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -35,9 +35,9 @@ periodics:
   name: daily-performance-benchmark
   branches: master
   decorate: true
-  timeout: 12h
+  timeout: 24h
   decoration_config:
-    timeout: 12h0m0s
+    timeout: 24h0m0s
   extra_refs:
     - org: istio
       repo: tools
@@ -62,16 +62,16 @@ periodics:
       testing: test-pool
 
 - cron: "0 8 * * *" # starts every day at 08:00AM UTC
-  name: daily-performance-benchmark-release-1.5
-  branches: release-1.5
+  name: daily-performance-benchmark-release-1.6
+  branches: release-1.6
   decorate: true
-  timeout: 12h
+  timeout: 24h
   decoration_config:
-    timeout: 12h0m0s
+    timeout: 24h0m0s
   extra_refs:
     - org: istio
       repo: tools
-      base_ref: release-1.5
+      base_ref: release-1.6
       path_alias: istio.io/tools
   annotations:
     testgrid-dashboards: istio_release-pipeline
@@ -84,7 +84,7 @@ periodics:
       - <<: *istio_container_with_kind
         env:
           - name: GIT_BRANCH
-            value: release-1.5
+            value: release-1.6
         command:
           - entrypoint
           - perf/benchmark/run_benchmark_job.sh


### PR DESCRIPTION
- Deprecate the 1.5 run
- Extend running time for running both fortio and nighthawk in the same cluster.