### PR TITLE
Bump upgrade periodic jobs to version 1.9

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -208,9 +208,9 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-# upgrade test using istioctl from 1.7 latest to 1.8 latest
+# upgrade test using istioctl from 1.8 latest to 1.9 latest
 - cron: "0 4 * * *"  # starts every day at 04:00AM UTC
-  name: istio-upgrade-using-istioctl-1.7_latest-1.8_latest
+  name: istio-upgrade-using-istioctl-1.8_latest-1.9_latest
   branches: master
   decorate: true
   extra_refs:
@@ -229,9 +229,9 @@ periodics:
     - <<: *istio_container_with_kind
       env:
       - name: SOURCE_TAG
-        value: 1.7_latest
-      - name: TARGET_TAG
         value: 1.8_latest
+      - name: TARGET_TAG
+        value: 1.9_latest
       - name: INSTALL_OPTIONS
         value: istioctl
       - name: TEST_SCENARIO
@@ -242,10 +242,10 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-# upgrade test using istioctl from 1.7 latest to 1.8 latest
+# upgrade test using istioctl from 1.8 latest to 1.9 latest
 # with dual control plane and deployment-by-deployment
 - cron: "0 4 * * *"  # starts every day at 04:00AM UTC
-  name: istio-dual-control-plane-upgrade-1.7-1.8
+  name: istio-dual-control-plane-upgrade-1.8-1.9
   branches: master
   decorate: true
   extra_refs:
@@ -264,9 +264,9 @@ periodics:
     - <<: *istio_container_with_kind
       env:
       - name: SOURCE_TAG
-        value: 1.7_latest
-      - name: TARGET_TAG
         value: 1.8_latest
+      - name: TARGET_TAG
+        value: 1.9_latest
       - name: INSTALL_OPTIONS
         value: istioctl
       - name: TEST_SCENARIO
@@ -277,10 +277,10 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-# kind-enabled upgrade test using istioctl from 1.7 latest to 1.8 latest
+# kind-enabled upgrade test using istioctl from 1.8 latest to 1.9 latest
 # with dual control plane and deployment-by-deployment
 - cron: "0 4 * * *"  # starts every day at 04:00AM UTC
-  name: istio-dual-control-plane-upgrade-kind-1.7-1.8
+  name: istio-dual-control-plane-upgrade-kind-1.8-1.9
   branches: master
   decorate: true
   extra_refs:
@@ -299,9 +299,9 @@ periodics:
     - <<: *istio_container_with_kind_mounts
       env:
       - name: SOURCE_TAG
-        value: 1.7_latest
-      - name: TARGET_TAG
         value: 1.8_latest
+      - name: TARGET_TAG
+        value: 1.9_latest
       - name: INSTALL_OPTIONS
         value: istioctl
       - name: TEST_SCENARIO
@@ -329,9 +329,9 @@ periodics:
     - emptyDir: {}
       name: docker-root
 
-# downgrade test using istioctl from 1.8 latest to 1.7 latest
+# downgrade test using istioctl from 1.9 latest to 1.8 latest
 - cron: "0 4 * * *"  # starts every day at 04:00AM UTC
-  name: istio-downgrade-using-istioctl-1.8_latest-1.7_latest
+  name: istio-downgrade-using-istioctl-1.9_latest-1.8_latest
   branches: master
   decorate: true
   extra_refs:
@@ -350,9 +350,9 @@ periodics:
     - <<: *istio_container_with_kind
       env:
       - name: SOURCE_TAG
-        value: 1.8_latest
+        value: 1.9_latest
       - name: TARGET_TAG
-        value: 1.7_latest
+        value: 1.8_latest
       - name: INSTALL_OPTIONS
         value: istioctl
       - name: TEST_SCENARIO
@@ -364,9 +364,9 @@ periodics:
       testing: test-pool
 
 # dual control plane rollback (canary upgrade rolled back) test
-# Canary upgrade to 1.8 rolled back to 1.7
+# Canary upgrade to 1.9 rolled back to 1.8
 - cron: "0 4 * * *"  # starts every day at 04:00AM UTC
-  name: istio-dual-control-plane-rollback-1.8-1.7
+  name: istio-dual-control-plane-rollback-1.9-1.8
   branches: master
   decorate: true
   extra_refs:
@@ -385,9 +385,9 @@ periodics:
     - <<: *istio_container_with_kind
       env:
       - name: SOURCE_TAG
-        value: 1.7_latest
-      - name: TARGET_TAG
         value: 1.8_latest
