### PR TITLE
Use new WG - Test and Release Maintainers/Operations team in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 *                                    @istio/wg-test-and-release-maintainers
-.prow.yaml                           @cjwagner @e-blackwelder @fejta @michelle192837 @chases2 @istio/wg-test-and-release-maintainers
-/authentikos/                        @clarketm @cjwagner @e-blackwelder @fejta @istio/wg-test-and-release-maintainers
-/prow/                               @cjwagner @e-blackwelder @fejta @michelle192837 @chases2
+.prow.yaml                           @istio/wg-test-and-release-maintainers @istio/wg-test-and-release-maintainers-operations
+/authentikos/                        @istio/wg-test-and-release-maintainers @istio/wg-test-and-release-maintainers-operations
+/prow/                               @istio/wg-test-and-release-maintainers-operations
 /prow/config/                        @istio/wg-test-and-release-maintainers
-/prow/config/jobs/test-infra.yaml    @cjwagner @e-blackwelder @fejta @michelle192837 @chases2 @istio/wg-test-and-release-maintainers
+/prow/config/jobs/test-infra.yaml    @istio/wg-test-and-release-maintainers @istio/wg-test-and-release-maintainers-operations
 /prow/cluster/jobs/                  @istio/wg-test-and-release-maintainers
-/prow/cluster/jobs/istio/test-infra/ @cjwagner @e-blackwelder @fejta @michelle192837 @chases2 @istio/wg-test-and-release-maintainers
+/prow/cluster/jobs/istio/test-infra/ @istio/wg-test-and-release-maintainers @istio/wg-test-and-release-maintainers-operations
 /prow/genjobs/                       @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Update CODEOWNERS to use newly created Operations team.

Going forward, operations team members will update https://github.com/istio/community/blob/master/org/teams.yaml. 