### PR TITLE
Added success for label

### DIFF
--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -139,14 +139,13 @@ checkForLabel() {
         ghPR=$(curl -L -s --show-error --fail  \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}")
-
     else
         ghPR=$(curl -L -s --show-error --fail \
             --header "Accept: application/vnd.github.v3+json" \
             --header "Authorization: Bearer ${token}" \
             "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}")
-
     fi
+
 
     labels=$(echo "${ghPR}" | jq '.labels | map(.name)')
 
@@ -158,6 +157,9 @@ checkForLabel() {
     if [ -z "${releaseNotesLabelPresent}" ]; then
         echo "Missing release notes and missing ${RELEASE_NOTES_NONE_LABEL} label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request"
         exit 1
+    else
+        echo "Found ${RELEASE_NOTES_NONE_LABEL} label. This pull request will not include release notes."
+        exit 0
     fi
 }
 

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -146,7 +146,6 @@ checkForLabel() {
             "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}")
     fi
 
-
     labels=$(echo "${ghPR}" | jq '.labels | map(.name)')
 
     # grep returns a non-zero error code on not found. Reset -e so we don't fail silently.


### PR DESCRIPTION
Add success case for label. To see this working, run: 

```
 ./tools/check_release_notes.sh --repo istio --org istio --pr 2510
Requesting files from pull request istio/istio#2510
No release notes files found.

Requesting labels from pull request istio/istio#2510
Missing release notes and missing release-notes-none label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request


```

```
./tools/check_release_notes.sh --repo istio --org istio --pr 2509 
Requesting files from pull request istio/istio#2509
No release notes files found.

Requesting labels from pull request istio/istio#2509
^[[AMissing release notes and missing release-notes-none label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request

```

```
./tools/check_release_notes.sh --repo istio --org istio --pr 25580
Requesting files from pull request istio/istio#25580
No release notes files found.

Requesting labels from pull request istio/istio#25580
Found release-notes-none label. This pull request will not include release notes.

```