### PR TITLE
Allow ProwJobs to be aborted without completion time.

### DIFF
--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -47,7 +47,6 @@ spec:
                   - "success"
                   - "failure"
                   - "error"
-                  - "aborted"
           - required:
             - completionTime
   additionalPrinterColumns:


### PR DESCRIPTION
fixes: https://github.com/kubernetes/test-infra/issues/17169
ref: https://github.com/kubernetes/test-infra/pull/17023
/assign @clarketm 