### PR TITLE
Uniformly apply 4 hours timeout to proxy jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -193,6 +193,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
     name: test_proxy_master_priv
@@ -238,6 +240,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
     name: test-asan_proxy_master_priv
@@ -283,6 +287,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_master_priv
@@ -328,6 +334,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
@@ -374,6 +382,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
@@ -421,6 +431,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/proxy.git
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_master_priv

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -147,6 +147,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     name: test_proxy
     path_alias: istio.io/proxy
     spec:
@@ -181,6 +183,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     name: test-asan_proxy
     path_alias: istio.io/proxy
     spec:
@@ -215,6 +219,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     name: test-tsan_proxy
     path_alias: istio.io/proxy
     spec:
@@ -249,6 +255,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-service-account: "true"
     name: release-test_proxy
@@ -285,6 +293,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     labels:
       preset-service-account: "true"
     name: release-centos-test_proxy
@@ -322,6 +332,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     name: check-wasm_proxy
     path_alias: istio.io/proxy
     spec:

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -9,19 +9,23 @@ jobs:
 - name: test
   type: presubmit
   command: [./prow/proxy-presubmit.sh]
+  timeout: 4h
 
 - name: test-asan
   type: presubmit
   command: [./prow/proxy-presubmit-asan.sh]
+  timeout: 4h
 
 - name: test-tsan
   type: presubmit
   command: [./prow/proxy-presubmit-tsan.sh]
+  timeout: 4h
 
 - name: release-test
   type: presubmit
   command: [./prow/proxy-presubmit-release.sh]
   requirements: [gcp]
+  timeout: 4h
 
 - name: release-centos-test
   type: presubmit
@@ -30,11 +34,13 @@ jobs:
   image: gcr.io/istio-testing/build-tools-centos:master-2020-10-02T20-42-01
   # Current optional until further testing is done to ensure stability
   modifiers: [optional]
+  timeout: 4h
 
 - name: check-wasm
   type: presubmit
   command: [entrypoint, ./prow/proxy-presubmit-wasm.sh]
   requirements: [docker]
+  timeout: 4h
 
 - name: release
   type: postsubmit


### PR DESCRIPTION
Proxy jobs, especially asan and tsan jobs, often times out. This is to uniformly increase timeout of all proxy jobs to 4 hours.