### PR TITLE
Revert autobump to a previous version

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -76,7 +76,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200601-4efada0619
+    - image: gcr.io/k8s-prow/autobump:v20200526-c96f7e37b
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Some change to bump.sh broke bumping. Since autobump is bumped to a broken version, programmatic tools to revert won't work until autobump is reverted.

Previous Bump Example: https://prow.istio.io/view/gs/istio-prow/logs/ci-prow-autobump/1525
Broken Bump Example: https://prow.istio.io/view/gcs/istio-prow/logs/ci-prow-autobump/1583

May address Issue #2704 