### PR TITLE
Update perf cluster k8s version

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -35,7 +35,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-32
             numnodes: 3
-            version: 1.16
+            version: 1.17
             zone: us-central1-f
             scopes:
             - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
`The Kubernetes version v1.16.13-gke.1 is not supported by Istio 1.8-alpha.ff6643c5d641f0839f3f9d2decd0d036d80bb115. The minimum supported Kubernetes version is 1.17.`