### PR TITLE
Revert "Automator: update build-tools:release-1.9"

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -177,7 +177,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -222,7 +222,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -175,7 +175,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -382,7 +382,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -492,7 +492,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -549,7 +549,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -612,7 +612,7 @@ presubmits:
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -106,7 +106,7 @@ postsubmits:
         - make
         - benchtest
         - report-benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -276,7 +276,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -336,7 +336,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -398,7 +398,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -458,7 +458,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -520,7 +520,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -580,7 +580,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -637,7 +637,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -701,7 +701,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -765,7 +765,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -831,7 +831,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -895,7 +895,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -959,7 +959,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1021,7 +1021,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1060,7 +1060,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1103,7 +1103,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1144,7 +1144,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1203,7 +1203,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1262,7 +1262,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1324,7 +1324,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1385,7 +1385,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1446,7 +1446,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1509,7 +1509,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1568,7 +1568,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1629,7 +1629,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1691,7 +1691,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1747,7 +1747,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1802,7 +1802,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1839,7 +1839,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1876,7 +1876,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -1922,7 +1922,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -111,7 +111,7 @@ postsubmits:
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -155,7 +155,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -227,7 +227,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -341,7 +341,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -253,7 +253,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -361,7 +361,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -401,7 +401,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -274,7 +274,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -309,7 +309,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.9.yaml
+++ b/prow/config/jobs/api-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.9.yaml
+++ b/prow/config/jobs/client-go-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.9.yaml
+++ b/prow/config/jobs/common-files-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/gogo-genproto-1.9.yaml
+++ b/prow/config/jobs/gogo-genproto-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.9.yaml
+++ b/prow/config/jobs/istio.io-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.9.yaml
+++ b/prow/config/jobs/pkg-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.9.yaml
+++ b/prow/config/jobs/proxy-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -30,7 +30,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-01-14T17-00-42
+  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-01-13T15-02-13
   modifiers:
   - optional
   name: release-centos-test
@@ -76,7 +76,7 @@ jobs:
   - --modifier=update_proxy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+  image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
   name: update-istio
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/release-builder-1.9.yaml
+++ b/prow/config/jobs/release-builder-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.9.yaml
+++ b/prow/config/jobs/tools-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-14T17-00-42
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-01-13T15-02-13
 jobs:
 - command:
   - make


### PR DESCRIPTION
Reverts istio/test-infra#3126

The 01-14 build image has some newer Kubernetes tools which don't have some of the flags we use. Reverting back to an older build image. A new build-image will be made pinning the tools version and when that is merged, the files will have the latest (and working) build-tools version again.