### PR TITLE
Add prow jobs for upgrade-downgrade tests, upgrade tests, and downgrade tests

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -157,9 +157,111 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-# upgrade using istioctl from 1.5 latest to 1.6 latest
+# upgrade-downgrade test using istioctl from 1.5 latest to 1.6 latest
+- cron: "0 4 * * *"  # starts every day at 04:00AM UTC
+  name: istio-upgrade-downgrade-using-istioctl-1.5_latest-1.6_latest
+  branches: master
+  decorate: true
+  extra_refs:
+  - org: istio
+    repo: tools
+    base_ref: master
+    path_alias: istio.io/tools
+  annotations:
+    testgrid-dashboards: istio_release-pipeline
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - <<: *istio_container_with_kind
+      env:
+      - name: SOURCE_TAG
+        value: 1.5_latest
+      - name: TARGET_TAG
+        value: 1.6_latest
+      - name: INSTALL_OPTIONS
+        value: istioctl
+      - name: TEST_SCENARIO
+        value: upgrade-downgrade
+      command:
+      - entrypoint
+      - upgrade/run_upgrade_test.sh
+    nodeSelector:
+      testing: test-pool
+
+# upgrade test using istioctl from 1.5 latest to 1.6 latest
 - cron: "0 4 * * *"  # starts every day at 04:00AM UTC
   name: istio-upgrade-using-istioctl-1.5_latest-1.6_latest
+  branches: master
+  decorate: true
+  extra_refs:
+  - org: istio
+    repo: tools
+    base_ref: master
+    path_alias: istio.io/tools
+  annotations:
+    testgrid-dashboards: istio_release-pipeline
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - <<: *istio_container_with_kind
+      env:
+      - name: SOURCE_TAG
+        value: 1.5_latest
+      - name: TARGET_TAG
+        value: 1.6_latest
+      - name: INSTALL_OPTIONS
+        value: istioctl
+      - name: TEST_SCENARIO
+        value: upgrade
+      command:
+      - entrypoint
+      - upgrade/run_upgrade_test.sh
+    nodeSelector:
+      testing: test-pool
+
+# downgrade test using istioctl from 1.6 latest to 1.5 latest
+- cron: "0 4 * * *"  # starts every day at 04:00AM UTC
+  name: istio-downgrade-using-istioctl-1.6_latest-1.5_latest
+  branches: master
+  decorate: true
+  extra_refs:
+  - org: istio
+    repo: tools
+    base_ref: master
+    path_alias: istio.io/tools
+  annotations:
+    testgrid-dashboards: istio_release-pipeline
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - <<: *istio_container_with_kind
+      env:
+      - name: SOURCE_TAG
+        value: 1.6_latest
+      - name: TARGET_TAG
+        value: 1.5_latest
+      - name: INSTALL_OPTIONS
+        value: istioctl
+      - name: TEST_SCENARIO
+        value: downgrade
+      command:
+      - entrypoint
+      - upgrade/run_upgrade_test.sh
+    nodeSelector:
+      testing: test-pool
+
+# upgrade-downgrade test using istioctl from 1.6 latest to master
+- cron: "0 8 * * *"  # starts every day at 08:00AM UTC
+  name: istio-upgrade-downgrade-using-istioctl-1.6_latest-master
   branches: master
   decorate: true
   extra_refs:
@@ -178,18 +280,20 @@ periodics:
       - <<: *istio_container_with_kind
         env:
           - name: SOURCE_TAG
-            value: 1.5_latest
-          - name: TARGET_TAG
             value: 1.6_latest
+          - name: TARGET_TAG
+            value: master
           - name: INSTALL_OPTIONS
             value: istioctl
+          - name: TEST_SCENARIO
+            value: upgrade-downgrade
         command:
           - entrypoint
           - upgrade/run_upgrade_test.sh
     nodeSelector:
       testing: test-pool
 
-# upgrade using istioctl from 1.6 latest to master
+# upgrade test using istioctl from 1.6 latest to master
 - cron: "0 8 * * *"  # starts every day at 08:00AM UTC
   name: istio-upgrade-using-istioctl-1.6_latest-master
   branches: master
@@ -215,8 +319,44 @@ periodics:
             value: master
           - name: INSTALL_OPTIONS
             value: istioctl
+          - name: TEST_SCENARIO
+            value: upgrade
         command:
           - entrypoint
           - upgrade/run_upgrade_test.sh
+    nodeSelector:
+      testing: test-pool
+
+# downgrade test using istioctl from master to 1.6 latest
+- cron: "0 8 * * *"  # starts every day at 08:00AM UTC
+  name: istio-downgrade-using-istioctl-master-1.6_latest
+  branches: master
+  decorate: true
+  extra_refs:
+  - org: istio
+    repo: tools
+    base_ref: master
+    path_alias: istio.io/tools
+  annotations:
+    testgrid-dashboards: istio_release-pipeline
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - <<: *istio_container_with_kind
+      env:
+      - name: SOURCE_TAG
+        value: master
+      - name: TARGET_TAG
+        value: 1.6_latest
+      - name: INSTALL_OPTIONS
+        value: istioctl
+      - name: TEST_SCENARIO
+        value: downgrade
+      command:
+      - entrypoint
+      - upgrade/run_upgrade_test.sh
     nodeSelector:
       testing: test-pool


### PR DESCRIPTION
- Add prow job for upgrade-downgrade test from 1.5 latest to 1.6 latest.
- Add prow job for upgrade test from 1.5 latest to 1.6 latest.
- Add prow job for downgrade test from 1.6 latest to 1.5 latest.
- Add prow job for upgrade-downgrade test from 1.6 latest to master.
- Add prow job for upgrade test from 1.6 latest to master.
- Add prow job for downgrade test from master to 1.6 latest.