### PR TITLE
Revert "Add branch protection for release-1.10 (#3247)"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -204,11 +204,6 @@ branch-protection:
               restrictions:
                 teams:
                 - release-managers-1.9
-            release-1.10: &release110
-              protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.10
         operator:
           branches: *blocked_branches
         istio.io:
@@ -276,8 +271,6 @@ branch-protection:
               <<: *release18
             release-1.9:
               <<: *release19
-            release-1.10:
-              <<: *release110
         proxy:
           branches:
             <<: *blocked_branches


### PR DESCRIPTION
Required to bring istio/envoy back up to date with envoyproxy/envoy main branch. In the future we should exclude envoy from the automated branch steps to avoid branching from an ancient master. Will add branch protec back as soon as the envoy change is merged in.

Could also potentially just have somebody with perms force merge https://github.com/istio/envoy/pull/309 as an alternative