### PR TITLE
dedicate node for pilot-mc job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -377,8 +377,8 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1610,8 +1610,8 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -385,8 +385,8 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1515,8 +1515,8 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -115,6 +115,7 @@ jobs:
         value: "-multicluster"
 
   - name: integ-pilot-multicluster-tests
+    resources: benchmark
     command:
       - entrypoint
       - prow/integ-suite-kind.sh


### PR DESCRIPTION
We can probably tune this so it takes up "half" a node. Just want to see if this makes the tests stable. 

---

I think we're hitting fd limits on our prow nodes.. I spot checked one of the ubuntu test pool nodes and they have ubuntu's default of just over 1 million as the hard limit for a single user. 

On my personal machine (8 CPU, 32GB ram), running Ubuntu with nothing else, I ran this job like we would in prow, using 5 kind clusters and consistently saw over 400k file descriptors being used via `lsof`. 5+ runs with no failures. 

![fds](https://user-images.githubusercontent.com/16195656/94872540-b8646e00-0401-11eb-9692-54a5f71c92bf.png)


I manually set the limit to 300,000 `ulimit -Hn 300000` and was able to replicate the sort of flakes seen here [integ-pilot-multicluster-tests_*](https://prow.istio.io/?job=integ-pilot-multicluster-tests_*)

```
=== RUN   TestTraffic/sniffing/grpc_naked->a_from_cluster-3
2020-10-01T23:05:18.819352Z	info	tf	=== BEGIN: Test: 'pilot[TestTraffic/sniffing/grpc_naked->a_from_cluster-3]' ===
    traffic.go:75: call for grpc naked->a from cluster-3/0 failed, retrying: failed calling naked->'grpc://a.echo-1-85969.svc.cluster.local:7070/': rpc error: code = Unknown desc = 5/25 requests had errors; first error: rpc error: code = DeadlineExceeded desc = context deadline exceeded
    traffic.go:75: call for grpc naked->a from cluster-3/0 failed, retrying: failed calling naked->'grpc://a.echo-1-85969.svc.cluster.local:7070/': rpc error: code = Unknown desc = 5/25 requests had errors; first error: rpc error: code = Unavailable desc = upstream connect error or disconnect/reset before headers. reset reason: local reset
    traffic.go:72: retry.UntilSuccessOrFail: timeout while waiting (last error: failed calling naked->'grpc://a.echo-1-85969.svc.cluster.local:7070/': rpc error: code = Unknown desc = 5/25 requests had errors; first error: rpc error: code = Unavailable desc = upstream connect error or disconnect/reset before headers. reset reason: local reset)
2020-10-01T23:05:28.942708Z	info	tf	=== DONE (failed):  Test: 'pilot[TestTraffic/sniffing/grpc_naked->a_from_cluster-3] (10.123348298s)' ===
```



