### PR TITLE
Add tools repo to release notes for 1.7

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -1654,6 +1654,10 @@ presubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/tools
+      repo: tools
     name: release-notes_istio_release-1.7
     optional: true
     path_alias: istio.io/istio

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -300,8 +300,7 @@ jobs:
   modifiers:
   - optional
   name: release-notes
-  repos:
-  - istio/test-infra@master
+  repos: [istio/test-infra@master,istio/tools@master]
   requirements:
   - github
   type: presubmit


### PR DESCRIPTION
This adds the tools repo to 1.7 so that it can use `gen-release-notes` as well. 