### PR TITLE
Remove deprecated github-endpoint flags

### DIFF
--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -20,8 +20,6 @@ spec:
         - --dry-run=false
         - --job-config-path=/etc/job-config
         - --tot-url=http://tot
-        - --github-endpoint=http://ghproxy
-        - --github-endpoint=https://api.github.com
         - --kubeconfig=/etc/kubeconfig/istio-config
         - --skip-report=true
         volumeMounts:


### PR DESCRIPTION
Which was removed in kubernetes/test-infra@2408556