### PR TITLE
Add job for benchmark test in presubmit and postsubmit

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -768,6 +768,41 @@ presubmits:
       volumes:
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.4-istio
+      preset-override-envoy: "true"
+    name: benchmark_istio_priv
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - benchtest
+        image: gcr.io/istio-testing/build-tools:master-2020-07-08T14-39-36
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 8Gi
+          requests:
+            cpu: "8"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -73,6 +73,38 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    labels:
+      preset-service-account: "true"
+    name: benchmark-report_istio_postsubmit
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - benchtest
+        - report-benchtest
+        image: gcr.io/istio-testing/build-tools:master-2020-07-08T14-39-36
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 8Gi
+          requests:
+            cpu: "8"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-distroless-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -702,6 +734,35 @@ presubmits:
       volumes:
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: benchmark_istio
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - benchtest
+        image: gcr.io/istio-testing/build-tools:master-2020-07-08T14-39-36
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 8Gi
+          requests:
+            cpu: "8"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/config/istio-private_jobs/istio.yaml
+++ b/prow/config/istio-private_jobs/istio.yaml
@@ -21,4 +21,4 @@ transforms:
     preset-override-envoy: "true"
     preset-override-deps: release-1.4-istio
   job-type: [presubmit, postsubmit]
-  job-blacklist: [release_istio_postsubmit, cache-experiment_istio_postsubmit, cache-experiment_istio, update-ref-docs-dry-run_istio]
+  job-blacklist: [benchmark-report_istio_postsubmit, release_istio_postsubmit, cache-experiment_istio_postsubmit, cache-experiment_istio, update-ref-docs-dry-run_istio]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -17,6 +17,19 @@ jobs:
     command: [entrypoint, prow/release-commit.sh]
     requirements: [gcp, docker]
 
+  - name: benchmark
+    type: presubmit
+    modifiers: [optional, skipped, hidden]
+    command: [entrypoint, make, benchtest]
+    resources: benchmark
+
+  - name: benchmark-report
+    type: postsubmit
+    modifiers: [hidden]
+    command: [entrypoint, make, benchtest, report-benchtest]
+    requirements: [gcp]
+    resources: benchmark
+
   - name: integ-galley-k8s-tests
     type: presubmit
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.galley.kube.presubmit]
@@ -218,3 +231,11 @@ resources:
       cpu: "3000m"
     limits:
       memory: "24Gi"
+  # Give Guaranteed QOS for consistency in the benchmarks
+  benchmark:
+    requests:
+      memory: "8Gi"
+      cpu: "8000m"
+    limits:
+      memory: "8Gi"
+      cpu: "8000m"


### PR DESCRIPTION
Hidden for now, to ensure I don't break something

For https://github.com/istio/istio/issues/18135

Depends on https://github.com/istio/istio/pull/25257

The intent is we have two jobs:

Postsubmit job runs benchmark, reports reports to bucket/SHA.txt
Presubmit job, optional and run on demand, runs benchmark and fetches
the latest results from postsubmit and compares the two.