### PR TITLE
make integ-pilot-multicluster-tests required

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -359,7 +359,6 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1590,9 +1589,7 @@ presubmits:
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
     name: integ-pilot-multicluster-tests_istio_priv
-    optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -367,7 +367,6 @@ postsubmits:
     decorate: true
     name: integ-pilot-multicluster-tests_istio_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1495,9 +1494,7 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-pilot-multicluster-tests_istio
-    optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -122,7 +122,6 @@ jobs:
       - MULTICLUSTER
       - test.integration.pilot.kube
     requirements: [kind]
-    modifiers: [optional, hidden]
     env:
       - name: TEST_SELECT
         value: "-multicluster"


### PR DESCRIPTION
Seems to be stable. Should help us keep from adding multicluster bugs. 