### PR TITLE
Drop boskos version

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -13,7 +13,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-4
             numnodes: 5
-            version: 1.17
+            version: 1.16
             networkpolicy:
               enabled: true
               provider: CALICO
@@ -35,7 +35,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-32
             numnodes: 3
-            version: 1.17
+            version: 1.16
             zone: us-central1-f
             scopes:
             - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
The zone they are in only supports 1.17 as part of release channels, and
boskos doesn't have support for release channels currently