### PR TITLE
update Prow commit tag length to 10

### DIFF
--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -76,7 +76,7 @@ postsubmits:
         - --github-token-path
         - /etc/github-token/oauth
         - --confirm
-        image: gcr.io/k8s-prow/peribolos:v20200601-4efada061
+        image: gcr.io/k8s-prow/peribolos:v20200601-4efada0619
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -28,7 +28,7 @@ periodics:
       - --paths=prow/cluster/jobs/**/!(*test-infra*).yaml,prow/config/jobs/**/!(*test-infra*).yaml
       - --source=$AUTOMATOR_ROOT_DIR/prow/cluster/plank_deployment.yaml
       - --image=gcr.io/k8s-prow/.*
-      - --tag=v[0-9]{8}-[a-f0-9]{9}
+      - --tag=v[0-9]{8}-[a-f0-9]{10}
       - --var=image
       image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
       name: ""

--- a/prow/config/jobs/community.yaml
+++ b/prow/config/jobs/community.yaml
@@ -10,7 +10,7 @@ jobs:
     command: [make, test]
 
   - name: sync-org
-    image: gcr.io/k8s-prow/peribolos:v20200601-4efada061
+    image: gcr.io/k8s-prow/peribolos:v20200601-4efada0619
     type: postsubmit
     command:
     - /app/prow/cmd/peribolos/app.binary

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -154,7 +154,7 @@ jobs:
     - --paths=prow/cluster/jobs/**/!(*test-infra*).yaml,prow/config/jobs/**/!(*test-infra*).yaml
     - --source=$AUTOMATOR_ROOT_DIR/prow/cluster/plank_deployment.yaml
     - --image=gcr.io/k8s-prow/.*
-    - --tag=v[0-9]{8}-[a-f0-9]{9}
+    - --tag=v[0-9]{8}-[a-f0-9]{10}
     - --var=image
     requirements: [github]
     repos: [istio/test-infra]


### PR DESCRIPTION
The tag length for Prow images has changed fro 9 to 10 characters (https://github.com/kubernetes/test-infra/pull/17649).