### PR TITLE
Switched to a plain string for the upstream branch name

### DIFF
--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=merge_upstream_changes
       - --token-path=/etc/github-token/oauth
       - --merge-repository=https://github.com/envoyproxy/envoy.git
-      - --merge-branch="release/$(cut --fields=1,2 -d. VERSION)"
+      - --merge-branch="release/v1.17"
       image: gcr.io/istio-testing/build-tools:master-2021-03-01T22-30-49
       name: ""
       resources:

--- a/prow/config/jobs/envoy-1.9.yaml
+++ b/prow/config/jobs/envoy-1.9.yaml
@@ -66,7 +66,7 @@ jobs:
   - --modifier=merge_upstream_changes
   - --token-path=/etc/github-token/oauth
   - --merge-repository=https://github.com/envoyproxy/envoy.git
-  - --merge-branch="release/$(cut --fields=1,2 -d. VERSION)"
+  - --merge-branch="release/v1.17"
   requirements: [github]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-2021-03-01T22-30-49


### PR DESCRIPTION
This should resolve `fatal: Invalid refspec '+refs/heads/"release/$(cut --fields=1,2 -d. VERSION)":refs/remotes/upstream/"release/$(cut --fields=1,2 -d. VERSION)'` error (see here: https://storage.googleapis.com/istio-prow/logs/update-envoy_envoy_release-1.9_periodic/1376286882396114944/build-log.txt)