### PR TITLE
Add github-optional

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -2406,4 +2406,5 @@ presubmits:
         name: build-cache
       - name: github
         secret:
+          optional: true
           secretName: oauth-token

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -2165,4 +2165,5 @@ presubmits:
         name: build-cache
       - name: github
         secret:
+          optional: true
           secretName: oauth-token

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -165,6 +165,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
 presubmits:
   istio-private/release-builder:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
@@ -165,6 +165,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
 presubmits:
   istio-private/release-builder:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
@@ -165,6 +165,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
 presubmits:
   istio-private/release-builder:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -1950,4 +1950,5 @@ presubmits:
         name: build-cache
       - name: github
         secret:
+          optional: true
           secretName: oauth-token

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -2168,4 +2168,5 @@ presubmits:
         name: build-cache
       - name: github
         secret:
+          optional: true
           secretName: oauth-token

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -1951,4 +1951,5 @@ presubmits:
         name: build-cache
       - name: github
         secret:
+          optional: true
           secretName: oauth-token

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -200,6 +200,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
@@ -200,6 +200,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
@@ -200,6 +200,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
@@ -200,6 +200,7 @@ postsubmits:
         name: docker-root
       - name: github
         secret:
+          optional: true
           secretName: oauth-token
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com

--- a/prow/config/jobs/.global.yaml
+++ b/prow/config/jobs/.global.yaml
@@ -79,6 +79,16 @@ requirement_presets:
     - name: github
       secret:
         secretName: oauth-token
+  github-optional:
+    volumeMounts:
+    - mountPath: /etc/github-token
+      name: github
+      readOnly: true
+      optional: true
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
   release:
     labels:
       preset-release-pipeline: "true"

--- a/prow/config/jobs/.global.yaml
+++ b/prow/config/jobs/.global.yaml
@@ -75,6 +75,7 @@ requirement_presets:
     - mountPath: /etc/github-token
       name: github
       readOnly: true
+      optional: true
     volumes:
     - name: github
       secret:
@@ -89,6 +90,7 @@ requirement_presets:
     - name: github
       secret:
         secretName: oauth-token
+        optional: true
   release:
     labels:
       preset-release-pipeline: "true"

--- a/prow/config/jobs/.global.yaml
+++ b/prow/config/jobs/.global.yaml
@@ -75,7 +75,6 @@ requirement_presets:
     - mountPath: /etc/github-token
       name: github
       readOnly: true
-      optional: true
     volumes:
     - name: github
       secret:
@@ -85,7 +84,6 @@ requirement_presets:
     - mountPath: /etc/github-token
       name: github
       readOnly: true
-      optional: true
     volumes:
     - name: github
       secret:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -440,7 +440,7 @@ jobs:
   - istio/tools@master
   requirements:
   - cache
-  - github
+  - github-optional
   - gocache
   types:
   - presubmit

--- a/prow/config/jobs/istio-1.8.yaml
+++ b/prow/config/jobs/istio-1.8.yaml
@@ -333,7 +333,7 @@ jobs:
   - istio/test-infra@master
   - istio/tools@master
   requirements:
-  - github
+  - github-optional
   types: [presubmit]
 org: istio
 repo: istio

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -326,7 +326,7 @@ jobs:
   - istio/test-infra@master
   - istio/tools@master
   requirements:
-  - github
+  - github-optional
   types:
   - presubmit
 org: istio

--- a/prow/config/jobs/release-builder-1.10.yaml
+++ b/prow/config/jobs/release-builder-1.10.yaml
@@ -73,7 +73,7 @@ jobs:
   - cache
   - release
   - docker
-  - github
+  - github-optional
   resources: build
   types:
   - postsubmit

--- a/prow/config/jobs/release-builder-1.8.yaml
+++ b/prow/config/jobs/release-builder-1.8.yaml
@@ -45,7 +45,7 @@ jobs:
   requirements:
   - release
   - docker
-  - github
+  - github-optional
   resources: build
   types: [postsubmit]
 - command:

--- a/prow/config/jobs/release-builder-1.9.yaml
+++ b/prow/config/jobs/release-builder-1.9.yaml
@@ -47,7 +47,7 @@ jobs:
   requirements:
   - release
   - docker
-  - github
+  - github-optional
   resources: build
   types:
   - postsubmit

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -35,7 +35,7 @@ jobs:
     types: [postsubmit]
     regex: '^release/trigger-build$'
     command: [entrypoint, release/build.sh]
-    requirements: [release, docker, github]
+    requirements: [release, docker, github-optional]
     resources: build
 
   - name: publish-release


### PR DESCRIPTION
This adds a new `github-optional` requirement in order to allow jobs in which presenting a GitHub token is optional to continue to run if not presented with a token. 
