### PR TITLE
Add istio-boskos-perf-06 back after the project migration

### DIFF
--- a/boskos/resources.yaml
+++ b/boskos/resources.yaml
@@ -48,6 +48,7 @@ resources:
   - istio-boskos-perf-01
   - istio-boskos-perf-02
   - istio-boskos-perf-05
+  - istio-boskos-perf-06
 - type: gcp-project
   state: dirty
   names:


### PR DESCRIPTION
istio-boskos-perf-06 project migration is done, I'm not sure how could i verify the clusters can be successfully created on that migrated project manually..