### PR TITLE
Touch 1.7 jobs

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -177,7 +177,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -178,7 +178,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ presubmits:
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -57,7 +57,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -100,7 +100,7 @@ postsubmits:
         - make
         - benchtest
         - report-benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -141,7 +141,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -259,7 +259,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -316,7 +316,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -490,7 +490,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -547,7 +547,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -608,7 +608,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -669,7 +669,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -730,7 +730,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -785,7 +785,7 @@ postsubmits:
         - entrypoint
         - make
         - cni.install-test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -830,7 +830,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -866,7 +866,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -906,7 +906,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -944,7 +944,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1000,7 +1000,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1056,7 +1056,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1112,7 +1112,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1168,7 +1168,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1226,7 +1226,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1284,7 +1284,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1344,7 +1344,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1400,7 +1400,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1460,7 +1460,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1515,7 +1515,7 @@ presubmits:
         - entrypoint
         - make
         - cni.install-test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1554,7 +1554,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1588,7 +1588,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1622,7 +1622,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -1662,7 +1662,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -253,7 +253,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -361,7 +361,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -401,7 +401,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.7.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -209,7 +209,7 @@ postsubmits:
         - -C
         - perf_dashboard
         - deploy
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -320,7 +320,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:
@@ -394,7 +394,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+        image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.7.yaml
+++ b/prow/config/jobs/api-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.7.yaml
+++ b/prow/config/jobs/client-go-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.7.yaml
+++ b/prow/config/jobs/common-files-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/gogo-genproto-1.7.yaml
+++ b/prow/config/jobs/gogo-genproto-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.7.yaml
+++ b/prow/config/jobs/istio.io-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.7.yaml
+++ b/prow/config/jobs/pkg-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/release-builder-1.7.yaml
+++ b/prow/config/jobs/release-builder-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.7.yaml
+++ b/prow/config/jobs/tools-1.7.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.7
-image: gcr.io/istio-testing/build-tools:release-1.7-2020-07-16T22-57-32
+image: gcr.io/istio-testing/build-tools:release-release-1.7-2020-07-16T22-57-32
 jobs:
 - command:
   - make


### PR DESCRIPTION
We need to trivially change all of these jobs to get them re-applied. I already accidentally pushed a misnamed image, so reusing that. I am not doing an extra space in all the files since it will fail configgen and I am afraid it may do a diff on the go struct not plain yaml