### PR TITLE
Remove deprecated plank arg

### DIFF
--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -21,7 +21,6 @@ spec:
         - --job-config-path=/etc/job-config
         - --tot-url=http://tot
         - --kubeconfig=/etc/kubeconfig/istio-config
-        - --skip-report=true
         volumeMounts:
         - name: oauth
           mountPath: /etc/github


### PR DESCRIPTION
Removing skip-report flag since it's going to be deprecated real soon: https://github.com/kubernetes/test-infra/blob/a4333b6022cbc19d82eaf6058d4ae4086619e5d5/prow/cmd/plank/main.go#L59

/assign @e-blackwelder