### PR TITLE
Restore istio.io doc tests for postsubmit

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -73,6 +73,228 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.io.git
+    cluster: private
+    decorate: true
+    name: doc.test.profile_default_istio.io_postsubmit_priv
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile_default
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.io.git
+    cluster: private
+    decorate: true
+    name: doc.test.profile_demo_istio.io_postsubmit_priv
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile_demo
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.io.git
+    cluster: private
+    decorate: true
+    name: doc.test.profile_none_istio.io_postsubmit_priv
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile_none
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.io.git
+    cluster: private
+    decorate: true
+    name: doc.test.multicluster_istio.io_postsubmit_priv
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - doc.test.multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio-private/istio.io:
   - always_run: true

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -140,7 +140,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:
@@ -307,7 +307,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -125,6 +125,228 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio.io_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: doc.test.profile_default_istio.io_postsubmit
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile_default
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio.io_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: doc.test.profile_demo_istio.io_postsubmit
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile_demo
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio.io_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: doc.test.profile_none_istio.io_postsubmit
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile_none
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio.io_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: doc.test.multicluster_istio.io_postsubmit
+    path_alias: istio.io/istio.io
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - doc.test.multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-01-14T20-42-32
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
 presubmits:
   istio/istio.io:
   - always_run: true

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -140,7 +140,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:
@@ -307,7 +307,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-01-19T23-29-57
+        image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -11,19 +11,16 @@ jobs:
     command: [make, gen-check]
 
   - name: doc.test.profile_default
-    types: [presubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_default]
     requirements: [kind]
     modifiers: [optional]
 
   - name: doc.test.profile_demo
-    types: [presubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_demo]
     requirements: [kind]
     modifiers: [optional]
 
   - name: doc.test.profile_none
-    types: [presubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_none]
     requirements: [kind]
     modifiers: [optional]

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -26,7 +26,6 @@ jobs:
     modifiers: [optional]
 
   - name: doc.test.multicluster
-    types: [presubmit]
     command:
     - entrypoint
     - prow/integ-suite-kind.sh


### PR DESCRIPTION
This PR reverts the earlier #3133 turning the post-submit istio.io doc tests back on. This will be merged once the failing tests are fixed.