### PR TITLE
Split automated command into two make calls

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -62,7 +62,7 @@ postsubmits:
         - --strict
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
-        - --cmd=make update-common gen
+        - --cmd=make update-common && make gen
         image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
@@ -116,7 +116,7 @@ postsubmits:
         - --strict
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
-        - --cmd=make update-common gen
+        - --cmd=make update-common && make gen
         image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:
@@ -170,7 +170,7 @@ postsubmits:
         - --strict
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
-        - --cmd=make update-common gen
+        - --cmd=make update-common && make gen
         image: gcr.io/istio-testing/build-tools:master-2021-01-29T01-18-46
         name: ""
         resources:

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -18,7 +18,7 @@ jobs:
     - --strict
     - --modifier=commonfiles
     - --token-path=/etc/github-token/oauth
-    - --cmd=make update-common gen
+    - --cmd=make update-common && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
     disable_release_branching: true
@@ -34,7 +34,7 @@ jobs:
     - --strict
     - --modifier=commonfiles
     - --token-path=/etc/github-token/oauth
-    - --cmd=make update-common gen
+    - --cmd=make update-common && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
 
@@ -49,7 +49,7 @@ jobs:
     - --strict
     - --modifier=commonfiles
     - --token-path=/etc/github-token/oauth
-    - --cmd=make update-common gen
+    - --cmd=make update-common && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
 


### PR DESCRIPTION
An update in https://github.com/istio/common-files/pull/382 was propagated to the various repos via the automation script. The automated PR included changes in go.sum where the common-files update should have changed the makefile target, mod-download-go, to prevent that. Some experimentation running `make update-common gen` in a build container showed that indeed the go.sum file was changed. This did not happen when running the command from the command line. Splitting the command into two makes in the build container did not update the go.sum.

A subsequent common-files update (remove the target and make the `mod-download-go` rule do nothing will hopefully get the automated PRs corrected and merged.