### PR TITLE
Manual update of build-tools:release-1.6

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -90,7 +90,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -147,7 +147,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -184,7 +184,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -223,7 +223,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.6.gen.yaml
@@ -25,7 +25,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -74,7 +74,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -182,7 +182,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -292,7 +292,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -354,7 +354,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -416,7 +416,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -478,7 +478,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -608,7 +608,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -676,7 +676,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -742,7 +742,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -809,7 +809,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -875,7 +875,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -917,7 +917,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -966,7 +966,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1029,7 +1029,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1092,7 +1092,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1155,7 +1155,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1218,7 +1218,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1283,7 +1283,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1348,7 +1348,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1411,7 +1411,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1476,7 +1476,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1539,7 +1539,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1584,7 +1584,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1625,7 +1625,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.6.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -84,7 +84,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -174,7 +174,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -220,7 +220,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -266,7 +266,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -134,7 +134,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -177,7 +177,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -214,7 +214,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -251,7 +251,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -177,7 +177,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cni/istio.cni.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/cni/istio.cni.release-1.6.gen.yaml
@@ -16,7 +16,7 @@ postsubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -54,7 +54,7 @@ postsubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -90,7 +90,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ presubmits:
         - entrypoint
         - make
         - docker
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ presubmits:
         - make
         - docker
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -236,7 +236,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -90,7 +90,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.postsubmit
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.kube.presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.6.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -57,7 +57,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -102,7 +102,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -259,7 +259,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -316,7 +316,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -430,7 +430,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -487,7 +487,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -550,7 +550,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -613,7 +613,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -674,7 +674,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -736,7 +736,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -795,7 +795,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -831,7 +831,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -873,7 +873,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -929,7 +929,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -985,7 +985,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1041,7 +1041,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1097,7 +1097,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1155,7 +1155,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1213,7 +1213,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1269,7 +1269,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1327,7 +1327,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1383,7 +1383,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1421,7 +1421,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -1455,7 +1455,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.6.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -59,7 +59,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -93,7 +93,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -127,7 +127,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -253,7 +253,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -361,7 +361,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -401,7 +401,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.6.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -274,7 +274,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -309,7 +309,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+        image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.6.yaml
+++ b/prow/config/jobs/api-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.6.yaml
+++ b/prow/config/jobs/client-go-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/cni-1.6.yaml
+++ b/prow/config/jobs/cni-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-10-01T21-30-44
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/common-files-1.6.yaml
+++ b/prow/config/jobs/common-files-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/gogo-genproto-1.6.yaml
+++ b/prow/config/jobs/gogo-genproto-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.6.yaml
+++ b/prow/config/jobs/istio-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.6.yaml
+++ b/prow/config/jobs/istio.io-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.6.yaml
+++ b/prow/config/jobs/pkg-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.6.yaml
+++ b/prow/config/jobs/proxy-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools-proxy:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh

--- a/prow/config/jobs/release-builder-1.6.yaml
+++ b/prow/config/jobs/release-builder-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.6.yaml
+++ b/prow/config/jobs/tools-1.6.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.6
-image: gcr.io/istio-testing/build-tools:release-1.6-2020-05-08T22-06-04
+image: gcr.io/istio-testing/build-tools:release-1.6-2020-11-13T15-30-50
 jobs:
 - command:
   - make


### PR DESCRIPTION
The automated job #3058 contains a lot of license/... file changes which cause the PR tests to fail. This PR is just the prow/... changes from that PR.

I believe this should be merged and that PR closed.