### PR TITLE
Revert update-ref-docs job back to using the SOURCE_BRANCH_NAME for the

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -19,11 +19,11 @@ periodics:
       - ./tools/automator/automator.sh
       - --org=istio
       - --repo=istio.io
-      - '--title=Automator: update istio.io@$AUTOMATOR_BRANCH reference docs'
+      - '--title=Automator: update istio.io@$AUTOMATOR_SRC_BRANCH reference docs'
       - --modifier=refdocs
       - --token-path=/etc/github-token/oauth
       - --cmd=make update_ref_docs
-      image: gcr.io/istio-testing/build-tools:master-2020-05-08T20-48-51
+      image: gcr.io/istio-testing/build-tools:master-2020-05-20T22-13-03
       name: ""
       resources:
         limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -19,11 +19,11 @@ periodics:
       - ./tools/automator/automator.sh
       - --org=istio
       - --repo=istio.io
-      - '--title=Automator: update istio.io@release-1.6 reference docs'
+      - '--title=Automator: update istio.io@$AUTOMATOR_BRANCH reference docs'
       - --modifier=refdocs
       - --token-path=/etc/github-token/oauth
-      - --cmd=SOURCE_BRANCH_NAME=release-1.6 make update_ref_docs
-      image: gcr.io/istio-testing/build-tools:master-2020-05-20T22-13-03
+      - --cmd=make update_ref_docs
+      image: gcr.io/istio-testing/build-tools:master-2020-05-08T20-48-51
       name: ""
       resources:
         limits:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -35,10 +35,10 @@ jobs:
     - ./tools/automator/automator.sh
     - --org=istio
     - --repo=istio.io
-    - "--title=Automator: update istio.io@release-1.6 reference docs"
+    - "--title=Automator: update istio.io@$AUTOMATOR_BRANCH reference docs"
     - --modifier=refdocs
     - --token-path=/etc/github-token/oauth
-    - --cmd=SOURCE_BRANCH_NAME=release-1.6 make update_ref_docs
+    - --cmd=make update_ref_docs
     requirements: [github]
     repos: [istio/test-infra@master]
 

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -35,7 +35,7 @@ jobs:
     - ./tools/automator/automator.sh
     - --org=istio
     - --repo=istio.io
-    - "--title=Automator: update istio.io@$AUTOMATOR_BRANCH reference docs"
+    - "--title=Automator: update istio.io@$AUTOMATOR_SRC_BRANCH reference docs"
     - --modifier=refdocs
     - --token-path=/etc/github-token/oauth
     - --cmd=make update_ref_docs


### PR DESCRIPTION
release