### PR TITLE
Update k8s post submit

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -489,7 +489,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.16.9
+        - kindest/node:v1.16.15
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -554,7 +554,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.17.5
+        - kindest/node:v1.17.11
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -611,7 +611,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
-    name: integ-k8s-119_istio_postsubmit_priv
+    name: integ-k8s-118_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -619,7 +619,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.19.0-rc.2
+        - kindest/node:v1.18.8
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -489,7 +489,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.16.9
+        - kindest/node:v1.16.15
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -550,7 +550,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.17.5
+        - kindest/node:v1.17.11
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -603,7 +603,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-119_istio_postsubmit
+    name: integ-k8s-118_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -611,7 +611,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.19.0-rc.2
+        - kindest/node:v1.18.8
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -139,7 +139,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.16.9
+      - kindest/node:v1.16.15
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -153,7 +153,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.17.5
+      - kindest/node:v1.17.11
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -161,13 +161,13 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
-  - name: integ-k8s-119
+  - name: integ-k8s-118
     type: postsubmit
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.19.0-rc.2
+      - kindest/node:v1.18.8
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
Bump to latest, and swap 1.19 for 1.18 since we run 1.19 by default now: https://github.com/istio/istio/pull/27360