### PR TITLE
Unhide 1.20 test, remove dead tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -440,75 +440,6 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.4-istio
       preset-override-envoy: "true"
-    name: integ-external-istiod-mc-tests_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
-        - test.integration.multicluster.kube.presubmit
-        - --topology-config
-        - ${ROOT}/prow/config/topology/externalistiod.json
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,+externalistiod
-        image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-ssh: "true"
-      preset-override-deps: release-1.4-istio
-      preset-override-envoy: "true"
     name: integ-security-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1042,7 +973,6 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-k8s-120_istio_postsubmit_priv
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1795,77 +1725,6 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-ssh: "true"
-      preset-override-deps: release-1.4-istio
-      preset-override-envoy: "true"
-    name: integ-external-istiod-mc-tests_istio_priv
-    optional: true
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
-        - test.integration.multicluster.kube.presubmit
-        - --topology-config
-        - ${ROOT}/prow/config/topology/externalistiod.json
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,+externalistiod
         image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -447,71 +447,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-external-istiod-mc-tests_istio_postsubmit
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
-        - test.integration.multicluster.kube.presubmit
-        - --topology-config
-        - ${ROOT}/prow/config/topology/externalistiod.json
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,+externalistiod
-        image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_istio_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: integ-security-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -1013,7 +948,6 @@ postsubmits:
       timeout: 4h0m0s
     name: integ-k8s-120_istio_postsubmit
     path_alias: istio.io/istio
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1695,71 +1629,6 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_istio
-    branches:
-    - ^master$
-    decorate: true
-    name: integ-external-istiod-mc-tests_istio
-    optional: true
-    path_alias: istio.io/istio
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - --topology
-        - MULTICLUSTER
-        - test.integration.multicluster.kube.presubmit
-        - --topology-config
-        - ${ROOT}/prow/config/topology/externalistiod.json
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky,+externalistiod
         image: gcr.io/istio-testing/build-tools:master-2020-11-12T22-29-05
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -125,20 +125,6 @@ jobs:
     env:
       - name: TEST_SELECT
         value: "-multicluster"
-  - name: integ-external-istiod-mc-tests
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --topology
-      - MULTICLUSTER
-      - test.integration.multicluster.kube.presubmit
-      - --topology-config
-      - ${ROOT}/prow/config/topology/externalistiod.json
-    requirements: [kind]
-    modifiers: [optional, hidden]
-    env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky,+externalistiod"
 
   - name: integ-security-k8s-tests
     type: postsubmit
@@ -243,7 +229,6 @@ jobs:
       - gcr.io/istio-testing/kind-node:v1.20.0-rc.0
       - test.integration.kube.presubmit
     requirements: [kind]
-    modifiers: [hidden] # Until this is verified to be stable
     timeout: 4h
     env:
       - name: INTEGRATION_TEST_FLAGS


### PR DESCRIPTION
* Unhide 1.20 test, it is passing and since its an RC its unlikely to
break on future updates
* Remove external-istiod test, this is completely broken and immediately
fails wasting resources