### PR TITLE
Trigger release notes on all pull requests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1458,7 +1458,7 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1339,7 +1339,7 @@ presubmits:
           privileged: true
       nodeSelector:
         testing: test-pool
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -229,7 +229,6 @@ jobs:
       - --token-path=/etc/github-token/oauth
     requirements: [github]
     modifiers:
-      - skipped
       - optional
     repos: [istio/test-infra@master]
 resources:

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -154,7 +154,7 @@ checkForLabel() {
     set -e
 
     if [ -z "${releaseNotesLabelPresent}" ]; then
-        echo "Missing release notes and missing ${RELEASE_NOTES_NONE_LABEL} label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request"
+        echo "Missing release notes and missing ${RELEASE_NOTES_NONE_LABEL} label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request. Note that the test will have to be manually retriggered after adding the label."
         exit 1
     else
         echo "Found ${RELEASE_NOTES_NONE_LABEL} label. This pull request will not include release notes."


### PR DESCRIPTION
Part of istio/istio#23622

This removes the `skip` modifier from `release-notes_istio`. After this, it will be run on all PRs in istio/istio as an optional test. This PR also clarifies the message that the test will have to be manually triggered if a label is added as prow does not rerun the tests on label changes. 

Testing
* `release-notes-none` label: https://github.com/istio/istio/pull/25580
* release notes present: https://github.com/istio/istio/pull/25509
* tested 25580 with and without the `release-notes-none` label as well. 
