### PR TITLE
Fix GO111MODULE="on" go get -u istio.io/test-infra/prow/genjobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.2.0+incompatible
+	github.com/fvbommel/sortorder => github.com/fvbommel/sortorder v1.0.2
 	github.com/garyburd/redigo => github.com/garyburd/redigo v1.6.0 // for LICENSE
 	github.com/otiai10/curr => github.com/otiai10/curr v1.0.0 // for LICENSE
 	github.com/otiai10/mint => github.com/otiai10/mint v1.3.0 // remove dependency on bou.ke/monkey


### PR DESCRIPTION
Error: Fix go.mod based on the following error

```
go: downloading k8s.io/test-infra v0.0.0-20210305021621-22c6cce02870
go: downloading golang.org/x/sys v0.0.0-20210305030159-61f932b4c616
go: downloading k8s.io/utils v0.0.0-20210305010621-2afb4311ab10
go: downloading k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
go get: vbom.ml/util/sortorder@none updating to
	vbom.ml/util/sortorder@v1.0.2: parsing go.mod:
	module declares its path as: github.com/fvbommel/sortorder
	        but was required as: vbom.ml/util/sortorder
```