### PR TITLE
add analyze-tests job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1364,7 +1364,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -1377,6 +1377,7 @@ presubmits:
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
     name: analyze-tests_istio_priv
+    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1376,6 +1376,37 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
+    name: analyze-tests_istio_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - make
+        - test.integration.analyze
+        image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.4-istio
+      preset-override-envoy: "true"
     name: lint_istio_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1263,13 +1263,14 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
     branches:
     - ^master$
     decorate: true
     name: analyze-tests_istio
+    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1269,6 +1269,31 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    name: analyze-tests_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - make
+        - test.integration.analyze
+        image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        testing: test-pool
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
     name: lint_istio
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -209,6 +209,7 @@ jobs:
         value: " --istio.test.retries=1 "
 
   - name: analyze-tests
+    modifiers: [optional, skipped]
     type: presubmit
     command: [make, test.integration.analyze]
 

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -208,6 +208,10 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
+  - name: analyze-tests
+    type: presubmit
+    command: [make, test.integration.analyze]
+
   - name: lint
     type: presubmit
     command: [make, lint]


### PR DESCRIPTION
`make test.integration.analyze` passes locally with https://github.com/istio/istio/commit/7e486c75d142b7ce16e09fd830850a7502e05d74

Also open to adding `optional,skipped` as a first step. 

<details>

<pre>
~/g/s/i/istio ❯❯❯ make test.integration.analyze                                                                                                                                                                master ✭
go test -p 1  ./tests/integration///... -timeout 30m \
--istio.test.analyze \
2>&1 | tee >(/usr/bin/go-junit-report > /work/out/darwin_amd64/junit.xml)
go: downloading github.com/openshift/api v0.0.0-20200713203337-b2494ecb17dd
go: downloading golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868
ok      istio.io/istio/tests/integration/framework      0.474s
?       istio.io/istio/tests/integration/framework/mycomponent  [no test files]
ok      istio.io/istio/tests/integration/galley 0.489s
ok      istio.io/istio/tests/integration/mixer  0.531s
ok      istio.io/istio/tests/integration/mixer/outboundtrafficpolicy    0.561s
ok      istio.io/istio/tests/integration/mixer/policy   0.478s
ok      istio.io/istio/tests/integration/mixer/telemetry/logs   0.525s
ok      istio.io/istio/tests/integration/mixer/telemetry/metrics        0.544s
?       istio.io/istio/tests/integration/multicluster   [no test files]
ok      istio.io/istio/tests/integration/multicluster/centralistio      1.486s
ok      istio.io/istio/tests/integration/multicluster/multimaster       0.647s
ok      istio.io/istio/tests/integration/multicluster/remote    1.276s
ok      istio.io/istio/tests/integration/operator       1.204s
ok      istio.io/istio/tests/integration/pilot  0.665s
ok      istio.io/istio/tests/integration/pilot/analysis 0.719s
ok      istio.io/istio/tests/integration/pilot/cni      0.615s
ok      istio.io/istio/tests/integration/pilot/ingress  0.714s
ok      istio.io/istio/tests/integration/pilot/locality 0.774s
ok      istio.io/istio/tests/integration/pilot/meshnetwork      0.573s
ok      istio.io/istio/tests/integration/pilot/revisions        0.597s
?       istio.io/istio/tests/integration/pilot/sidecarscope     [no test files]
ok      istio.io/istio/tests/integration/pilot/vm       0.631s
ok      istio.io/istio/tests/integration/security       0.581s
ok      istio.io/istio/tests/integration/security/cert_provision_prometheus     0.516s
ok      istio.io/istio/tests/integration/security/chiron        0.532s
ok      istio.io/istio/tests/integration/security/filebased_tls_origination     0.554s
ok      istio.io/istio/tests/integration/security/mtls_first_party_jwt  0.583s
ok      istio.io/istio/tests/integration/security/mtlscert_pluginca_securenaming        0.636s
ok      istio.io/istio/tests/integration/security/mtlsk8sca     0.735s
ok      istio.io/istio/tests/integration/security/sds_egress    0.735s
ok      istio.io/istio/tests/integration/security/sds_ingress   0.536s
?       istio.io/istio/tests/integration/security/sds_ingress/util      [no test files]
ok      istio.io/istio/tests/integration/security/sds_ingress_k8sca     1.040s
ok      istio.io/istio/tests/integration/security/sds_vault_flow        0.570s
?       istio.io/istio/tests/integration/security/util  [no test files]
?       istio.io/istio/tests/integration/security/util/authn    [no test files]
?       istio.io/istio/tests/integration/security/util/cert     [no test files]
?       istio.io/istio/tests/integration/security/util/connection       [no test files]
?       istio.io/istio/tests/integration/security/util/dir      [no test files]
?       istio.io/istio/tests/integration/security/util/rbac_util        [no test files]
?       istio.io/istio/tests/integration/security/util/reachability     [no test files]
?       istio.io/istio/tests/integration/security/util/secret   [no test files]
ok      istio.io/istio/tests/integration/security/webhook       0.693s
ok      istio.io/istio/tests/integration/telemetry      0.682s
ok      istio.io/istio/tests/integration/telemetry/outboundtrafficpolicy        0.700s
ok      istio.io/istio/tests/integration/telemetry/requestclassification        0.516s
ok      istio.io/istio/tests/integration/telemetry/stackdriver  0.605s
?       istio.io/istio/tests/integration/telemetry/stats/prometheus     [no test files]
?       istio.io/istio/tests/integration/telemetry/stats/prometheus/http        [no test files]
ok      istio.io/istio/tests/integration/telemetry/stats/prometheus/http/nullvm 0.564s
ok      istio.io/istio/tests/integration/telemetry/stats/prometheus/http/wasm   0.646s
ok      istio.io/istio/tests/integration/telemetry/stats/prometheus/istioctl    0.708s
ok      istio.io/istio/tests/integration/telemetry/stats/prometheus/tcp 0.649s
?       istio.io/istio/tests/integration/telemetry/tracing      [no test files]
ok      istio.io/istio/tests/integration/telemetry/tracing/clienttracing        0.681s
ok      istio.io/istio/tests/integration/telemetry/tracing/servertracing        2.956s
~/g/s/i/istio ❯❯❯ echo $?                                                                                                                                                                                      master ✭
0

</pre>

</summary>