### PR TITLE
Update `make gen` to also do go formatting (checks format on PR)

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ fmt: format-go tidy-go
 test:
 	@go test -race ./...
 
-gen: generate-config tidy-go mirror-licenses
+gen: generate-config fmt mirror-licenses
 
 gen-check: gen check-clean-repo
 

--- a/boskos/cmd/mason/main.go
+++ b/boskos/cmd/mason/main.go
@@ -17,14 +17,12 @@ package main
 import (
 	"context"
 	"flag"
-
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/boskos/client"
 	"sigs.k8s.io/boskos/crds"

--- a/boskos/gcp/config.go
+++ b/boskos/gcp/config.go
@@ -254,7 +254,6 @@ func (rc resourceConfigs) construct(ctx context.Context, res common.Resource, ty
 				})
 			}
 		}
-
 	}
 	if err := errGroup.Wait(); err != nil {
 		logrus.WithError(err).Errorf("failed to construct resources for %s", res.Name)

--- a/boskos/gcp/config_test.go
+++ b/boskos/gcp/config_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	container "google.golang.org/api/container/v1beta1"
-
 	"sigs.k8s.io/boskos/common"
 	"sigs.k8s.io/boskos/mason"
 )
@@ -178,9 +177,7 @@ func TestParseConfig(t *testing.T) {
 						t.Errorf("Needs do not match for config %s. Expected %v found %v", config.Type, config.Needs, needs)
 					}
 				}
-
 			}
-
 		}
 	}
 
