### PR TITLE
Add build cache to all Istio jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -60,73 +60,6 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
-    name: cache-integ-pilot-k8s-tests_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,-multicluster
-        - name: T
-          value: -v -count=1
-        image: gcr.io/istio-testing/build-tools:master-2020-07-16T22-57-32
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-ssh: "true"
-      preset-override-deps: release-1.4-istio
-      preset-override-envoy: "true"
     name: unit-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -135,7 +68,7 @@ postsubmits:
         - entrypoint
         - make
         - -e
-        - T=-v
+        - T=-v -count=1
         - build
         - racetest
         - binaries-test
@@ -850,75 +783,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
-    name: cache-integ-pilot-k8s-tests_istio_priv
-    optional: true
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,-multicluster
-        - name: T
-          value: -v -count=1
-        image: gcr.io/istio-testing/build-tools:master-2020-07-16T22-57-32
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-ssh: "true"
-      preset-override-deps: release-1.4-istio
-      preset-override-envoy: "true"
     name: unit-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -927,7 +791,7 @@ presubmits:
         - entrypoint
         - make
         - -e
-        - T=-v
+        - T=-v -count=1
         - build
         - racetest
         - binaries-test
@@ -945,6 +809,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -988,6 +855,9 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1032,6 +902,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1084,6 +957,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1146,6 +1022,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1208,6 +1087,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1270,6 +1152,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1334,6 +1219,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1398,6 +1286,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1464,6 +1355,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1526,6 +1420,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1592,6 +1489,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1647,6 +1547,9 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1690,6 +1593,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1730,6 +1636,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1770,6 +1679,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1820,6 +1732,9 @@ presubmits:
         - mountPath: /etc/github-token
           name: github
           readOnly: true
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -8,69 +8,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: cache-integ-pilot-k8s-tests_istio_postsubmit
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,-multicluster
-        - name: T
-          value: -v -count=1
-        image: gcr.io/istio-testing/build-tools:master-2020-07-16T22-57-32
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_istio_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: unit-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -79,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - -e
-        - T=-v
+        - T=-v -count=1
         - build
         - racetest
         - binaries-test
@@ -824,69 +761,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: cache-integ-pilot-k8s-tests_istio
-    optional: true
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,-multicluster
-        - name: T
-          value: -v -count=1
-        image: gcr.io/istio-testing/build-tools:master-2020-07-16T22-57-32
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_istio
-    branches:
-    - ^master$
-    decorate: true
     name: unit-tests_istio
     path_alias: istio.io/istio
     spec:
@@ -895,7 +769,7 @@ presubmits:
         - entrypoint
         - make
         - -e
-        - T=-v
+        - T=-v -count=1
         - build
         - racetest
         - binaries-test
@@ -913,6 +787,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -951,6 +828,9 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -989,6 +869,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1035,6 +918,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1091,6 +977,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1147,6 +1036,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1203,6 +1095,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1261,6 +1156,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1319,6 +1217,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1379,6 +1280,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1435,6 +1339,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1495,6 +1402,9 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1544,6 +1454,9 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1581,6 +1494,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1615,6 +1531,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1649,6 +1568,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1692,6 +1614,9 @@ presubmits:
         - mountPath: /etc/github-token
           name: github
           readOnly: true
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -73,7 +73,16 @@ const (
 	RequirementDeploy  = "deploy"
 )
 
-var AllRequirements = []string{RequirementKind, RequirementDocker, RequirementGitHub, RequirementRelease, RequirementRoot, RequirementGCP, RequirementDeploy, RequirementCache}
+var AllRequirements = []string{
+	RequirementKind,
+	RequirementDocker,
+	RequirementGitHub,
+	RequirementRelease,
+	RequirementRoot,
+	RequirementGCP,
+	RequirementDeploy,
+	RequirementCache,
+}
 
 type JobConfig struct {
 	Jobs                    []Job                              `json:"jobs,omitempty"`

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -3,18 +3,8 @@ repo: istio
 support_release_branching: true
 image: gcr.io/istio-testing/build-tools:master-2020-07-16T22-57-32
 jobs:
-  - name: cache-integ-pilot-k8s-tests
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
-    requirements: [kind, cache]
-    modifiers: [optional,hidden]
-    env:
-    - name: TEST_SELECT
-      value: "-postsubmit,-flaky,-multicluster"
-    - name: T
-      value: "-v -count=1"
-
   - name: unit-tests
-    command: [entrypoint, make, -e, "T=-v", build, racetest, binaries-test]
+    command: [entrypoint, make, -e, "T=-v -count=1", build, racetest, binaries-test]
 
   - name: release-test
     type: presubmit
@@ -249,3 +239,4 @@ resources:
       cpu: "15000m"
     limits:
       memory: "24Gi"
+requirements: [cache]


### PR DESCRIPTION
Experiments on one job were very succesful:
https://prow.istio.io/?job=cache-integ-pilot-k8s-tests_istio

This adds the build cache to all istio/istio master jobs. I did not add
this universally as I could not find an easy way to ensure we do not
cache test results (only build), which may lead to false negatives.

Blocked by https://github.com/istio/istio/pull/25796