### PR TITLE
Add docker requirements for perf jobs

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -36,6 +36,7 @@ periodics:
   timeout: 24h
   decoration_config:
     timeout: 24h0m0s
+  requirements: [docker]
   extra_refs:
     - org: istio
       repo: tools
@@ -68,6 +69,7 @@ periodics:
   timeout: 24h
   decoration_config:
     timeout: 24h0m0s
+  requirements: [docker]
   extra_refs:
     - org: istio
       repo: tools
@@ -100,6 +102,7 @@ periodics:
   timeout: 24h
   decoration_config:
     timeout: 24h0m0s
+  requirements: [docker]
   extra_refs:
     - org: istio
       repo: tools
@@ -132,6 +135,7 @@ periodics:
   timeout: 24h
   decoration_config:
     timeout: 24h0m0s
+  requirements: [docker]
   extra_refs:
     - org: istio
       repo: tools


### PR DESCRIPTION
https://github.com/istio/istio/issues/25057

To fix this error:

```
Status: Downloaded newer image for envoyproxy/nighthawk-dev:59683b759eb8f8bd8cce282795c08f9e2b3313d4
docker: Error response from daemon: error creating aufs mount to /var/lib/docker/aufs/mnt/b10c4a55f090d7e9444af9c7cfdbf9cc91faf2fd755f638ffa8c7303d66c0cd8-init: mount target=/var/lib/docker/aufs/mnt/b10c4a55f090d7e9444af9c7cfdbf9cc91faf2fd755f638ffa8c7303d66c0cd8-init 
...
```