### PR TITLE
Update autobump to include splitting fix.

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -76,7 +76,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200622-168a90f1b0
+    - image: gcr.io/k8s-prow/autobump:v20200629-afa95802c0
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Update to include https://github.com/kubernetes/test-infra/pull/18060