### PR TITLE
Update autobump to include fix to image existence check.

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -76,7 +76,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200629-8c9d7c7957
+    - image: gcr.io/k8s-prow/autobump:v20200630-ba12d68fe6
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Update to include: https://github.com/kubernetes/test-infra/pull/18120
Images successfully published at this tag: `https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-prow/1278048757333626884`