### PR TITLE
enable test analyzer

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1433,7 +1433,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -1446,7 +1446,6 @@ presubmits:
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
     name: analyze-tests_istio_priv
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1350,14 +1350,13 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:
     - ^master$
     decorate: true
     name: analyze-tests_istio
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -181,7 +181,6 @@ jobs:
     requirements: [docker]
 
   - name: analyze-tests
-    modifiers: [optional, skipped]
     type: presubmit
     command: [make, test.integration.analyze]
 


### PR DESCRIPTION
https://prow.istio.io/?job=analyze-tests_istio

Enabling this job will prevent unlabeled tests from getting into master. After a recent PR things were passing. https://github.com/istio/istio/pull/26226 should be merged before merging this. 

It's possible that other PRs in istio/istio could break this before it lands, so I'm putting a hold and will manually check before merging .