### PR TITLE
always run security and telemetry mc jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -112,7 +112,6 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-mc-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -576,7 +575,6 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1482,7 +1480,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -1497,7 +1495,6 @@ presubmits:
     name: integ-telemetry-mc-k8s-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1957,7 +1954,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -1972,7 +1969,6 @@ presubmits:
     name: integ-security-multicluster-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -139,7 +139,6 @@ postsubmits:
     decorate: true
     name: integ-telemetry-mc-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -575,7 +574,6 @@ postsubmits:
     decorate: true
     name: integ-security-multicluster-tests_istio_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1414,7 +1412,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:
@@ -1423,7 +1421,6 @@ presubmits:
     name: integ-telemetry-mc-k8s-tests_istio
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1847,7 +1844,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:
@@ -1856,7 +1853,6 @@ presubmits:
     name: integ-security-multicluster-tests_istio
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -139,7 +139,6 @@ postsubmits:
     decorate: true
     name: integ-telemetry-mc-k8s-tests_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -576,7 +575,6 @@ postsubmits:
     decorate: true
     name: integ-security-multicluster-tests_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1415,7 +1413,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.8_istio
     branches:
@@ -1424,7 +1422,6 @@ presubmits:
     name: integ-telemetry-mc-k8s-tests_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1850,7 +1847,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.8_istio
     branches:
@@ -1859,7 +1856,6 @@ presubmits:
     name: integ-security-multicluster-tests_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio-1.8.yaml
+++ b/prow/config/jobs/istio-1.8.yaml
@@ -90,9 +90,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - skipped
   - optional
-  - hidden
   name: integ-telemetry-mc-k8s-tests
   requirements:
   - kind
@@ -210,9 +208,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - skipped
   - optional
-  - hidden
   name: integ-security-multicluster-tests
   requirements:
   - kind

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -60,7 +60,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.telemetry.kube
     requirements: [kind]
-    modifiers: [skipped, optional, hidden]
+    modifiers: [optional]
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -156,7 +156,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.security.kube
     requirements: [kind]
-    modifiers: [skipped, optional, hidden]
+    modifiers: [optional]
     env:
       - name: TEST_SELECT
         value: "-multicluster"


### PR DESCRIPTION
this should increase visibility of multicluster failures in these jobs and allow us to see if there are flakes prior to marking them required