### PR TITLE
Verify that release notes are present

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1426,3 +1426,42 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.4-istio
+      preset-override-envoy: "true"
+    name: checkReleaseNotes_istio_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - ./tools/check_release_notes.sh
+        - --token-path=/etc/github-token/auth
+        image: gcr.io/istio-testing/build-tools:master-2020-07-10T02-22-20
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1439,6 +1439,7 @@ presubmits:
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
     name: checkReleaseNotes_istio_priv
+    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1445,7 +1445,7 @@ presubmits:
       - command:
         - ./tools/check_release_notes.sh
         - --token-path=/etc/github-token/auth
-        image: gcr.io/istio-testing/build-tools:master-2020-07-10T02-22-20
+        image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1444,7 +1444,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - ./tools/check_release_notes.sh
+        - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/auth
         image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
         name: ""

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1313,3 +1313,36 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: checkReleaseNotes_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - ./tools/check_release_notes.sh
+        - --token-path=/etc/github-token/auth
+        image: gcr.io/istio-testing/build-tools:master-2020-07-10T02-22-20
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1325,7 +1325,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - ./tools/check_release_notes.sh
+        - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/auth
         image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
         name: ""

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1326,7 +1326,7 @@ presubmits:
       - command:
         - ./tools/check_release_notes.sh
         - --token-path=/etc/github-token/auth
-        image: gcr.io/istio-testing/build-tools:master-2020-07-10T02-22-20
+        image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1320,6 +1320,7 @@ presubmits:
     - ^master$
     decorate: true
     name: checkReleaseNotes_istio
+    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -225,6 +225,7 @@ jobs:
     requirements: [github]
     modifiers:
       - skipped
+      - optional
 repos: [istio/test-infra@master]
 resources:
   default:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -225,7 +225,7 @@ jobs:
     requirements: [github]
     modifiers:
       - skipped
-
+repos: [istio/test-infra@master]
 resources:
   default:
     requests:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -217,6 +217,15 @@ jobs:
     type: presubmit
     command: [make, gen-check]
 
+  - name: checkReleaseNotes
+    type: presubmit
+    command:
+      - ./tools/check_release_notes.sh
+      - --token-path=/etc/github-token/auth
+    requirements: [github]
+    modifiers:
+      - skipped
+
 resources:
   default:
     requests:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -220,7 +220,7 @@ jobs:
   - name: checkReleaseNotes
     type: presubmit
     command:
