### PR TITLE
Update script to check for release notes files rather than querying GitHub

### DIFF
--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -215,6 +215,7 @@ jobs:
     command:
       - ../test-infra/tools/check_release_notes.sh
       - --token-path=/etc/github-token/oauth
+      - --repopath=$(pwd)
     requirements: [github]
     modifiers:
       - optional

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -215,7 +215,6 @@ jobs:
     command:
       - ../test-infra/tools/check_release_notes.sh
       - --token-path=/etc/github-token/oauth
-      - --repopath=$(pwd)
     requirements: [github]
     modifiers:
       - optional

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -111,6 +111,21 @@ validate_opts() {
         print_error_and_exit "PULL_NUMBER is a required option. It must match the GitHub pull request number."
         exit 1
     fi
+
+    if [ -z "${REPO_PATH:-}" ]; then
+        echo "REPO_PATH not specified. Using current working directory."
+        REPO_PATH=$(pwd)
+    fi
+
+    if [ -z "${PULL_PULL_SHA:-}" ]; then
+        echo "PULL_PULL_SHA not specified. This must match the HEAD SHA for the pull request."
+        exit 1
+    fi
+
+    if [ -z "${PULL_BASE_REF:-}" ]; then
+        echo "PULL_BASE_REF not specified. This must match the target branch for the pull request."
+        exit 1
+    fi
 }
 
 # Curl the GitHub API to get a list of files for the specified PR. If files are
@@ -164,7 +179,7 @@ checkForLabel() {
     if [ -z "${releaseNotesLabelPresent}" ]; then
         echo "Missing \"${RELEASE_NOTES_NONE_LABEL}\" label"
         echo ""
-        echo "Missing release notes and missing ${RELEASE_NOTES_NONE_LABEL} label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request. Note that the test will have to be manually retriggered after adding the label."
+        echo "Missing release notes and missing \"${RELEASE_NOTES_NONE_LABEL}\" label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request. Note that the test will have to be manually retriggered after adding the label."
         exit 1
     else
         echo "Found ${RELEASE_NOTES_NONE_LABEL} label. This pull request will not include release notes."

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -112,11 +112,6 @@ validate_opts() {
         exit 1
     fi
 
-    if [ -z "${REPO_PATH:-}" ]; then
-        echo "REPO_PATH not specified. Using current working directory."
-        REPO_PATH=$(pwd)
-    fi
-
     if [ -z "${PULL_PULL_SHA:-}" ]; then
         echo "PULL_PULL_SHA not specified. This must match the HEAD SHA for the pull request."
         exit 1
@@ -126,6 +121,14 @@ validate_opts() {
         echo "PULL_BASE_REF not specified. This must match the target branch for the pull request."
         exit 1
     fi
+
+    if [ -z "${REPO_PATH:-}" ]; then
+        echo "REPO_PATH not specified. Using current working directory."
+        REPO_PATH=$(pwd)
+    else
+        echo "Using REPO_PATH ${REPO_PATH}"
+    fi
+
 }
 
 # Curl the GitHub API to get a list of files for the specified PR. If files are
@@ -137,7 +140,7 @@ checkForFiles() {
 
     addedFiles=$(git diff "${PULL_BASE_REF}...${PULL_PULL_SHA}" --name-only --diff-filter=AMR)
     echo "Added files: ${addedFiles}"
-    echo ""
+    echo
     popd
 
     # grep returns a non-zero error code on not found. Reset -e so we don't fail silently.
@@ -146,7 +149,7 @@ checkForFiles() {
     set -e
     if [ -z "${releaseNotesFiles}" ]; then
         echo "No release notes files found in '/releasenotes/notes/'."
-        echo ""
+        echo
     else
         echo "Found release notes entries"
         exit 0
@@ -178,7 +181,7 @@ checkForLabel() {
 
     if [ -z "${releaseNotesLabelPresent}" ]; then
         echo "Missing \"${RELEASE_NOTES_NONE_LABEL}\" label"
-        echo ""
+        echo
         echo "Missing release notes and missing \"${RELEASE_NOTES_NONE_LABEL}\" label. If this pull request contains user facing changes, please follow the instructions at https://github.com/istio/istio/tree/master/releasenotes to add an entry. If not, please add the release-notes-none label to the pull request. Note that the test will have to be manually retriggered after adding the label."
         exit 1
     else

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -135,7 +135,7 @@ checkForFiles() {
 
     pushd "${REPO_PATH}"
 
-    addedFiles=$(git diff ${PULL_BASE_REF}...${PULL_PULL_SHA} --name-only --diff-filter=AMR)
+    addedFiles=$(git diff "${PULL_BASE_REF}...${PULL_PULL_SHA}" --name-only --diff-filter=AMR)
     echo "Added files: ${addedFiles}"
     echo ""
     popd

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -135,7 +135,7 @@ checkForFiles() {
 
     pushd "${REPO_PATH}"
 
-    addedFiles=$(git diff ${PULL_BASE_REF}...${PULL_PULL_SHA} --name-only --diff-filter=A)
+    addedFiles=$(git diff ${PULL_BASE_REF}...${PULL_PULL_SHA} --name-only --diff-filter=AMR)
     echo "Added files: ${addedFiles}"
     echo ""
     popd


### PR DESCRIPTION
With the current release notes script, we are performing two GitHub API operations for every pull request. One of these is necessary to get the labels. The other is unnecessary as we already have a git clone. This pull request updates the verification to use the cloned repo for information on added files instead of using the API. 

Also, the GitHub API limits the number of files returned from a pull request to 30 before it starts paginating. Some pull requests in Istio are quite a bit larger. This fixes that such that it will return the entire list of added/renamed/modified files instead of just looking at the first 30 files. 