### PR TITLE
genjobs: only override annotations if o.Annotations is not empty

### DIFF
--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -787,7 +787,9 @@ func updateEnvs(o options, job *config.JobBase) {
 
 // updateJobBase updates the jobs JobBase fields based on provided inputs to work with private repositories.
 func updateJobBase(o options, job *config.JobBase, orgrepo string) {
-	job.Annotations = o.Annotations
+	if len(o.Annotations) != 0 {
+		job.Annotations = o.Annotations
+	}
 
 	if o.SSHClone && orgrepo != "" {
 		job.CloneURI = fmt.Sprintf("git@%s:%s.git", gitHost, orgrepo)

--- a/prow/genjobs/testdata/branches-out/branches-out_in.yaml
+++ b/prow/genjobs/testdata/branches-out/branches-out_in.yaml
@@ -1,9 +1,6 @@
 postsubmits:
   istio/istio:
   - name: example_postsubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     branches:
     - ^master$
     decorate: true
@@ -29,9 +26,6 @@ postsubmits:
 presubmits:
   istio/istio:
   - name: example_presubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     always_run: true
     branches:
     - ^master$

--- a/prow/genjobs/testdata/env_denylist/env_denylist_in.yaml
+++ b/prow/genjobs/testdata/env_denylist/env_denylist_in.yaml
@@ -1,9 +1,6 @@
 postsubmits:
   istio/istio:
   - name: example_postsubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     branches:
     - ^master$
     decorate: true
@@ -34,9 +31,6 @@ postsubmits:
 presubmits:
   istio/istio:
   - name: example_presubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     always_run: true
     branches:
     - ^master$
@@ -68,9 +62,6 @@ presubmits:
 periodics:
 - name: example_periodic
   cron: 0 2 * * *
-  annotations:
-    description: Information that isn't needed
-    testgrid-dashboards: public-dash
   decorate: true
   extra_refs:
   - base_ref: master

--- a/prow/genjobs/testdata/simple_transform/simple_transform_in.yaml
+++ b/prow/genjobs/testdata/simple_transform/simple_transform_in.yaml
@@ -1,9 +1,6 @@
 postsubmits:
   istio/istio:
   - name: example_postsubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     branches:
     - ^master$
     decorate: true
@@ -29,9 +26,6 @@ postsubmits:
 presubmits:
   istio/istio:
   - name: example_presubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     always_run: true
     branches:
     - ^master$

--- a/prow/genjobs/testdata/volume_denylist/volume_denylist_in.yaml
+++ b/prow/genjobs/testdata/volume_denylist/volume_denylist_in.yaml
@@ -1,9 +1,6 @@
 postsubmits:
   istio/istio:
   - name: example_postsubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     branches:
     - ^master$
     decorate: true
@@ -39,9 +36,6 @@ postsubmits:
 presubmits:
   istio/istio:
   - name: example_presubmit
-    annotations:
-      description: Information that isn't needed
-      testgrid-dashboards: public-dash
     always_run: true
     branches:
     - ^master$
@@ -78,9 +72,6 @@ presubmits:
 periodics:
 - name: example_periodic
   cron: 0 2 * * *
-  annotations:
-    description: Information that isn't needed
-    testgrid-dashboards: public-dash
   decorate: true
   extra_refs:
   - base_ref: master


### PR DESCRIPTION
This allow us to keep different annotations per job.