-      - ./tools/check_release_notes.sh
+      - ../test-infra/tools/check_release_notes.sh
       - --token-path=/etc/github-token/auth
     requirements: [github]
     modifiers:

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+print_error() {
+    local last_return="$?"
+
+    {
+        echo
+        echo "${1:-unknown error}"
+        echo
+    } >&2
+
+    return "${2:-$last_return}"
+}
+
+print_error_and_exit() {
+    print_error "${1:-unknown error}"
+    exit "${2:-1}"
+}
+
+RELEASE_NOTES_NONE_LABEL="release-notes-none"
+
+cleanup() {
+    rm -rf "${tmp_token:-}"
+}
+
+get_opts() {
+    if opt="$(getopt -o '' -l token-path:,token:,pr:,org:,repo:,verbose -n "$(basename "$0")" -- "$@")"; then
+        eval set -- "$opt"
+    else
+        print_error_and_exit "unable to parse options"
+    fi
+
+    while true; do
+        case "$1" in
+        --token-path)
+            token_path="$2"
+            token="$(cat "$token_path")"
+            shift 2
+            ;;
+        --token)
+            token="$2"
+            tmp_token="$(mktemp -t token-XXXXXXXXXX)"
+            echo "$token" >"$tmp_token"
+            token_path="$tmp_token"
+            shift 2
+            ;;
+        --verbose)
+            shell_args+=("-x")
+            shift
+            ;;
+        --org)
+            REPO_OWNER="$2"
+            shift 2
+            ;;
+        --repo)
+            REPO_NAME="$2"
+            shift 2
+            ;;
+        --pr)
+            PULL_NUMBER="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            script_args=("$@")
+            break
+            ;;
+        *)
+            print_error_and_exit "unknown option: $1"
+            ;;
+        esac
+    done
+}
+
+#This script relies on the REPO_OWNER, REPO_NAME, and PULL_NUMBER environment
+#variables as defined in https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables.
+validate_opts() {
+    if [ -z "${REPO_OWNER:-}" ]; then
+        print_error_and_exit "REPO_OWNER is a required option. It must match the GitHub org."
+        exit 1
+    fi
+
+    if [ -z "${REPO_NAME:-}" ]; then
+        print_error_and_exit "REPO_NAME is a required option. It must match the GitHub repo."
+        exit 1
+    fi
+
+    if [ -z "${PULL_NUMBER:-}" ]; then
+        print_error_and_exit "PULL_NUMBER is a required option. It must match the GitHub pull request number."
+        exit 1
+    fi
+}
+
+# Curl the GitHub API to get a list of files for the specified PR. If files are
+# found, exit. We might eventually want to validate the data here.
+checkForFiles() {
+    echo "Requesting files from pull request ${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
+    if [ -z ${token} ]; then
+        ghFiles=$(curl -L -s --show-error --fail \
+            --header "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}/files)
+    else
+        ghFiles=$(curl -L -s --show-error --fail \
+            --header "Accept: application/vnd.github.v3+json" \
+            --header "Authorization: Bearer ${token}" \
+            https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}/files)
+    fi
+    
+    #if return code isn't 0, print the error and exit.
+    if [ $? != 0 ]; then
+        exit 1
+    fi
+
+    releaseNotesFiles=$(echo "${ghFiles}" | jq 'map(.filename)' |
+            grep 'releasenotes\/notes\/.*\.yaml' ) 
+
+    if [ -z ${releaseNotesFiles} ]; then
+        echo "No release notes files found."
+    else
+        echo "Found release notes entries"
+        exit 0
+    fi
+}
+
+checkForLabel() {
+    # If no release notes files were found in the PR, go back and request the actual
+    # PR info (instead of the files) and check the labels.
+    echo "Requesting labels from pull request ${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
+
+    if [ -z ${token} ]; then
+        ghPR=$(curl -L -s --show-error --fail  \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER})
+
+    else
+        ghPR=$(curl -L -s --show-error --fail \
+            --header "Accept: application/vnd.github.v3+json" \
+            --header "Authorization: Bearer ${token}" \
+            https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER})
+
+    fi
+
+    #if return code isn't 0, print the error and exit.
+    if [ $? != 0 ]; then
+        exit 1
+    fi
+
+    labels=$(echo "${ghPR}" | jq '.labels | map(.name)')
+    releaseNotesLabelPresent=$(echo "${labels}" | grep RELEASE_NOTES_NONE_LABEL)
+
+    if [ -z ${releaseNotesLabelPresent} ]; then
+        echo "Missing release notes and missing release notes label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request"
+        exit 1
+    fi
+}
+
+main() {
+    trap cleanup EXIT
+    get_opts "$@"
+    validate_opts
+
+    checkForFiles
+    checkForLabel
+    return 1
+}
+
+main "$@"
+exit "${exit_code:-0}"


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/23622

This is a job to look for a release note file to be created in `/releasenotes/notes`. If that file has not been created, then the job will check the labels on the pull request for a label `release-notes-none`. If neither are present, the script will exit with a non-zero error code. 

* Testing:  I have tested this script manually with:
** A commit containing release notes
** One missing release notes
** An invalid authorization token. 

I currently have:
```
    modifiers:
      - skipped
```

set on the PR, which should skip running the job on any PRs unless manually called. This will allow me to test it on the `istio/istio` repo end to end before I enable it as an optional PR. Eventually, once this is tested thoroughly, I would like to make it a required PR.