### PR TITLE
Fix deprecated prow option

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -25,7 +25,7 @@ slack:
     - istio/test-infra
     channels:
     - test-and-release
-    whitelist:
+    exempt_users:
     - istio-testing
 
 lgtm:


### PR DESCRIPTION
```
jsonPayload: {
  component: "status-reconciler"   
  file: "prow/plugins/config.go:647"   
  func: "k8s.io/test-infra/prow/plugins.warnDeprecated"   
  level: "warning"   
  msg: "whitelist field in Slack merge warning is deprecated and has been renamed to exempt_users. Please update your configuration."   
 }
```