@@ -255,7 +252,7 @@ func TestResourcesConfig_Construct(t *testing.T) {
 		info *ResourceInfo
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name      string
 		rc        resourceConfigs
 		res       common.Resource
@@ -336,13 +333,15 @@ func TestResourcesConfig_Construct(t *testing.T) {
 			name:      "timeout vm creation",
 			setClient: true,
 			rc: resourceConfigs{
-				"test": {{
-					Clusters: []clusterConfig{
-						{},
+				"test": {
+					{
+						Clusters: []clusterConfig{
+							{},
+						},
+						Vms: []virtualMachineConfig{
+							{},
+						},
 					},
-					Vms: []virtualMachineConfig{
-						{},
-					}},
 				},
 			},
 			res: common.Resource{
@@ -364,13 +363,15 @@ func TestResourcesConfig_Construct(t *testing.T) {
 			name:      "timeout cluster creation",
 			setClient: true,
 			rc: resourceConfigs{
-				"test": {{
-					Clusters: []clusterConfig{
-						{},
+				"test": {
+					{
+						Clusters: []clusterConfig{
+							{},
+						},
+						Vms: []virtualMachineConfig{
+							{},
+						},
 					},
-					Vms: []virtualMachineConfig{
-						{},
-					}},
 				},
 			},
 			res: common.Resource{
@@ -420,13 +421,15 @@ func TestResourcesConfig_Construct(t *testing.T) {
 			name:      "failed cluster creation",
 			setClient: true,
 			rc: resourceConfigs{
-				"test": {{
-					Clusters: []clusterConfig{
-						{},
+				"test": {
+					{
+						Clusters: []clusterConfig{
+							{},
+						},
+						Vms: []virtualMachineConfig{
+							{},
+						},
 					},
-					Vms: []virtualMachineConfig{
-						{},
-					}},
 				},
 			},
 			res: common.Resource{
@@ -448,13 +451,15 @@ func TestResourcesConfig_Construct(t *testing.T) {
 			name:      "running out project",
 			setClient: true,
 			rc: resourceConfigs{
-				"test": {{
-					Clusters: []clusterConfig{
-						{},
+				"test": {
+					{
+						Clusters: []clusterConfig{
+							{},
+						},
+						Vms: []virtualMachineConfig{
+							{},
+						},
 					},
-					Vms: []virtualMachineConfig{
-						{},
-					}},
 				},
 			},
 			res: common.Resource{
@@ -472,13 +477,15 @@ func TestResourcesConfig_Construct(t *testing.T) {
 		{
 			name: "client not set",
 			rc: resourceConfigs{
-				"test": {{
-					Clusters: []clusterConfig{
-						{},
+				"test": {
+					{
+						Clusters: []clusterConfig{
+							{},
+						},
+						Vms: []virtualMachineConfig{
+							{},
+						},
 					},
-					Vms: []virtualMachineConfig{
-						{},
-					}},
 				},
 			},
 			res: common.Resource{

--- a/boskos/gcp/gcloud.go
+++ b/boskos/gcp/gcloud.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	container "google.golang.org/api/container/v1beta1"
-
 	clientapi "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"istio.io/test-infra/toolbox/util"

--- a/boskos/gcp/gke.go
+++ b/boskos/gcp/gke.go
@@ -77,7 +77,6 @@ func (cc *containerEngine) waitForReady(ctx context.Context, cluster, project, z
 		if err := os.Remove(kubeconfigFile.Name()); err != nil {
 			logrus.WithError(err).Errorf("failed to delete file %s", kubeconfigFile.Name())
 		}
-
 	}()
 
 	if err := SetKubeConfig(project, zone, cluster, kubeconfigFile.Name()); err != nil {
@@ -92,7 +91,6 @@ func (cc *containerEngine) waitForReady(ctx context.Context, cluster, project, z
 			err := checkCluster(kubeconfigFile.Name())
 			if err != nil {
 				logrus.WithError(err).Errorf("cluster %s in zone %s for project %s is not ready", cluster, zone, project)
-
 			} else {
 				logrus.Infof("cluster %s in zone %s for project %s is ready", cluster, zone, project)
 				return nil

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -28,8 +28,10 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
-var configPath = flag.String("config", "../config.yaml", "Path to prow config")
-var jobConfigPath = flag.String("job-config", "../cluster/jobs/", "Path to prow job config")
+var (
+	configPath    = flag.String("config", "../config.yaml", "Path to prow config")
+	jobConfigPath = flag.String("job-config", "../cluster/jobs/", "Path to prow job config")
+)
 
 // Loaded at TestMain.
 var c *config.Config

--- a/prow/config/generate_test.go
+++ b/prow/config/generate_test.go
@@ -42,7 +42,7 @@ func TestGenerateConfig(t *testing.T) {
 }
 
 func TestFilterReleaseBranchingJobs(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name         string
 		jobs         []Job
 		filteredJobs []Job

--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -48,9 +48,7 @@ const (
 	yamlExt           = ".(yml|yaml)$"
 )
 
-var (
-	defaultJobTypes = []string{"presubmit", "postsubmit", "periodic"}
-)
+var defaultJobTypes = []string{"presubmit", "postsubmit", "periodic"}
 
 // sortOrder is the type to define sort order.
 type sortOrder string
@@ -185,7 +183,6 @@ func (o *options) parseConfiguration() []options {
 	}
 
 	for _, c := range o.Configs {
-
 		if err := filepath.Walk(c, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return nil
@@ -527,7 +524,6 @@ volume:
 				job.Spec.Volumes[i] = vol
 				continue volume
 			}
-
 		}
 
 		job.Spec.Volumes = append(job.Spec.Volumes, vol)
@@ -866,7 +862,6 @@ func sortJobs(o options, pre map[string][]config.Presubmit, post map[string][]co
 	sort.Slice(per, func(a, b int) bool {
 		return comparator(per[a].Name, per[b].Name)
 	})
-
 }
 
 // getOutPath derives the output path from the specified input directory and current path.

--- a/prow/rewriteConfig_test.go
+++ b/prow/rewriteConfig_test.go
@@ -91,7 +91,6 @@ repos:
 	if strings.Compare(output, string(correctOutput)) != 0 {
 		t.Fail()
 	}
-
 }
 
 func TestMasterForMasterWithConentsNoNeedsAdmin(t *testing.T) {

--- a/toolbox/githubctl/main.go
+++ b/toolbox/githubctl/main.go
@@ -64,7 +64,7 @@ func getBaseSha(repo string, prNumber int) (string, error) {
 		return "", err
 	}
 
-	var allCommitShas = make(map[string]bool)
+	allCommitShas := make(map[string]bool)
 	for _, commit := range commits {
 		allCommitShas[*commit.SHA] = true
 	}
@@ -78,7 +78,6 @@ func getBaseSha(repo string, prNumber int) (string, error) {
 		}
 	}
 	return "", errors.New("base cannot be found")
-
 }
 
 // CreateReleaseRequest triggers release pipeline by creating a PR.

--- a/toolbox/metrics/buildfreshness/buildFreshness.go
+++ b/toolbox/metrics/buildfreshness/buildFreshness.go
@@ -90,7 +90,7 @@ func GetAgeMetrics(owner, repo, branch string) ([]DepFreshness, error) {
 		return stats, err
 	}
 	var wg sync.WaitGroup
-	var mutex = &sync.Mutex{} // used to synchronize access to stats and multiErr
+	mutex := &sync.Mutex{} // used to synchronize access to stats and multiErr
 	var multiErr error
 	for _, dep := range deps {
 		wg.Add(1)

--- a/toolbox/metrics/coverage/coverage.go
+++ b/toolbox/metrics/coverage/coverage.go
@@ -83,7 +83,7 @@ func getCoverage(r io.ReadCloser) (Coverage, error) {
 		}
 	}()
 
-	//Line example: "istio.io/mixer/adapter/denyChecker	99"
+	// Line example: "istio.io/mixer/adapter/denyChecker	99"
 	scanner := bufio.NewScanner(r)
 	reg := regexp.MustCompile(`(.*)\t(.*)`)
 	for scanner.Scan() {

--- a/toolbox/metrics/flakes/flakes.go
+++ b/toolbox/metrics/flakes/flakes.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"strconv"
 
-	u "istio.io/test-infra/toolbox/util"
-
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+
+	u "istio.io/test-infra/toolbox/util"
 )
 
 const (
@@ -30,9 +30,7 @@ const (
 	latestFlakesMetric = "istio-job-flakes-latest.json"
 )
 
-var (
-	gcsClient = u.NewGCSClient(bucket)
-)
+var gcsClient = u.NewGCSClient(bucket)
 
 // FlakeGauge implement the metrics.Metric interface
 type FlakeGauge struct {

--- a/toolbox/metrics/metrics_test.go
+++ b/toolbox/metrics/metrics_test.go
@@ -24,9 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var (
-	m *Publisher
-)
+var m *Publisher
 
 func newGauge(n string) prometheus.Gauge {
 	return prometheus.NewGauge(prometheus.GaugeOpts{

--- a/toolbox/release_note_collector/main.go
+++ b/toolbox/release_note_collector/main.go
@@ -29,8 +29,10 @@ import (
 	u "istio.io/test-infra/toolbox/util"
 )
 
-type orderV string
-type sortV string
+type (
+	orderV string
+	sortV  string
+)
 
 const (
 	// Allowed field values can be found at https://developer.github.com/v3/search/#search-repositories
@@ -66,7 +68,6 @@ func init() {
 	} else {
 		gh = u.NewGithubClientNoAuth(*org)
 	}
-
 }
 
 func main() {

--- a/toolbox/util/commonUtils.go
+++ b/toolbox/util/commonUtils.go
@@ -33,13 +33,11 @@ const (
 	ReleaseNoteNone = "none"
 )
 
-var (
-	kvSplitters = []string{
-		" = ",
-		"=",
-		":",
-	}
-)
+var kvSplitters = []string{
+	" = ",
+	"=",
+	":",
+}
 
 // Retry executes do() until no error was returned or numTrials has reached
 func Retry(interval time.Duration, numTrials int, do func() error) error {

--- a/toolbox/util/githubClient.go
+++ b/toolbox/util/githubClient.go
@@ -28,9 +28,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var (
-	commitType = "commit"
-)
+var commitType = "commit"
 
 const (
 	maxCommitDistance   = 200
@@ -171,7 +169,6 @@ func (g *GithubClient) AddAutoMergeLabelsToPR(repo string, pr *github.PullReques
 // AddlabelsToPR adds labels to the pull request
 func (g *GithubClient) AddlabelsToPR(
 	repo string, pr *github.PullRequest, labels ...string) error {
-
 	// skip existing labels
 	existingLabels, _, err := g.client.Issues.ListLabelsByIssue(context.Background(), g.owner, repo, *pr.Number, &github.ListOptions{})
 	if err != nil {

--- a/tools/github_helper/main.go
+++ b/tools/github_helper/main.go
@@ -287,7 +287,7 @@ func (h helper) updatePullRequest(pr *github.PullRequest, s *github.CombinedStat
 		for _, check := range h.CheckToSkip {
 			pattern := fmt.Sprintf("(^|/)%s(/|$)", check)
 			if match, _ := regexp.MatchString(pattern, context); match {
-				//Find a match so that this failure can be skipped
+				// Find a match so that this failure can be skipped
 				return true
 			}
 		}


### PR DESCRIPTION
This will verify that `go` files will be off the correct format when a PR is submitted. It also updates the files such that they pass a `gofumpt` check.