### PR TITLE
Revert "Update perf cluster k8s version"

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -35,7 +35,7 @@ resources:
         - clusters:
           - machinetype: n1-standard-32
             numnodes: 3
-            version: 1.17
+            version: 1.16
             zone: us-central1-f
             scopes:
             - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
Reverts istio/test-infra#2873

Boskos cannot support 1.17 version. So it go back to use its default version 1.15.