### PR TITLE
Tune benchmark CPU

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -793,10 +793,9 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "8"
+            cpu: "15"
             memory: 8Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -150,7 +150,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -178,7 +178,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -206,7 +206,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -240,7 +240,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.4.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -147,7 +147,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -175,7 +175,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -203,7 +203,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -237,7 +237,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -88,7 +88,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -124,7 +124,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -150,7 +150,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -103,7 +103,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -172,7 +172,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -206,7 +206,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -232,7 +232,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -258,7 +258,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -284,7 +284,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -104,7 +104,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -130,7 +130,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -156,7 +156,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -61,7 +61,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -111,7 +111,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -147,7 +147,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -75,7 +75,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -110,7 +110,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -136,7 +136,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -103,7 +103,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -131,7 +131,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -157,7 +157,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -209,7 +209,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -104,7 +104,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -130,7 +130,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -156,7 +156,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -88,10 +88,9 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "8"
+            cpu: "15"
             memory: 8Gi
         securityContext:
           privileged: true
@@ -752,10 +751,9 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "8"
+            cpu: "15"
             memory: 8Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -103,7 +103,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -131,7 +131,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -157,7 +157,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -209,7 +209,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -212,7 +212,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -238,7 +238,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -264,7 +264,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -326,7 +326,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -353,7 +353,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.4.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.4.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -194,7 +194,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -220,7 +220,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -246,7 +246,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -302,7 +302,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -329,7 +329,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -37,7 +37,7 @@ periodics:
           cpu: "3"
           memory: 24Gi
         requests:
-          cpu: 500m
+          cpu: "1"
           memory: 3Gi
       securityContext:
         privileged: true
@@ -74,7 +74,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -128,7 +128,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -167,7 +167,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -201,7 +201,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -235,7 +235,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -269,7 +269,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -311,7 +311,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -352,7 +352,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -393,7 +393,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -427,7 +427,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -453,7 +453,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -479,7 +479,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -508,7 +508,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -540,7 +540,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -103,7 +103,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -173,7 +173,7 @@ postsubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -207,7 +207,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -233,7 +233,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -259,7 +259,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -285,7 +285,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -318,7 +318,7 @@ presubmits:
             cpu: "3"
             memory: 24Gi
           requests:
-            cpu: 500m
+            cpu: "1"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -51,7 +51,7 @@ const (
 
 	DefaultResource      = "default"
 	DefaultMemoryRequest = "3Gi"
-	DefaultCPURequest    = "500m"
+	DefaultCPURequest    = "1000m"
 	DefaultMemoryLimit   = "24Gi"
 	DefaultCPULimit      = "3000m"
 

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -244,11 +244,10 @@ resources:
       cpu: "3000m"
     limits:
       memory: "24Gi"
-  # Give Guaranteed QOS for consistency in the benchmarks
+  # Give 15 CPUs which will put us on a dedicate node, for consistency
   benchmark:
     requests:
       memory: "8Gi"
-      cpu: "8000m"
+      cpu: "15000m"
     limits:
       memory: "24Gi"
-      cpu: "8000m"


### PR DESCRIPTION
Even giving requests==limit, we do not get rid of noisy neighbor issues.
Seems like the only fix is to give a dedicated node.