### PR TITLE
Update Automator to do make clean gen

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -80,7 +80,7 @@ postsubmits:
         - --labels=auto-merge
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
-        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
         image: gcr.io/istio-testing/build-tools:master-2020-07-13T16-10-49
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.5.gen.yaml
@@ -80,7 +80,7 @@ postsubmits:
         - --labels=auto-merge
         - --modifier=client-go_update_api
         - --token-path=/etc/github-token/oauth
-        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
         image: gcr.io/istio-testing/build-tools:release-1.5-2020-05-11T22-26-45
         name: ""
         resources:
@@ -127,7 +127,7 @@ postsubmits:
         - --labels=auto-merge
         - --modifier=istio_update_api
         - --token-path=/etc/github-token/oauth
-        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
         image: gcr.io/istio-testing/build-tools:release-1.5-2020-05-11T22-26-45
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
@@ -80,7 +80,7 @@ postsubmits:
         - --labels=auto-merge
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
-        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
         image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
         name: ""
         resources:

--- a/prow/config/jobs/api-1.5.yaml
+++ b/prow/config/jobs/api-1.5.yaml
@@ -18,7 +18,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=client-go_update_api
   - --token-path=/etc/github-token/oauth
-  - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+  - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
   name: gen_client-go
   repos:
   - istio/test-infra@master
@@ -33,7 +33,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=istio_update_api
   - --token-path=/etc/github-token/oauth
-  - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+  - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
   name: gen_istio
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/api-1.6.yaml
+++ b/prow/config/jobs/api-1.6.yaml
@@ -18,7 +18,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=update_api_dep
   - --token-path=/etc/github-token/oauth
-  - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+  - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
   name: update_api_dep
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -20,6 +20,6 @@ jobs:
     - --labels=auto-merge
     - --modifier=update_api_dep
     - --token-path=/etc/github-token/oauth
-    - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make gen
+    - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]


### PR DESCRIPTION
Fix issue in client-go where `make gen` does not produce the complete output.

It might take longer for istio/istio to finish the job, but it is postsubmit job.