### PR TITLE
istio/ti extra ref should always be pinned to master

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
@@ -63,7 +63,7 @@ postsubmits:
     - ^release-1.6$
     decorate: true
     extra_refs:
-    - base_ref: release-1.6
+    - base_ref: master
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra

--- a/prow/config/jobs/api-1.6.yaml
+++ b/prow/config/jobs/api-1.6.yaml
@@ -21,7 +21,7 @@ jobs:
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
   name: update_api_dep
   repos:
-  - istio/test-infra
+  - istio/test-infra@master
   requirements:
   - github
   type: postsubmit

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -22,4 +22,4 @@ jobs:
     - --token-path=/etc/github-token/oauth
     - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
     requirements: [github]
-    repos: [istio/test-infra]
+    repos: [istio/test-infra@master]

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -32,7 +32,7 @@ jobs:
     - --dry-run
     requirements: [github]
     modifiers: [optional]
-    repos: [istio/test-infra]
+    repos: [istio/test-infra@master]
 
   - name: update-ref-docs
     type: periodic
@@ -46,7 +46,7 @@ jobs:
     - --token-path=/etc/github-token/oauth
     - --cmd=SOURCE_BRANCH_NAME=release-1.6 make update_ref_docs
     requirements: [github]
-    repos: [istio/test-infra]
+    repos: [istio/test-infra@master]
 
 resources:
   default:


### PR DESCRIPTION
When added as an extra ref, the `istio/test-infra` dependency should always be set to `master`. Otherwise, when a job is copied from `master` to `release-1.x`, it will fail to clone. 

e.g. https://prow.istio.io/view/gcs/istio-prow/logs/update_api_dep_api_release-1.6_postsubmit/6

ref: https://github.com/istio/istio/pull/23576