### PR TITLE
Add build cache to lint and gen

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1089,8 +1089,16 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache-pvc
+          subPath: gomod
       nodeSelector:
         testing: test-pool
+      volumes:
+      - name: build-cache-pvc
+        persistentVolumeClaim:
+          claimName: build-cache-claim
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1114,5 +1122,13 @@ presubmits:
             memory: 3Gi
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache-pvc
+          subPath: gomod
       nodeSelector:
         testing: test-pool
+      volumes:
+      - name: build-cache-pvc
+        persistentVolumeClaim:
+          claimName: build-cache-claim

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -206,11 +206,13 @@ jobs:
 
   - name: lint
     type: presubmit
+    requirements: [cache]
     command: [make, lint]
     resources: lint
 
   - name: gencheck
     type: presubmit
+    requirements: [cache]
     command: [make, gen-check]
 
 resources:


### PR DESCRIPTION
This is to speed up the jobs by removing the `go mod download` step. Note: the reason we aren't enabling this globally is to ensure we get proper testing. Currently unit test job runs this only, so expanding this to a few more then we can globally enable