### PR TITLE
Explicitly specify --github-token-path.

### DIFF
--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - --slack-token-file=/etc/slack/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -34,6 +34,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -21,6 +21,7 @@ spec:
         - --gcs-credentials-file=/etc/service-account/service-account.json
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         - --history-uri=gs://istio-prow/tide-history.json
         - --job-config-path=/etc/job-config
         - --status-path=gs://istio-prow/tide-status-checkpoint.yaml


### PR DESCRIPTION
Explicitly specify the token path as the default value since the default will be removed in the near future.
```
{
  component: "hook"   
  file: "prow/flagutil/github.go:71"   
  func: "k8s.io/test-infra/prow/flagutil.(*GitHubOptions).Validate"   
  level: "warning"   
  msg: "missing required flag: please set to --github-token-path=/etc/github/oauth before June 2020"   
}
```
/assign @clarketm 