### PR TITLE
Fix proxy automator job and configgen improvement

### DIFF
--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -10,11 +10,14 @@ periodics:
   extra_refs:
   - base_ref: master
     org: istio
+    path_alias: istio.io/envoy
+    repo: envoy
+  - base_ref: master
+    org: istio
     path_alias: istio.io/test-infra
     repo: test-infra
   interval: 168h
   name: update-proxy_envoy_periodic
-  path_alias: istio.io/envoy
   spec:
     containers:
     - command:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -12,7 +12,6 @@ periodics:
     path_alias: istio.io/test-infra
     repo: test-infra
   name: update-ref-docs_istio.io_periodic
-  path_alias: istio.io/istio.io
   spec:
     containers:
     - command:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -12,7 +12,6 @@ periodics:
     path_alias: istio.io/test-infra
     repo: test-infra
   name: bump-k8s-prow-images_test-infra_periodic
-  path_alias: istio.io/test-infra
   spec:
     containers:
     - command:

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -554,11 +554,13 @@ func createJobBase(jobConfig JobConfig, job Job, name string, repo string, branc
 		},
 		UtilityConfig: config.UtilityConfig{
 			Decorate:  &yes,
-			PathAlias: fmt.Sprintf("istio.io/%s", repo),
 			ExtraRefs: createExtraRefs(job.Repos, branch),
 		},
 		Labels:      make(map[string]string),
 		Annotations: make(map[string]string),
+	}
+	if job.Type != TypePeriodic {
+		jb.UtilityConfig.PathAlias = fmt.Sprintf("istio.io/%s", repo)
 	}
 	if jobConfig.NodeSelector != nil {
 		jb.Spec.NodeSelector = jobConfig.NodeSelector

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -47,7 +47,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=scripts/update_envoy.sh $AUTOMATOR_SHA $AUTOMATOR_SHA_COMMIT_DATE
   requirements: [github]
-  repos: [istio/test-infra@master]
+  repos: [istio/envoy@master, istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
   timeout: 4h
 

--- a/prow/config/testdata/simple.gen.yaml
+++ b/prow/config/testdata/simple.gen.yaml
@@ -12,7 +12,6 @@ periodics:
     path_alias: istio.io/istio
     repo: istio
   name: periodic-job_istio_periodic
-  path_alias: istio.io/istio
   spec:
     containers:
     - command:

--- a/prow/genjobs/testdata/env_denylist/env_denylist_in.yaml
+++ b/prow/genjobs/testdata/env_denylist/env_denylist_in.yaml
@@ -72,7 +72,6 @@ periodics:
     description: Information that isn't needed
     testgrid-dashboards: public-dash
   decorate: true
-  path_alias: istio.io/istio
   extra_refs:
   - base_ref: master
     org: istio

--- a/prow/genjobs/testdata/env_denylist/env_denylist_out.yaml
+++ b/prow/genjobs/testdata/env_denylist/env_denylist_out.yaml
@@ -8,7 +8,6 @@ periodics:
     path_alias: istio.io/test-infra
     repo: test-infra
   name: example_periodic_private
-  path_alias: istio.io/istio
   spec:
     containers:
     - command:

--- a/prow/genjobs/testdata/volume_denylist/volume_denylist_in.yaml
+++ b/prow/genjobs/testdata/volume_denylist/volume_denylist_in.yaml
@@ -82,7 +82,6 @@ periodics:
     description: Information that isn't needed
     testgrid-dashboards: public-dash
   decorate: true
-  path_alias: istio.io/istio
   extra_refs:
   - base_ref: master
     org: istio

--- a/prow/genjobs/testdata/volume_denylist/volume_denylist_out.yaml
+++ b/prow/genjobs/testdata/volume_denylist/volume_denylist_out.yaml
@@ -8,7 +8,6 @@ periodics:
     path_alias: istio.io/test-infra
     repo: test-infra
   name: example_periodic_private
-  path_alias: istio.io/istio
   spec:
     containers:
     - command:


### PR DESCRIPTION
1. Fixes https://github.com/istio/istio/issues/28876
2. `path_alias` for periodic jobs does not have any meaning, since periodic Prow jobs do not necessarily need a repo, and the `path_alias` is already specified in `extra_refs`, so removing it from the job generator tool to avoid confusion.

/cc @howardjohn @carolynhu 