### PR TITLE
Update latest k8s for tests, move 1.21 postsubmit to 1.20 for coverage

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -773,7 +773,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.17.11
+        - kindest/node:v1.17.17
         - --kind-config
         - prow/config/endpointslice.yaml
         - test.integration.kube.presubmit
@@ -843,7 +843,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.18.8
+        - kindest/node:v1.18.15
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -911,7 +911,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.19.4
+        - kindest/node:v1.19.7
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -971,7 +971,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-k8s-121_istio_postsubmit_priv
+    name: integ-k8s-120_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -979,7 +979,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.21.0
+        - gcr.io/istio-testing/kind-node:v1.20.5
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -760,7 +760,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.17.11
+        - kindest/node:v1.17.17
         - --kind-config
         - prow/config/endpointslice.yaml
         - test.integration.kube.presubmit
@@ -826,7 +826,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.18.8
+        - kindest/node:v1.18.15
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -890,7 +890,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.19.4
+        - kindest/node:v1.19.7
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -946,7 +946,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-121_istio_postsubmit
+    name: integ-k8s-120_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -954,7 +954,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.21.0
+        - gcr.io/istio-testing/kind-node:v1.20.5
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -180,7 +180,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.17.11
+      - kindest/node:v1.17.17
       - --kind-config
       - prow/config/endpointslice.yaml
       - test.integration.kube.presubmit
@@ -196,7 +196,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.18.8
+      - kindest/node:v1.18.15
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -210,7 +210,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.19.4
+      - kindest/node:v1.19.7
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -218,13 +218,13 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
-  - name: integ-k8s-121
+  - name: integ-k8s-120
     types: [postsubmit]
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.21.0
+      - gcr.io/istio-testing/kind-node:v1.20.5
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
1.21 is covered in pre-submit, so move that post-submit to 1.20