### PR TITLE
Make doc tests required for release-1.9

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
@@ -374,7 +374,6 @@ presubmits:
     - ^release-1.9$
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.9
-    optional: true
     path_alias: istio.io/istio.io
     spec:
       containers:
@@ -429,7 +428,6 @@ presubmits:
     - ^release-1.9$
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.9
-    optional: true
     path_alias: istio.io/istio.io
     spec:
       containers:
@@ -484,7 +482,6 @@ presubmits:
     - ^release-1.9$
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.9
-    optional: true
     path_alias: istio.io/istio.io
     spec:
       containers:
@@ -539,7 +536,6 @@ presubmits:
     - ^release-1.9$
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.9
-    optional: true
     path_alias: istio.io/istio.io
     spec:
       containers:

--- a/prow/config/jobs/istio.io-1.9.yaml
+++ b/prow/config/jobs/istio.io-1.9.yaml
@@ -14,8 +14,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_default
-  modifiers:
-  - optional
   name: doc.test.profile_default
   requirements:
   - kind
@@ -23,8 +21,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_demo
-  modifiers:
-  - optional
   name: doc.test.profile_demo
   requirements:
   - kind
@@ -32,8 +28,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_none
-  modifiers:
-  - optional
   name: doc.test.profile_none
   requirements:
   - kind
@@ -43,8 +37,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - doc.test.multicluster
-  modifiers:
-  - optional
   name: doc.test.multicluster
   requirements:
   - kind


### PR DESCRIPTION
The tests are currently failing, so I'll make this as DNM for now. Once the tests are back to passing, we should un-label and require the tests. Today, it's too easy to approve the cherrypicks right away, and since the tests aren't required they are stopped and the PR merged.