### PR TITLE
use MULTICLUSTER topology in multicluster tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1039,7 +1039,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --topology
-        - MULTICLUSTER_SINGLE_NETWORK
+        - MULTICLUSTER
         - test.integration.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -953,7 +953,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --topology
-        - MULTICLUSTER_SINGLE_NETWORK
+        - MULTICLUSTER
         - test.integration.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -64,7 +64,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --topology
-      - MULTICLUSTER_SINGLE_NETWORK
+      - MULTICLUSTER
       - test.integration.kube.presubmit
     requirements: [kind]
     env:


### PR DESCRIPTION
Following up https://github.com/istio/istio/pull/2373 we can consolidate MULTICLUSTER_SINGLE_NETWORK and MULTICLUSTER_MULTINETWORK into a single MULTICLUSTER topology for testing, where we test combinations of clusters on the same and on different networks. See:

https://github.com/istio/istio/blob/a677b024c91763e24355413a86e120a09175e29f/prow/integ-suite-kind.sh#L62