### PR TITLE
add analyze-tests presubmit

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1392,3 +1392,34 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.4-istio
+      preset-override-envoy: "true"
+    name: analyze-tests_istio_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - make
+        - test.integration.analyze
+        image: gcr.io/istio-testing/build-tools:master-2020-06-30T00-03-39
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1254,3 +1254,28 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: analyze-tests_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - make
+        - test.integration.analyze
+        image: gcr.io/istio-testing/build-tools:master-2020-06-30T00-03-39
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -205,6 +205,10 @@ jobs:
     type: presubmit
     command: [make, gen-check]
 
+  - name: analyze-tests
+    type: presubmit
+    command: [make, test.integration.analyze]
+
 resources:
   default:
     requests:


### PR DESCRIPTION
https://github.com/istio/istio/pull/25046 moved feature label validation out of the main test running flow. This job will block tests that fail the feature label requirements, as well as produce output files with metadata about the current set of integration tests. 