### PR TITLE
Revert "make integ-pilot-multicluster-tests required (#2949)"

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -359,6 +359,7 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:
@@ -1589,7 +1590,9 @@ presubmits:
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
     name: integ-pilot-multicluster-tests_istio_priv
+    optional: true
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -367,6 +367,7 @@ postsubmits:
     decorate: true
     name: integ-pilot-multicluster-tests_istio_postsubmit
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:
@@ -1494,7 +1495,9 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-pilot-multicluster-tests_istio
+    optional: true
     path_alias: istio.io/istio
+    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -122,6 +122,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.pilot.kube
     requirements: [kind]
+    modifiers: [optional, hidden]
     env:
       - name: TEST_SELECT
         value: "-multicluster"


### PR DESCRIPTION
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/26959/integ-pilot-multicluster-tests_istio/1657
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25787/integ-pilot-multicluster-tests_istio/1673
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/26059/integ-pilot-multicluster-tests_istio/1668

There are still flakes (excluding runs that cancelled in 2-3 mins) in the sniffing tests. For the most part things are passing but needs more work. 