### PR TITLE
Update netrc HOME path

### DIFF
--- a/prow/cluster/jobs/all-presets.yaml
+++ b/prow/cluster/jobs/all-presets.yaml
@@ -149,9 +149,24 @@ presets:
         path: .netrc
         mode: 0600
 - labels:
-    preset-enable-netrc: "true"
+    preset-enable-prowbazel-netrc: "true"
   volumeMounts:
   - mountPath: /home/bootstrap/.netrc
+    subPath: .netrc
+    name: netrc
+    readOnly: true
+  volumes:
+  - name: netrc
+    secret:
+      secretName: netrc-secret
+      items:
+      - key: secret
+        path: .netrc
+        mode: 0600
+- labels:
+    preset-enable-netrc: "true"
+  volumeMounts:
+  - mountPath: /home/.netrc
     subPath: .netrc
     name: netrc
     readOnly: true

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.4.yaml
@@ -16,7 +16,7 @@ postsubmits:
       path_alias: istio.io/istio
       repo: istio
     labels:
-      preset-enable-netrc: "true"
+      preset-enable-prowbazel-netrc: "true"
       preset-service-account: "true"
     name: proxy-postsubmit_release-1.4_priv
     path_alias: istio.io/proxy
@@ -68,7 +68,7 @@ presubmits:
       path_alias: istio.io/istio
       repo: istio
     labels:
-      preset-enable-netrc: "true"
+      preset-enable-prowbazel-netrc: "true"
       preset-service-account: "true"
     name: proxy-presubmit_release-1.4_priv
     path_alias: istio.io/proxy
@@ -110,7 +110,7 @@ presubmits:
       path_alias: istio.io/istio
       repo: istio
     labels:
-      preset-enable-netrc: "true"
+      preset-enable-prowbazel-netrc: "true"
       preset-service-account: "true"
     name: proxy-presubmit-asan_release-1.4_priv
     path_alias: istio.io/proxy
@@ -152,7 +152,7 @@ presubmits:
       path_alias: istio.io/istio
       repo: istio
     labels:
-      preset-enable-netrc: "true"
+      preset-enable-prowbazel-netrc: "true"
       preset-service-account: "true"
     name: proxy-presubmit-tsan_release-1.4_priv
     path_alias: istio.io/proxy
@@ -194,7 +194,7 @@ presubmits:
       path_alias: istio.io/istio
       repo: istio
     labels:
-      preset-enable-netrc: "true"
+      preset-enable-prowbazel-netrc: "true"
       preset-service-account: "true"
     name: proxy-presubmit-release_release-1.4_priv
     path_alias: istio.io/proxy

--- a/prow/config/istio-private_jobs/proxy_1.4.yaml
+++ b/prow/config/istio-private_jobs/proxy_1.4.yaml
@@ -12,7 +12,7 @@ transforms:
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     ENVOY_PREFIX: envoy
   labels:
-    preset-enable-netrc: "true"
+    preset-enable-prowbazel-netrc: "true"
   job-type: [presubmit]
 
 
@@ -25,5 +25,5 @@ transforms:
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     ENVOY_PREFIX: envoy
   labels:
-    preset-enable-netrc: "true"
+    preset-enable-prowbazel-netrc: "true"
   job-type: [postsubmit]


### PR DESCRIPTION
The `build-tools-proxy` image sets `HOME=/home`