### PR TITLE
Exempt istio-release-robot from slack manual merge warnings.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -27,6 +27,7 @@ slack:
     - test-and-release
     exempt_users:
     - istio-testing
+    - istio-release-robot
 
 lgtm:
 - repos:


### PR DESCRIPTION
It looks like it is intended for this bot to to push directly to the repo so we should probably silence the slack warnings.
<img width="660" alt="Screen Shot 2021-01-25 at 1 05 28 PM" src="https://user-images.githubusercontent.com/5334145/105765973-03087980-5f0e-11eb-9117-1c7e22ae8a44.png">

/assign @howardjohn 