### PR TITLE
Re-enable TestGrid presubmit

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -1,22 +1,20 @@
 presubmits:
   istio/test-infra:
-
-  # TODO(https://github.com/istio/test-infra/issues/2708) re-enable this
-  # - name: pull-test-infra-check-testgrid-config
-  #   run_if_changed: '^(prow/cluster/jobs/.*\.yaml)|(testgrid/default\.yaml)$'
-  #   decorate: true
-  #   branches:
-  #   - master
-  #   annotations:
-  #     testgrid-create-test-group: "false"
-  #   spec:
-  #     containers:
-  #     - image: gcr.io/k8s-prow/transfigure
-  #       command:
-  #       - /transfigure.sh
-  #       args:
-  #       - test
-  #       - prow/config.yaml
-  #       - prow/cluster/jobs
-  #       - testgrid/default.yaml
-  #       - istio
+  - name: pull-test-infra-check-testgrid-config
+    run_if_changed: '^(prow/cluster/jobs/.*\.yaml)|(testgrid/default\.yaml)$'
+    decorate: true
+    branches:
+    - master
+    annotations:
+      testgrid-create-test-group: "false"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/transfigure
+        command:
+        - /transfigure.sh
+        args:
+        - test
+        - prow/config.yaml
+        - prow/cluster/jobs
+        - testgrid/default.yaml
+        - istio

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -9,7 +9,7 @@ postsubmits:
     - master
     annotations:
       testgrid-dashboards: istio_test-infra_postsubmit
-      testgrid-alert-email: slchase@google.com
+      testgrid-alert-email: k8s-infra-oncall@google.com
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure

--- a/testgrid/default.yaml
+++ b/testgrid/default.yaml
@@ -14,6 +14,7 @@ dashboards:
 - name: istio_community
 - name: istio_community_postsubmit
 - name: istio_envoy
+- name: istio_envoy_periodic
 - name: istio_gogo-genproto
 - name: istio_gogo-genproto_postsubmit
 - name: istio_infrastructure
@@ -218,6 +219,7 @@ dashboard_groups:
   - istio_common-files
   - istio_community
   - istio_envoy
+  - istio_envoy_periodic
   - istio_gogo-genproto
   - istio_infrastructure
   - istio_istio.io


### PR DESCRIPTION
Changes alert email to group for next postsubmit issue
Adds required dashboard to pass presubmit

Addresses https://github.com/istio/test-infra/issues/2957