### PR TITLE
Add labels to specify merge type for a repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -399,6 +399,9 @@ tide:
     istio-private: squash
   target_url: https://prow.istio.io/tide
   blocker_label: tide/merge-blocker
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
   context_options:
     from-branch-protection: true
     skip-unknown-contexts: true


### PR DESCRIPTION
Context: https://github.com/istio/envoy/pull/304#issuecomment-797069745
cc @PiotrSikora 

I *think* this means we stick that label on it and it will merge instead of squash