### PR TITLE
Unhide benchmark job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -783,7 +783,6 @@ presubmits:
     name: benchmark_istio_priv
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -795,7 +794,7 @@ presubmits:
         resources:
           limits:
             cpu: "8"
-            memory: 8Gi
+            memory: 24Gi
           requests:
             cpu: "8"
             memory: 8Gi

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -77,7 +77,6 @@ postsubmits:
       preset-service-account: "true"
     name: benchmark-report_istio_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -90,7 +89,7 @@ postsubmits:
         resources:
           limits:
             cpu: "8"
-            memory: 8Gi
+            memory: 24Gi
           requests:
             cpu: "8"
             memory: 8Gi
@@ -743,7 +742,6 @@ presubmits:
     name: benchmark_istio
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -755,7 +753,7 @@ presubmits:
         resources:
           limits:
             cpu: "8"
-            memory: 8Gi
+            memory: 24Gi
           requests:
             cpu: "8"
             memory: 8Gi

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -19,13 +19,12 @@ jobs:
 
   - name: benchmark
     type: presubmit
-    modifiers: [optional, skipped, hidden]
+    modifiers: [optional, skipped]
     command: [entrypoint, make, benchtest]
     resources: benchmark
 
   - name: benchmark-report
     type: postsubmit
-    modifiers: [hidden]
     command: [entrypoint, make, benchtest, report-benchtest]
     requirements: [gcp]
     resources: benchmark
@@ -237,5 +236,5 @@ resources:
       memory: "8Gi"
       cpu: "8000m"
     limits:
-      memory: "8Gi"
+      memory: "24Gi"
       cpu: "8000m"


### PR DESCRIPTION
Also put memory back to the default limit; there was 1 case where it was
OOM killed.