+      - name: TARGET_TAG
+        value: 1.9_latest
       - name: INSTALL_OPTIONS
         value: istioctl
       - name: TEST_SCENARIO
@@ -398,9 +398,9 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-# upgrade test using istioctl from 1.8 latest to master
+# upgrade test using istioctl from 1.9 latest to master
 - cron: "0 8 * * *"  # starts every day at 08:00AM UTC
-  name: istio-upgrade-using-istioctl-1.8_latest-master
+  name: istio-upgrade-using-istioctl-1.9_latest-master
   branches: master
   decorate: true
   extra_refs:
@@ -419,7 +419,7 @@ periodics:
       - <<: *istio_container_with_kind
         env:
           - name: SOURCE_TAG
-            value: 1.8_latest
+            value: 1.9_latest
           - name: TARGET_TAG
             value: master
           - name: INSTALL_OPTIONS
@@ -432,10 +432,10 @@ periodics:
     nodeSelector:
       testing: test-pool
 
-# upgrade test using istioctl from 1.8 latest to master
+# upgrade test using istioctl from 1.9 latest to master
 # with dual control plane method
 - cron: "0 8 * * *"  # starts every day at 08:00AM UTC
-  name: istio-dual-control-plane-upgrade-1.8-master
+  name: istio-dual-control-plane-upgrade-1.9-master
   branches: master
   decorate: true
   extra_refs:
@@ -454,7 +454,7 @@ periodics:
       - <<: *istio_container_with_kind
         env:
           - name: SOURCE_TAG
-            value: 1.8_latest
+            value: 1.9_latest
           - name: TARGET_TAG
             value: master
           - name: INSTALL_OPTIONS
@@ -468,9 +468,9 @@ periodics:
       testing: test-pool
 
 
-# downgrade test using istioctl from master to 1.8 latest
+# downgrade test using istioctl from master to 1.9 latest
 - cron: "0 8 * * *"  # starts every day at 08:00AM UTC
-  name: istio-downgrade-using-istioctl-master-1.8_latest
+  name: istio-downgrade-using-istioctl-master-1.9_latest
   branches: master
   decorate: true
   extra_refs:
@@ -491,7 +491,7 @@ periodics:
       - name: SOURCE_TAG
         value: master
       - name: TARGET_TAG
-        value: 1.8_latest
+        value: 1.9_latest
       - name: INSTALL_OPTIONS
         value: istioctl
       - name: TEST_SCENARIO
@@ -504,7 +504,7 @@ periodics:
 
 # dual control plane rollback test using istioctl from master to 1.8 latest
 - cron: "0 8 * * *"  # starts every day at 08:00AM UTC
-  name: istio-dual-control-plane-rollback-master-1.8
+  name: istio-dual-control-plane-rollback-master-1.9
   branches: master
   decorate: true
   extra_refs:
@@ -523,7 +523,7 @@ periodics:
     - <<: *istio_container_with_kind
       env:
       - name: SOURCE_TAG
-        value: 1.8_latest
+        value: 1.9_latest
       - name: TARGET_TAG
         value: master
       - name: INSTALL_OPTIONS
@@ -537,7 +537,7 @@ periodics:
       testing: test-pool
 
 - cron: "0 10 * * *"  # starts every day at 10:00AM UTC
-  name: istio-boutique-upgrade-master-1.8
+  name: istio-boutique-upgrade-master-1.9
   branches: master
   decorate: true
   extra_refs:
@@ -556,7 +556,7 @@ periodics:
       - <<: *istio_container_with_kind
         env:
           - name: SOURCE_TAG
-            value: 1.8_latest
+            value: 1.9_latest
           - name: TARGET_TAG
             value: master
           - name: TEST_SCENARIO
@@ -568,7 +568,7 @@ periodics:
       testing: test-pool
 
 - cron: "0 10 * * *"  # starts every day at 10:00AM UTC
-  name: istio-boutique-rollback-master-1.8
+  name: istio-boutique-rollback-master-1.9
   branches: master
   decorate: true
   extra_refs:
@@ -587,7 +587,7 @@ periodics:
       - <<: *istio_container_with_kind
         env:
           - name: SOURCE_TAG
-            value: 1.8_latest
+            value: 1.9_latest
           - name: TARGET_TAG
             value: master
           - name: TEST_SCENARIO


### PR DESCRIPTION
As we already fixed the upgrade jobs failures for 1.7 to 1.8. This PR is for bump its version to 1.9 once we cut branch release-1.9 in master.