### PR TITLE
Allow env vars to be defined incrementally for config generator tool

### DIFF
--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -512,6 +512,8 @@ func createContainer(jobConfig JobConfig, job Job, resources map[string]v1.Resou
 	envs := job.Env
 	if len(envs) == 0 {
 		envs = jobConfig.Env
+	} else {
+		envs = append(envs, jobConfig.Env...)
 	}
 
 	c := v1.Container{


### PR DESCRIPTION
Currently if env vars are defined in both file-level and job-level, the generate Prow job config will only has the env vars defined in the job-level. This change will allow env vars to be defined incrementally in both levels.