### PR TITLE
multicluster job uses directory target

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1193,7 +1193,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - test.integration.kube.presubmit
+        - test.integration.multicluster.kube.presubmit
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1130,7 +1130,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - test.integration.kube.presubmit
+        - test.integration.multicluster.kube.presubmit
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -135,7 +135,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.multicluster.kube.reachability
+        - test.integration.kube.reachability
         env:
         - name: VARIANT
           value: distroless
@@ -1222,7 +1222,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - test.integration.kube.presubmit
+        - test.integration.multicluster.kube.presubmit
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
@@ -1278,7 +1278,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.multicluster.kube.reachability
+        - test.integration.kube.reachability
         env:
         - name: VARIANT
           value: distroless

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -135,7 +135,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.reachability
+        - test.integration.multicluster.kube.reachability
         env:
         - name: VARIANT
           value: distroless
@@ -1278,7 +1278,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.reachability
+        - test.integration.multicluster.kube.reachability
         env:
         - name: VARIANT
           value: distroless

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -107,7 +107,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - --topology
   - MULTICLUSTER
-  - test.integration.kube.presubmit
+  - test.integration.multicluster.kube.presubmit
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
@@ -118,7 +118,7 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - test.integration.multicluster.kube.reachability
+  - test.integration.kube.reachability
   env:
   - name: VARIANT
     value: distroless

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -118,7 +118,7 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - test.integration.kube.reachability
+  - test.integration.multicluster.kube.reachability
   env:
   - name: VARIANT
     value: distroless

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -67,7 +67,7 @@ jobs:
       - prow/integ-suite-kind.sh
       - --topology
       - MULTICLUSTER
-      - test.integration.kube.presubmit
+      - test.integration.multicluster.kube.presubmit
     requirements: [kind]
     env:
       - name: TEST_SELECT


### PR DESCRIPTION
In a previous change, the pilot package removed the `RequiresSingleCluster` flag causing its setup to be run in the integ-multicluster-k8s-tests job because of the way label selection works at the suite-level. This PR will fix that and keep the multicluster job shorter in the meantime before we can remove it entirely. This change does not change the behavior of our tests because the only tests using the `Multicluster` label are in [tests/integration/multicluster].(https://github.com/istio/istio/tree/master/tests/integration/multicluster). 

The plan for multicluster testing is to eventually eliminate the multicluster job and the tests under this directory along with the multicluster label. Instead we will have appropriate jobs use `--topology MULTICLUSTER` with the tests supporting any number of clusters. 

