### PR TITLE
Add missing preset-service-account label to istio-private/proxy 1.5.

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.5.gen.yaml
@@ -64,6 +64,7 @@ presubmits:
     decorate: true
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test_proxy_release-1.5_release-1.5_priv
     path_alias: istio.io/proxy
     spec:
@@ -100,6 +101,7 @@ presubmits:
     decorate: true
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-asan_proxy_release-1.5_release-1.5_priv
     path_alias: istio.io/proxy
     spec:
@@ -136,6 +138,7 @@ presubmits:
     decorate: true
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-tsan_proxy_release-1.5_release-1.5_priv
     path_alias: istio.io/proxy
     spec:
@@ -209,6 +212,7 @@ presubmits:
     decorate: true
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: check-wasm_proxy_release-1.5_release-1.5_priv
     path_alias: istio.io/proxy
     spec:


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>