### PR TITLE
Removed double-quotes from the merge-branch parameter

### DIFF
--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=merge_upstream_changes
       - --token-path=/etc/github-token/oauth
       - --merge-repository=https://github.com/envoyproxy/envoy.git
-      - --merge-branch="release/v1.17"
+      - --merge-branch=release/v1.17
       image: gcr.io/istio-testing/build-tools:master-2021-03-01T22-30-49
       name: ""
       resources:

--- a/prow/config/jobs/envoy-1.9.yaml
+++ b/prow/config/jobs/envoy-1.9.yaml
@@ -66,7 +66,7 @@ jobs:
   - --modifier=merge_upstream_changes
   - --token-path=/etc/github-token/oauth
   - --merge-repository=https://github.com/envoyproxy/envoy.git
-  - --merge-branch="release/v1.17"
+  - --merge-branch=release/v1.17
   requirements: [github]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-2021-03-01T22-30-49


### PR DESCRIPTION
This should fix `fatal: Couldn't find remote ref refs/heads/"release/v1.17"` error.