### PR TITLE
Allow configuring Annotations and Labels fields for Prow job config

### DIFF
--- a/prow/config/generate_test.go
+++ b/prow/config/generate_test.go
@@ -110,3 +110,51 @@ func TestFilterReleaseBranchingJobs(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeMaps(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		mp1      map[string]string
+		mp2      map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "combine two empty maps",
+			mp1:      nil,
+			mp2:      nil,
+			expected: map[string]string{},
+		},
+		{
+			name:     "the first map is empty",
+			mp1:      map[string]string{},
+			mp2:      map[string]string{"a": "aa", "b": "bb"},
+			expected: map[string]string{"a": "aa", "b": "bb"},
+		},
+		{
+			name:     "the second map is empty",
+			mp1:      map[string]string{"a": "aa", "b": "bb"},
+			mp2:      map[string]string{},
+			expected: map[string]string{"a": "aa", "b": "bb"},
+		},
+		{
+			name:     "two maps without duplicated keys",
+			mp1:      map[string]string{"a": "aa"},
+			mp2:      map[string]string{"b": "bb"},
+			expected: map[string]string{"a": "aa", "b": "bb"},
+		},
+		{
+			name:     "two maps with duplicated keys",
+			mp1:      map[string]string{"a": "aa", "b": "b"},
+			mp2:      map[string]string{"b": "bb"},
+			expected: map[string]string{"a": "aa", "b": "bb"},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := mergeMaps(tc.mp1, tc.mp2)
+
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("mergeMaps does not work as intended; actual: %v\n expected %v\n", actual, tc.expected)
+		}
+	}
+}

--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -46,6 +46,7 @@ const (
 	defaultCluster    = "default"
 	defaultsFilename  = ".defaults.yaml"
 	yamlExt           = ".(yml|yaml)$"
+	gerritReportLabel = "prow.k8s.io/gerrit-report-label"
 )
 
 var (
@@ -687,9 +688,13 @@ func updateSSHKeySecrets(o options, job *prowjob.DecorationConfig) {
 func updateGerritReportingLabels(o options, skipReport, optional bool, labels map[string]string) {
 	if o.SupportGerritReporting && !skipReport {
 		if !optional {
-			labels["prow.k8s.io/gerrit-report-label"] = "Verified"
+			// For non-optional jobs, only add the label if it's not configured,
+			// this allows us defining internal jobs that report to a different label.
+			if _, ok := labels[gerritReportLabel]; !ok {
+				labels[gerritReportLabel] = "Verified"
+			}
 		} else {
-			labels["prow.k8s.io/gerrit-report-label"] = "Advisory"
+			labels[gerritReportLabel] = "Advisory"
 		}
 	}
 }


### PR DESCRIPTION
1. Allow configuring Annotations and Labels fields for Prow job config
2. Do not overwrite the `gerritReportLabel` if it's configured and the job is required. This allows us to define internal Prow jobs that report with a different label. The logic is a bit hacky, but since the job-transformer tool is only used by ASM, I guess it's fine.

For fixing internal issues:
173647011
179949877