### PR TITLE
Update autobump to include fix to path splitting (part 2).

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -76,7 +76,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200629-afa95802c0
+    - image: gcr.io/k8s-prow/autobump:v20200629-8c9d7c7957
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Updates to include https://github.com/kubernetes/test-infra/pull/18107