### PR TITLE
Allow istio/proxy tests to use RBE cache and execution.

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -197,6 +197,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -244,6 +245,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-asan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -291,6 +293,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-tsan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -435,6 +438,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: check-wasm_proxy_master_priv
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -149,6 +149,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test_proxy
     path_alias: istio.io/proxy
     spec:
@@ -185,6 +187,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test-asan_proxy
     path_alias: istio.io/proxy
     spec:
@@ -221,6 +225,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test-tsan_proxy
     path_alias: istio.io/proxy
     spec:
@@ -334,6 +340,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: check-wasm_proxy
     path_alias: istio.io/proxy
     spec:

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -9,16 +9,19 @@ jobs:
 - name: test
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
+  requirements: [gcp]
   timeout: 4h
 
 - name: test-asan
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
+  requirements: [gcp]
   timeout: 4h
 
 - name: test-tsan
   types: [presubmit]
   command: [./prow/proxy-presubmit-tsan.sh]
+  requirements: [gcp]
   timeout: 4h
 
 - name: release-test
@@ -39,7 +42,7 @@ jobs:
 - name: check-wasm
   types: [presubmit]
   command: [entrypoint, ./prow/proxy-presubmit-wasm.sh]
-  requirements: [docker]
+  requirements: [gcp, docker]
   timeout: 4h
 
 - name: release


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>