### PR TITLE
Switch perf job cron time to make current release run as first

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -29,7 +29,7 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-- cron: "0 0 * * *" # starts every day at 00:00AM UTC
+- cron: "0 8 * * *" # starts every day at 08:00AM UTC
   name: daily-fortio-performance-benchmark
   branches: master
   decorate: true
@@ -105,7 +105,7 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-- cron: "0 8 * * *" # starts every day at 08:00AM UTC
+- cron: "0 12 * * *" # starts every day at 12:00AM UTC
   name: daily-nighthawk-performance-benchmark
   branches: master
   decorate: true
@@ -143,7 +143,7 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-- cron: "0 12 * * *" # starts every day at 12:00PM UTC
+- cron: "0 0 * * *" # starts every day at 00:00PM UTC
   name: daily-nighthawk-performance-benchmark-release-1.7
   branches: release-1.7
   decorate: true


### PR DESCRIPTION
Focusing on debugging current release issues, want to get the logs earlier daily.