### PR TITLE
Increase boskos resources

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -2,8 +2,8 @@ resources:
 - type: gke-e2e-test
   state: dirty
   # TODO: Set min lower when mason client supports request ids.
-  min-count: 1
-  max-count: 1
+  min-count: 6
+  max-count: 6
   needs:
     gcp-project: 1
   config:
@@ -24,8 +24,8 @@ resources:
 - type: gke-perf-preset
   state: dirty
   # Set back to 1 when mason client supports request ids.
-  min-count: 3
-  max-count: 3
+  min-count: 4
+  max-count: 4
   needs:
     gcp-perf-test: 1
   config:


### PR DESCRIPTION
Increase `gke-e2e-test` to match jobs using this pool and increase `gke-perf-preset` to number of projects.