### PR TITLE
Fix release 1.9 centos build image.

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -75,6 +75,7 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit-centos.sh
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE
@@ -103,6 +104,8 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: build-pool
       volumes:
@@ -110,6 +113,8 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-create-test-group: "false"
     branches:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
@@ -75,6 +75,7 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit-centos.sh
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE
@@ -103,6 +104,8 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: build-pool
       volumes:
@@ -110,6 +113,8 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-create-test-group: "false"
     branches:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
@@ -75,6 +75,7 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit-centos.sh
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE
@@ -88,7 +89,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:master-2021-03-15T07-16-03
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-03-15T05-33-53
         name: ""
         resources:
           limits:
@@ -103,6 +104,8 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: build-pool
       volumes:
@@ -110,6 +113,8 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-create-test-group: "false"
     branches:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -61,6 +61,7 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit-centos.sh
         image: gcr.io/istio-testing/build-tools-centos:master-2021-03-15T07-16-03
         name: ""
@@ -77,6 +78,8 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: build-pool
       volumes:
@@ -84,6 +87,8 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_proxy_postsubmit

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
@@ -61,6 +61,7 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit-centos.sh
         image: gcr.io/istio-testing/build-tools-centos:release-1.8-2021-02-05T16-03-58
         name: ""
@@ -77,6 +78,8 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: build-pool
       volumes:
@@ -84,6 +87,8 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.8_proxy_postsubmit

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
@@ -61,8 +61,9 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2021-03-15T07-16-03
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-03-15T05-33-53
         name: ""
         resources:
           limits:
@@ -77,6 +78,8 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
       nodeSelector:
         testing: build-pool
       volumes:
@@ -84,6 +87,8 @@ postsubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_release-1.9_proxy_postsubmit

--- a/prow/config/jobs/proxy-1.8.yaml
+++ b/prow/config/jobs/proxy-1.8.yaml
@@ -59,11 +59,13 @@ jobs:
   timeout: 4h0m0s
   types: [postsubmit]
 - command:
+  - entrypoint
   - ./prow/proxy-postsubmit-centos.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.8-2021-02-05T16-03-58
   name: release-centos
   requirements:
   - gcp
+  - docker
   timeout: 4h0m0s
   types: [postsubmit]
 - command:

--- a/prow/config/jobs/proxy-1.9.yaml
+++ b/prow/config/jobs/proxy-1.9.yaml
@@ -66,11 +66,13 @@ jobs:
   types:
   - postsubmit
 - command:
+  - entrypoint
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:master-2021-03-15T07-16-03
+  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-03-15T05-33-53
   name: release-centos
   requirements:
   - gcp
+  - docker
   timeout: 4h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -53,8 +53,8 @@ jobs:
 
 - name: release-centos
   types: [postsubmit]
-  command: [./prow/proxy-postsubmit-centos.sh]
-  requirements: [gcp]
+  command: [entrypoint, ./prow/proxy-postsubmit-centos.sh]
+  requirements: [gcp, docker]
   image: gcr.io/istio-testing/build-tools-centos:master-2021-03-15T07-16-03
   timeout: 4h
 


### PR DESCRIPTION
Also made several other changes to the centos job to make it match proxy build job. Now the generated manifests are exactly the same for both jobs. I cannot think of how the diff would cause job failure at private repo, but just in case...