### PR TITLE
Remove repos with only `main` from release branch common-file updates

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -49,6 +49,60 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
+    name: update-common-mainonly_common-files_postsubmit
+    path_alias: istio.io/common-files
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=test-infra,bots,cri
+        - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --labels=auto-merge,release-notes-none
+        - --strict
+        - --modifier=commonfiles
+        - --token-path=/etc/github-token/oauth
+        - --cmd=make update-common gen
+        image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: github
+        secret:
+          secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_common-files_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
     name: update-common_common-files_postsubmit
     path_alias: istio.io/common-files
     spec:
@@ -56,7 +110,61 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cri,client-go,gogo-genproto,proxy
+        - --repo=istio,api,tools,release-builder,pkg,client-go,gogo-genproto,proxy
+        - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --labels=auto-merge,release-notes-none
+        - --strict
+        - --modifier=commonfiles
+        - --token-path=/etc/github-token/oauth
+        - --cmd=make update-common gen
+        image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: github
+        secret:
+          secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_common-files_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    name: update-common-istio.io_common-files_postsubmit
+    path_alias: istio.io/common-files
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=istio.io
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
         - --strict

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.6.gen.yaml
@@ -56,7 +56,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
+        - --repo=istio,istio.io,api,tools,release-builder,pkg,cni,client-go,gogo-genproto,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge
         - --strict

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.7.gen.yaml
@@ -56,7 +56,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cri,client-go,gogo-genproto,proxy
+        - --repo=istio,istio.io,api,tools,release-builder,pkg,client-go,gogo-genproto,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
         - --strict

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.8.gen.yaml
@@ -56,7 +56,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cri,client-go,gogo-genproto,proxy
+        - --repo=istio,istio.io,api,tools,release-builder,pkg,client-go,gogo-genproto,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
         - --strict

--- a/prow/config/jobs/common-files-1.6.yaml
+++ b/prow/config/jobs/common-files-1.6.yaml
@@ -9,7 +9,7 @@ jobs:
 - command:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
-  - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cni,cri,client-go,gogo-genproto,proxy
+  - --repo=istio,istio.io,api,tools,release-builder,pkg,cni,client-go,gogo-genproto,proxy
   - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge
   - --strict

--- a/prow/config/jobs/common-files-1.7.yaml
+++ b/prow/config/jobs/common-files-1.7.yaml
@@ -9,7 +9,7 @@ jobs:
 - command:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
-  - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cri,client-go,gogo-genproto,proxy
+  - --repo=istio,istio.io,api,tools,release-builder,pkg,client-go,gogo-genproto,proxy
   - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
   - --strict

--- a/prow/config/jobs/common-files-1.8.yaml
+++ b/prow/config/jobs/common-files-1.8.yaml
@@ -9,7 +9,7 @@ jobs:
 - command:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
-  - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cri,client-go,gogo-genproto,proxy
+  - --repo=istio,istio.io,api,tools,release-builder,pkg,client-go,gogo-genproto,proxy
   - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
   - --strict

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -7,12 +7,43 @@ jobs:
   - name: lint
     command: [make, lint]
 
+  - name: update-common-mainonly
+    type: postsubmit
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=test-infra,bots,cri
+    - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --labels=auto-merge,release-notes-none
+    - --strict
+    - --modifier=commonfiles
+    - --token-path=/etc/github-token/oauth
+    - --cmd=make update-common gen
+    requirements: [github]
+    repos: [istio/test-infra@master]
+    disable_release_branching: true
+
   - name: update-common
     type: postsubmit
     command:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
-    - --repo=istio,istio.io,api,test-infra,tools,bots,release-builder,pkg,cri,client-go,gogo-genproto,proxy
+    - --repo=istio,api,tools,release-builder,pkg,client-go,gogo-genproto,proxy
+    - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --labels=auto-merge,release-notes-none
+    - --strict
+    - --modifier=commonfiles
+    - --token-path=/etc/github-token/oauth
+    - --cmd=make update-common gen
+    requirements: [github]
+    repos: [istio/test-infra@master]
+
+  - name: update-common-istio.io
+    type: postsubmit
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=istio.io
     - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
     - --strict


### PR DESCRIPTION
Looking at all the jobs in: 

https://prow.istio.io/job-history/gs/istio-prow/logs/update-common_common-files_release-1.x_postsubmit,

they ALL show failed. The jobs in 

https://prow.istio.io/job-history/gs/istio-prow/logs/update-common_common-files_postsubmit

for the most part are successful.

I believe the problem is the fatal error in the logs like:
```
Cloning into 'src/istio.io/test-infra'...
warning: Could not find remote branch release-1.6 to clone.
fatal: Remote branch release-1.6 not found in upstream origin
```
caused by trying to checkout the non-existent branches in those repos that only have a `master/main` (test-infra, bots, cri)

This PR removes those repos from the automated job.