### PR TITLE
Fix docs postsubmit

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -62,8 +62,6 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: k8s-tests_istio.io_postsubmit_priv
     path_alias: istio.io/istio.io
     spec:
@@ -71,7 +69,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.kube.postsubmit
+        - test.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2020-05-08T20-48-51
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -107,8 +107,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: k8s-tests_istio.io_postsubmit
     path_alias: istio.io/istio.io
     spec:
@@ -116,7 +114,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.kube.postsubmit
+        - test.kube.presubmit
         image: gcr.io/istio-testing/build-tools:master-2020-05-08T20-48-51
         name: ""
         resources:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -11,15 +11,9 @@ jobs:
     command: [make, gen-check]
 
   - name: k8s-tests
-    type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.kube.presubmit]
     requirements: [kind]
     modifiers: [optional]
-
-  - name: k8s-tests
-    type: postsubmit
-    command: [entrypoint, prow/integ-suite-kind.sh, test.kube.postsubmit]
-    requirements: [kind, gcp]
 
   - name: update-ref-docs-dry-run
     type: presubmit


### PR DESCRIPTION
The job doesn't run quite right. Rather than attempting to get the
makefile to do the same thing for presubmit and postsubmit, instead we
can just share the job definition like most jobs do