### PR TITLE
Allow istio/proxy (releases) tests to use RBE cache and execution.

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
@@ -197,6 +197,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -244,6 +245,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-asan_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -291,6 +293,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-tsan_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -435,6 +438,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: check-wasm_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
@@ -197,6 +197,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -244,6 +245,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-asan_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -291,6 +293,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: test-tsan_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -435,6 +438,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+      preset-service-account: "true"
     name: check-wasm_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
@@ -149,6 +149,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -185,6 +187,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test-asan_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -221,6 +225,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test-tsan_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -334,6 +340,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: check-wasm_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
@@ -149,6 +149,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -185,6 +187,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test-asan_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -221,6 +225,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: test-tsan_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -334,6 +340,8 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    labels:
+      preset-service-account: "true"
     name: check-wasm_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:

--- a/prow/config/jobs/proxy-1.8.yaml
+++ b/prow/config/jobs/proxy-1.8.yaml
@@ -5,16 +5,22 @@ jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   name: test
+  requirements:
+  - gcp
   timeout: 4h0m0s
   types: [presubmit]
 - command:
   - ./prow/proxy-presubmit-asan.sh
   name: test-asan
+  requirements:
+  - gcp
   timeout: 4h0m0s
   types: [presubmit]
 - command:
   - ./prow/proxy-presubmit-tsan.sh
   name: test-tsan
+  requirements:
+  - gcp
   timeout: 4h0m0s
   types: [presubmit]
 - command:
@@ -39,6 +45,7 @@ jobs:
   - ./prow/proxy-presubmit-wasm.sh
   name: check-wasm
   requirements:
+  - gcp
   - docker
   timeout: 4h0m0s
   types: [presubmit]

--- a/prow/config/jobs/proxy-1.9.yaml
+++ b/prow/config/jobs/proxy-1.9.yaml
@@ -5,18 +5,24 @@ jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   name: test
+  requirements:
+  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-asan.sh
   name: test-asan
+  requirements:
+  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-tsan.sh
   name: test-tsan
+  requirements:
+  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -44,6 +50,7 @@ jobs:
   - ./prow/proxy-presubmit-wasm.sh
   name: check-wasm
   requirements:
+  - gcp
   - docker
   timeout: 4h0m0s
   types:


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>