### PR TITLE
Some updates and fixes to the genjobs tools

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -9,13 +9,17 @@ periodics:
   extra_refs:
   - base_ref: master
     org: istio
+    path_alias: istio.io/istio.io
+    repo: istio.io
+  - base_ref: master
+    org: istio
     path_alias: istio.io/test-infra
     repo: test-infra
   name: update-ref-docs_istio.io_periodic
   spec:
     containers:
     - command:
-      - ./tools/automator/automator.sh
+      - ../test-infra/tools/automator/automator.sh
       - --org=istio
       - --repo=istio.io
       - '--title=Automator: update istio.io@$AUTOMATOR_SRC_BRANCH reference docs'
@@ -60,13 +64,17 @@ periodics:
   extra_refs:
   - base_ref: master
     org: istio
+    path_alias: istio.io/istio.io
+    repo: istio.io
+  - base_ref: master
+    org: istio
     path_alias: istio.io/test-infra
     repo: test-infra
   name: update-istio-ref_istio.io_periodic
   spec:
     containers:
     - command:
-      - ./tools/automator/automator.sh
+      - ../test-infra/tools/automator/automator.sh
       - --org=istio
       - --repo=istio.io
       - '--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference'

--- a/prow/config/cmd/generate.go
+++ b/prow/config/cmd/generate.go
@@ -62,7 +62,10 @@ func main() {
 		panic("too many arguments")
 	}
 
-	settings := config.ReadGlobalSettings(filepath.Join(*inputDir, ".global.yaml"))
+	var settings config.GlobalConfig
+	if _, err := os.Stat(filepath.Join(*inputDir, ".global.yaml")); !os.IsNotExist(err) {
+		settings = config.ReadGlobalSettings(filepath.Join(*inputDir, ".global.yaml"))
+	}
 	cli := &config.Client{GlobalConfig: settings}
 
 	if os.Args[1] == "branch" {

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -51,7 +51,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=scripts/update_envoy.sh $AUTOMATOR_SHA $AUTOMATOR_SHA_COMMIT_DATE
   requirements: [github]
-  repos: [istio/envoy@master, istio/test-infra@master]
+  repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-2021-03-01T22-30-49
   timeout: 4h
 

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -53,7 +53,7 @@ jobs:
     types: [periodic]
     cron: "0 2 * * *"  # every day at 02:00AM UTC
     command:
-    - ./tools/automator/automator.sh
+    - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio.io
     - "--title=Automator: update istio.io@$AUTOMATOR_SRC_BRANCH reference docs"
@@ -69,7 +69,7 @@ jobs:
     types: [periodic]
     cron: "0 2 * * 0"  # every Sunday at 02:00AM UTC
     command:
-    - ./tools/automator/automator.sh
+    - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=istio.io
     - "--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference"

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -157,4 +157,3 @@ jobs:
     - --tag=v[0-9]{8}-[a-f0-9]{10}
     - --var=image
     requirements: [github]
-    repos: [istio/test-infra]

--- a/prow/genjobs/cmd/genjobs/main.go
+++ b/prow/genjobs/cmd/genjobs/main.go
@@ -827,7 +827,7 @@ func updateExtraRefs(o options, job *config.UtilityConfig) {
 		}
 	}
 	if len(o.ExtraRefs) > 0 {
-		job.ExtraRefs = o.ExtraRefs
+		job.ExtraRefs = append(job.ExtraRefs, o.ExtraRefs...)
 	}
 }
 


### PR DESCRIPTION
1. Set `.global.yaml` to be optional
2. For periodic Prow jobs, add the repo to the refs and set it as the first ref by default
3. For non-GitHub repos, the org name can contain `/` and has a different `CloneURI`, so handle them a bit differently
4. `genjobs` tool should append the extra refs passed from the flag, instead of overwriting