### PR TITLE
Remove gerrit report label for Prow jobs that do not need to report

### DIFF
--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -696,6 +696,8 @@ func updateGerritReportingLabels(o options, skipReport, optional bool, labels ma
 		} else {
 			labels[gerritReportLabel] = "Advisory"
 		}
+	} else {
+		delete(labels, gerritReportLabel)
 	}
 }
 


### PR DESCRIPTION
For Prow jobs that do not need to report, adding gerrit report label will make `checkconfig` job unhappy. This PR removes the label for Prow jobs that do not need to report.