### PR TITLE
Add a flag to genjobs to allow disabling the limit set on the job name length

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -16,3 +16,4 @@ presubmits:
       - --strict
       - --exclude-warning=mismatched-tide
       - --exclude-warning=non-decorated-jobs
+      - --exclude-warning=long-job-names

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.5.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.5.gen.yaml
@@ -450,7 +450,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.5-istio
       preset-override-envoy: "true"
-    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.5_posts_priv
+    name: e2e-bookInfoTests-envoyv2-v1alpha3_istio_release-1.5_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
@@ -466,7 +466,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.7_postsubmi_priv
+    name: integ-pilot-multicluster-tests_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     skip_report: true
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -427,7 +427,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.8_postsubmi_priv
+    name: integ-pilot-multicluster-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -494,7 +494,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmi_priv
+    name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     skip_report: true
     spec:
@@ -629,7 +629,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.8_postsu_priv
+    name: integ-security-multicluster-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -427,7 +427,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.9_postsubmi_priv
+    name: integ-pilot-multicluster-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -559,7 +559,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.9_postsu_priv
+    name: integ-security-multicluster-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/istio-private_jobs/.defaults.yaml
+++ b/prow/config/istio-private_jobs/.defaults.yaml
@@ -10,3 +10,4 @@ defaults:
   annotations:
     testgrid-create-test-group: "false"
   volume-denylist: [build-cache-pvc]
+  allow-long-job-names: true


### PR DESCRIPTION
It doesn't really matter if the job name has more than 63 characters AFAICT, and truncating the job name sometimes makes it harder to parse, so I think it's better to remove this logic from the `genjobs` tool.