### PR TITLE
Support generating periodic jobs for internal repos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	cloud.google.com/go/storage v1.1.2
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.4.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/kr/pretty v0.2.0

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -40,6 +40,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -86,6 +89,9 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -140,6 +146,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -203,6 +212,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -268,6 +280,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -329,6 +344,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -393,6 +411,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -459,6 +480,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -520,6 +544,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -584,6 +611,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -645,6 +675,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -703,6 +736,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -768,6 +804,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -833,6 +872,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -898,6 +940,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -963,6 +1008,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1029,6 +1077,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1082,6 +1133,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -34,6 +34,9 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -73,6 +76,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -114,6 +120,9 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -164,6 +173,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -223,6 +235,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -284,6 +299,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -341,6 +359,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -401,6 +422,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -463,6 +487,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -520,6 +547,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -580,6 +610,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -637,6 +670,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -691,6 +727,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -752,6 +791,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -813,6 +855,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -874,6 +919,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -935,6 +983,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -997,6 +1048,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1046,6 +1100,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -34,6 +34,9 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -73,6 +76,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -114,6 +120,9 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -164,6 +173,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -223,6 +235,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -284,6 +299,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -341,6 +359,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -401,6 +422,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -463,6 +487,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -520,6 +547,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -580,6 +610,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -637,6 +670,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -691,6 +727,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -752,6 +791,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -813,6 +855,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -874,6 +919,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -935,6 +983,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -997,6 +1048,9 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1046,6 +1100,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/config/testdata/simple.gen.yaml
+++ b/prow/config/testdata/simple.gen.yaml
@@ -6,6 +6,11 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   cron: 0 2 * * *
   decorate: true
+  extra_refs:
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/istio
+    repo: istio
   name: periodic-job_istio_periodic
   path_alias: istio.io/istio
   spec:

--- a/prow/genjobs/main_test.go
+++ b/prow/genjobs/main_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
 
 	"istio.io/test-infra/prow/genjobs/cmd/genjobs"
@@ -78,67 +79,54 @@ func TestGenjobs(t *testing.T) {
 		output  string
 		args    []string
 		configs bool
-		equal   bool
 	}{
 		{
-			name:  "simple transform",
-			args:  []string{"--mapping=istio=istio-private"},
-			equal: true,
+			name: "simple transform",
+			args: []string{"--mapping=istio=istio-private"},
 		},
 		{
-			name:  "branches-out",
-			args:  []string{"--mapping=istio=istio-private", "--branches-out=custom-1,^custom-2$"},
-			equal: true,
+			name: "branches-out",
+			args: []string{"--mapping=istio=istio-private", "--branches-out=custom-1,^custom-2$"},
 		},
 		{
-			name:  "refs exists",
-			args:  []string{"--mapping=istio=istio-private", "--refs"},
-			equal: true,
+			name: "refs exists",
+			args: []string{"--mapping=istio=istio-private", "--refs"},
 		},
 		{
-			name:  "refs not exists",
-			args:  []string{"--mapping=istio=istio-private", "--refs"},
-			equal: true,
+			name: "refs not exists",
+			args: []string{"--mapping=istio=istio-private", "--refs"},
 		},
 		{
-			name:  "rerun-orgs",
-			args:  []string{"--mapping=istio=istio-private", "--rerun-orgs=istio-private,istio-secret"},
-			equal: true,
+			name: "rerun-orgs",
+			args: []string{"--mapping=istio=istio-private", "--rerun-orgs=istio-private,istio-secret"},
 		},
 		{
-			name:  "rerun-users",
-			args:  []string{"--mapping=istio=istio-private", "--rerun-users=clarketm,scoobydoo"},
-			equal: true,
+			name: "rerun-users",
+			args: []string{"--mapping=istio=istio-private", "--rerun-users=clarketm,scoobydoo"},
 		},
 		{
-			name:  "override annotations",
-			args:  []string{"--mapping=istio=istio-private", "--annotations=testgrid-create-test-group=false"},
-			equal: true,
+			name: "override annotations",
+			args: []string{"--mapping=istio=istio-private", "--annotations=testgrid-create-test-group=false"},
 		},
 		{
-			name:  "sort ascending",
-			args:  []string{"--mapping=istio=istio-private", "--sort=asc"},
-			equal: true,
+			name: "sort ascending",
+			args: []string{"--mapping=istio=istio-private", "--sort=asc"},
 		},
 		{
-			name:  "sort descending",
-			args:  []string{"--mapping=istio=istio-private", "--sort=desc"},
-			equal: true,
+			name: "sort descending",
+			args: []string{"--mapping=istio=istio-private", "--sort=desc"},
 		},
 		{
-			name:  "env denylist",
-			args:  []string{"--mapping=istio=istio-private", "--env-denylist=bad-env"},
-			equal: true,
+			name: "env denylist",
+			args: []string{"--mapping=istio=istio-private", "--env-denylist=bad-env"},
 		},
 		{
-			name:  "volume denylist",
-			args:  []string{"--mapping=istio=istio-private", "--volume-denylist=bad-volume"},
-			equal: true,
+			name: "volume denylist",
+			args: []string{"--mapping=istio=istio-private", "--volume-denylist=bad-volume"},
 		},
 		{
 			name:    "config file",
 			configs: true,
-			equal:   true,
 		},
 	}
 
@@ -178,9 +166,6 @@ func TestGenjobs(t *testing.T) {
 				t.Fatalf("failed reading actual output file %v: %v", outA, err)
 			}
 
-			t.Logf("expected (%v):\n%s\n", test.name, expected)
-			t.Logf("actual (%v):\n%s\n", test.name, actual)
-
 			if os.Getenv("REFRESH_GOLDEN") == "true" {
 				if err = ioutil.WriteFile(outE, actual, 0644); err != nil {
 					t.Fatalf("failed writing expected output file %v: %v", outE, err)
@@ -188,9 +173,8 @@ func TestGenjobs(t *testing.T) {
 				expected = actual
 			}
 
-			equal := bytes.Equal(expected, actual)
-			if equal != test.equal {
-				t.Fatalf("expected output to be: %t", test.equal)
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Error("TestGenjobs (-want, +got):", diff)
 			}
 		})
 	}

--- a/prow/genjobs/pkg/util/strings_test.go
+++ b/prow/genjobs/pkg/util/strings_test.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNormalizeHost(t *testing.T) {
@@ -93,8 +95,8 @@ func TestNormalizeHost(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := NormalizeOrg(test.input, test.sep)
 
-			if actual != test.expected {
-				t.Errorf("Actual: %v ; Expected: %v", actual, test.expected)
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
+				t.Error("TestNormalizeHost (-want, +got):", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Update the `genjobs` tool to be able to generate periodic jobs for internal repos.

Plus some bug fixes and improvements.