### PR TITLE
Update master to release in non-master configs

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.7.gen.yaml
@@ -102,7 +102,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.7-2020-10-12T16-50-25
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.6.gen.yaml
@@ -16,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -54,7 +54,7 @@ postsubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -90,7 +90,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ presubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -236,7 +236,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.7.gen.yaml
@@ -72,7 +72,7 @@ postsubmits:
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.7-2020-10-12T16-50-25
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
@@ -62,7 +62,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools-centos:release-1.8-2020-10-21T02-26-15
         name: ""
         resources:
           limits:
@@ -111,7 +111,7 @@ postsubmits:
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools:release-1.8-2020-10-21T02-26-15
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2020-10-26T17-20-43
+        image: gcr.io/istio-testing/build-tools-centos:release-1.8-2020-10-21T02-26-15
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/cni-1.6.yaml
+++ b/prow/config/jobs/cni-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/proxy-1.7.yaml
+++ b/prow/config/jobs/proxy-1.7.yaml
@@ -45,7 +45,7 @@ jobs:
   - --modifier=update_proxy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+  image: gcr.io/istio-testing/build-tools:release-1.7-2020-10-12T16-50-25
   name: update-istio
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/proxy-1.8.yaml
+++ b/prow/config/jobs/proxy-1.8.yaml
@@ -26,7 +26,7 @@ jobs:
   type: presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:master-2020-10-26T17-20-43
+  image: gcr.io/istio-testing/build-tools-centos:release-1.8-2020-10-21T02-26-15
   modifiers:
   - optional
   name: release-centos-test
@@ -53,7 +53,7 @@ jobs:
   type: postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:master-2020-10-26T17-20-43
+  image: gcr.io/istio-testing/build-tools-centos:release-1.8-2020-10-21T02-26-15
   name: release-centos
   requirements:
   - gcp
@@ -68,7 +68,7 @@ jobs:
   - --modifier=update_proxy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
+  image: gcr.io/istio-testing/build-tools:release-1.8-2020-10-21T02-26-15
   name: update-istio
   repos:
   - istio/test-infra@master


### PR DESCRIPTION
I noticed in #3001 that the master image was being updated in some jobs in releases. This PR is to change those files to use the specific release images instead of master.