### PR TITLE
bump autobumper to working image

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -76,7 +76,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210111-f6f01a1373
+    - image: gcr.io/k8s-prow/autobump:v20210114-dfe4a7d4c0
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
autobumper.sh was broken and will not be able to bump itself out of being broken, so I am manually bumping the autobumper to the current k8s/test-infra image that has the fix.