### PR TITLE
Add release notes to api

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -199,3 +199,54 @@ presubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_api
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/tools
+      repo: tools
+    name: release-notes_api
+    optional: true
+    path_alias: istio.io/api
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/check_release_notes.sh
+        - --token-path=/etc/github-token/oauth
+        image: gcr.io/istio-testing/build-tools:master-2020-09-15T14-05-50
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: github
+        secret:
+          secretName: oauth-token

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -222,7 +222,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:master-2020-09-15T14-05-50
+        image: gcr.io/istio-testing/build-tools:master-2020-10-26T17-20-43
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -23,3 +23,12 @@ jobs:
     - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]
+
+  - name: release-notes
+    type: presubmit
+    modifiers: [optional]
+    command:
+      - ../test-infra/tools/check_release_notes.sh
+      - --token-path=/etc/github-token/oauth
+    requirements: [github]
+    repos: [istio/test-infra@master,istio/tools@master]

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -180,6 +180,7 @@ checkForLabel() {
     labels=$(echo "${ghPR}" | jq '.labels | map(.name)')
     owner=$(echo "${ghPR}" | jq -r '.user.login')
     branch=$(echo "${ghPR}" | jq -r '.head.ref')
+    repo=$(echo "${ghPR}" | jq -r '.head.repo.name')
 
     # grep returns a non-zero error code on not found. Reset -e so we don't fail silently.
     set +e
@@ -190,7 +191,7 @@ checkForLabel() {
         echo "Missing \"${RELEASE_NOTES_NONE_LABEL}\" label"
         echo
         echo "Missing release notes and missing \"${RELEASE_NOTES_NONE_LABEL}\" label."
-        echo "If this pull request contains user facing changes, please create a release note based on the template: https://github.com/istio/istio/blob/master/releasenotes/template.yaml by going here: https://github.com/${owner}/istio/new/${branch}/releasenotes/notes"
+        echo "If this pull request contains user facing changes, please create a release note based on the template: https://github.com/istio/istio/blob/master/releasenotes/template.yaml by going here: https://github.com/${owner}/${repo}/new/${branch}/releasenotes/notes"
         echo "Release notes documentation can be found here: https://github.com/istio/istio/tree/master/releasenotes"
         echo "If this pull request has no user facing changes, please add the release-notes-none label to the pull request. Note that the test will have to be manually retriggered after adding the label."
         exit 1

--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -185,6 +185,7 @@ checkForLabel() {
     labels=$(echo "${ghPR}" | jq '.labels | map(.name)')
     owner=$(echo "${ghPR}" | jq -r '.user.login')
     branch=$(echo "${ghPR}" | jq -r '.head.ref')
+    repo=$(echo "${ghPR}" | jq -r '.head.repo.name')
 
     # grep returns a non-zero error code on not found. Reset -e so we don't fail silently.
     set +e
@@ -195,7 +196,7 @@ checkForLabel() {
         echo "Missing \"${RELEASE_NOTES_NONE_LABEL}\" label"
         echo
         echo "Missing release notes and missing \"${RELEASE_NOTES_NONE_LABEL}\" label."
-        echo "If this pull request contains user facing changes, please create a release note based on the template: https://github.com/istio/istio/blob/master/releasenotes/template.yaml by going here: https://github.com/${owner}/istio/new/${branch}/releasenotes/notes"
+        echo "If this pull request contains user facing changes, please create a release note based on the template: https://github.com/istio/istio/blob/master/releasenotes/template.yaml by going here: https://github.com/${owner}/${repo}/new/${branch}/releasenotes/notes"
         echo "Release notes documentation can be found here: https://github.com/istio/istio/tree/master/releasenotes"
         echo "If this pull request has no user facing changes, please add the release-notes-none label to the pull request. Note that the test will have to be manually retriggered after adding the label."
         exit 1


### PR DESCRIPTION
This adds a test for release notes to the API repo. This also fixes an issue where it was assumed that a developer's fork of Istio is always called `istio`. 

I've tested the changes to the script locally. Creating the prow job as optional until it's tested. 

Related: https://github.com/istio/tools/pull/1274
Related: https://github.com/istio/api/pull/1716