### PR TITLE
add integ-multicluster-pilot-k8s-tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -892,6 +892,63 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
+    name: integ-multicluster-pilot-k8s-tests_istio_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,-multicluster
+        image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.4-istio
+      preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -365,6 +365,63 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
+    name: integ-pilot-multicluster-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.4-istio
+      preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -844,63 +901,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-ssh: "true"
-      preset-override-deps: release-1.4-istio
-      preset-override-envoy: "true"
-    name: integ-multicluster-pilot-k8s-tests_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
         - test.integration.pilot.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -822,6 +822,57 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-multicluster-pilot-k8s-tests_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,-multicluster
+        image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
     name: integ-security-k8s-tests_istio
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -338,6 +338,59 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-pilot-multicluster-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-security-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -780,57 +833,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-05-31T23-50-32
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_istio
-    branches:
-    - ^master$
-    decorate: true
-    name: integ-multicluster-pilot-k8s-tests_istio
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
         - test.integration.pilot.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -42,6 +42,19 @@ jobs:
       - name: TEST_SELECT
         value: "-postsubmit,-flaky,-multicluster"
 
+  - name: integ-multicluster-pilot-k8s-tests
+      type: presubmit
+      command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube.presubmit
+      requirements: [kind]
+      env:
+        - name: TEST_SELECT
+          value: "-postsubmit,-flaky,-multicluster"
+
   - name: integ-security-k8s-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube.presubmit]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -42,19 +42,6 @@ jobs:
       - name: TEST_SELECT
         value: "-postsubmit,-flaky,-multicluster"
 
-  - name: integ-multicluster-pilot-k8s-tests
-    type: presubmit
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --topology
-      - MULTICLUSTER
-      - test.integration.pilot.kube.presubmit
-    requirements: [kind]
-    env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky,-multicluster"
-
   - name: integ-security-k8s-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube.presubmit]
@@ -133,6 +120,20 @@ jobs:
     type: postsubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
+    env:
+      - name: TEST_SELECT
+        value: "-multicluster"
+
+  - name: integ-pilot-multicluster-tests
+    type: postsubmit
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - test.integration.pilot.kube
+    requirements: [kind]
+    modifiers: [hidden]
     env:
       - name: TEST_SELECT
         value: "-multicluster"

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -133,7 +133,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.pilot.kube
     requirements: [kind]
-    modifiers: [hidden]
+    modifiers: [optional, hidden, skipped]
     env:
       - name: TEST_SELECT
         value: "-multicluster"

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -43,17 +43,17 @@ jobs:
         value: "-postsubmit,-flaky,-multicluster"
 
   - name: integ-multicluster-pilot-k8s-tests
-      type: presubmit
-      command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
-        - test.integration.pilot.kube.presubmit
-      requirements: [kind]
-      env:
-        - name: TEST_SELECT
-          value: "-postsubmit,-flaky,-multicluster"
+    type: presubmit
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - test.integration.pilot.kube.presubmit
+    requirements: [kind]
+    env:
+      - name: TEST_SELECT
+        value: "-postsubmit,-flaky,-multicluster"
 
   - name: integ-security-k8s-tests
     type: presubmit


### PR DESCRIPTION
To incrementally move Pilot tests such as https://github.com/istio/istio/pull/24549 as part of https://github.com/istio/istio/issues/23618, we need a separate prow job that uses the multicluster topology. 

Suites that haven't been converted (had `RequireSingleCluster` removed) will be skipped. If this job is added we will be able to properly test https://github.com/istio/istio/pull/24549 under both single and multicluster scenarios. 