### PR TITLE
Add prefixes private repos

### DIFF
--- a/prow/cluster/jobs/all-presets.yaml
+++ b/prow/cluster/jobs/all-presets.yaml
@@ -133,6 +133,45 @@ presets:
       - key: secret
         path: id_rsa
         mode: 0600
+- labels: 
+    preset-use-api-private: "true"
+  volumeMounts:
+  - mountPath: $HOME/.gitconfig
+    name: gitconfig
+    readOnly: true
+  volumes:
+  - name: gitconfig
+    secret:
+      secretName: gitconfig
+  env:
+  - name: GOPRIVATE
+    value: istio.io/api
+- labels:
+    preset-use-go-control-plane-private: "true"
+  volumeMounts:
+  - mountPath: $HOME/.gitconfig
+    name: gitconfig
+    readOnly: true
+  volumes:
+  - name: gitconfig
+    secret:
+      secretName: gitconfig
+  env:
+  - name: GOPRIVATE
+    value: github.com/envoyproxy/go-control-plane
+- labels:
+    preset-use-go-control-plane-api-private: "true"
+  volumeMounts:
+  - mountPath: $HOME/.gitconfig
+    name: gitconfig
+    readOnly: true
+  volumes:
+  - name: gitconfig
+    secret:
+      secretName: gitconfig
+  env:
+  - name: GOPRIVATE
+    value: github.com/envoyproxy/go-control-plane,istio.io/api
 - labels:
     preset-enable-gomod-netrc: "true"
   volumeMounts:

--- a/prow/cluster/jobs/all-presets.yaml
+++ b/prow/cluster/jobs/all-presets.yaml
@@ -133,10 +133,11 @@ presets:
       - key: secret
         path: id_rsa
         mode: 0600
-- labels: 
+- labels:
     preset-use-api-private: "true"
   volumeMounts:
   - mountPath: $HOME/.gitconfig
+    subPath: .gitconfig
     name: gitconfig
     readOnly: true
   volumes:
@@ -150,6 +151,7 @@ presets:
     preset-use-go-control-plane-private: "true"
   volumeMounts:
   - mountPath: $HOME/.gitconfig
+    subPath: .gitconfig
     name: gitconfig
     readOnly: true
   volumes:
@@ -163,6 +165,7 @@ presets:
     preset-use-go-control-plane-api-private: "true"
   volumeMounts:
   - mountPath: $HOME/.gitconfig
+    subPath: .gitconfig
     name: gitconfig
     readOnly: true
   volumes:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -63,6 +63,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: unit-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -110,6 +111,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-mc-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -176,6 +178,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -242,6 +245,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-ipv6-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -310,6 +314,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -374,6 +379,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -440,6 +446,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -504,6 +511,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -570,6 +578,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -634,6 +643,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-helm-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -697,6 +707,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-116_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -765,6 +776,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-117_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -835,6 +847,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-118_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -903,6 +916,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-119_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -971,6 +985,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-120_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1039,6 +1054,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-122_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1107,6 +1123,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-cni-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     skip_report: true
@@ -1176,6 +1193,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: unit-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1225,6 +1243,7 @@ presubmits:
       preset-override-deps: master-istio
       preset-override-envoy: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-test_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1272,6 +1291,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: benchmark_istio_priv
     optional: true
     path_alias: istio.io/istio
@@ -1317,6 +1337,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1382,6 +1403,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1447,6 +1469,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1512,6 +1535,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-mc-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1579,6 +1603,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-multicluster-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1646,6 +1671,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1713,6 +1739,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-ipv6-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1782,6 +1809,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-operator-controller-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1847,6 +1875,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-multicluster-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1914,6 +1943,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-multicluster-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1981,6 +2011,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-helm-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -2043,6 +2074,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: analyze-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -2086,6 +2118,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: lint_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -2129,6 +2162,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -2183,6 +2217,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-notes_istio_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -65,6 +65,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: unit-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -114,6 +115,7 @@ postsubmits:
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: benchmark-report_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -159,6 +161,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-mc-k8s-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -226,6 +229,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -293,6 +297,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-ipv6-k8s-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -362,6 +367,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-k8s-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -427,6 +433,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-multicluster-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -494,6 +501,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     skip_report: true
@@ -564,6 +572,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -629,6 +638,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-multicluster-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -696,6 +706,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-k8s-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -761,6 +772,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-helm-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -825,6 +837,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-115_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -894,6 +907,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-116_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -963,6 +977,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-117_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1032,6 +1047,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-118_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1101,6 +1117,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-120_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     skip_report: true
@@ -1169,6 +1186,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: install-cni-test_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     skip_report: true
@@ -1221,6 +1239,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: unit-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1271,6 +1290,7 @@ presubmits:
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-test_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1319,6 +1339,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: benchmark_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
@@ -1365,6 +1386,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1431,6 +1453,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1497,6 +1520,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1563,6 +1587,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-mc-k8s-tests_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
@@ -1632,6 +1657,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-multicluster-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1700,6 +1726,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1768,6 +1795,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-ipv6-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1838,6 +1866,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-operator-controller-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1904,6 +1933,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-multicluster-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1972,6 +2002,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-external-istiod-mc-tests_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
@@ -2044,6 +2075,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-multicluster-tests_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
@@ -2113,6 +2145,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-helm-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -2176,6 +2209,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: install-cni-test_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
@@ -2227,6 +2261,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: analyze-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -2271,6 +2306,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: lint_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -2315,6 +2351,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -2370,6 +2407,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-notes_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -65,6 +65,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: unit-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -114,6 +115,7 @@ postsubmits:
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: benchmark-report_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -159,6 +161,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-mc-k8s-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -226,6 +229,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -293,6 +297,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-ipv6-k8s-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -362,6 +367,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-k8s-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -427,6 +433,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-multicluster-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -494,6 +501,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -559,6 +567,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-multicluster-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -626,6 +635,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-k8s-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -691,6 +701,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-helm-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -755,6 +766,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-115_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -824,6 +836,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-116_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -893,6 +906,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-117_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -964,6 +978,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-118_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1033,6 +1048,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-k8s-119_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -1103,6 +1119,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: unit-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1153,6 +1170,7 @@ presubmits:
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-test_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1201,6 +1219,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: benchmark_istio_release-1.9_priv
     optional: true
     path_alias: istio.io/istio
@@ -1247,6 +1266,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1313,6 +1333,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1379,6 +1400,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1445,6 +1467,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-telemetry-mc-k8s-tests_istio_release-1.9_priv
     optional: true
     path_alias: istio.io/istio
@@ -1514,6 +1537,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-multicluster-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1582,6 +1606,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1650,6 +1675,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-ipv6-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1720,6 +1746,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-operator-controller-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1786,6 +1813,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-pilot-multicluster-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1854,6 +1882,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-multicluster-tests_istio_release-1.9_priv
     optional: true
     path_alias: istio.io/istio
@@ -1923,6 +1952,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-helm-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1986,6 +2016,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: analyze-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -2030,6 +2061,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: lint_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -2074,6 +2106,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -2129,6 +2162,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-notes_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -70,6 +71,7 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-centos_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -127,6 +129,7 @@ postsubmits:
       repo: test-infra
     labels:
       preset-enable-netrc: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: update-istio_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -195,6 +198,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -242,6 +246,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test-asan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -289,6 +294,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test-tsan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -336,6 +342,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -383,6 +390,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-centos-test_proxy_master_priv
     optional: true
     path_alias: istio.io/proxy
@@ -431,6 +439,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: check-wasm_proxy_master_priv
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release_proxy_release-1.8_postsubmit_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -70,6 +71,7 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-centos_proxy_release-1.8_postsubmit_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -127,6 +129,7 @@ postsubmits:
       repo: test-infra
     labels:
       preset-enable-netrc: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: update-istio_proxy_release-1.8_postsubmit_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -195,6 +198,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -242,6 +246,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test-asan_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -289,6 +294,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test-tsan_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -336,6 +342,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-test_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -383,6 +390,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-centos-test_proxy_release-1.8_release-1.8_priv
     optional: true
     path_alias: istio.io/proxy
@@ -431,6 +439,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: check-wasm_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release_proxy_release-1.9_postsubmit_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -70,6 +71,7 @@ postsubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-centos_proxy_release-1.9_postsubmit_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -127,6 +129,7 @@ postsubmits:
       repo: test-infra
     labels:
       preset-enable-netrc: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: update-istio_proxy_release-1.9_postsubmit_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -195,6 +198,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -242,6 +246,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test-asan_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -289,6 +294,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: test-tsan_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -336,6 +342,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-test_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -383,6 +390,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: release-centos-test_proxy_release-1.9_release-1.9_priv
     optional: true
     path_alias: istio.io/proxy
@@ -431,6 +439,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
       preset-service-account: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: check-wasm_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -8,6 +8,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: lint_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -44,6 +46,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: test_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -80,6 +84,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_release-builder_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -177,6 +183,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: lint_release-builder_priv
     path_alias: istio.io/release-builder
     spec:
@@ -214,6 +222,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: test_release-builder_priv
     path_alias: istio.io/release-builder
     spec:
@@ -251,6 +261,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_release-builder_priv
     path_alias: istio.io/release-builder
     spec:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
@@ -8,6 +8,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: lint_release-builder_release-1.8_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -44,6 +46,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: test_release-builder_release-1.8_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -80,6 +84,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_release-builder_release-1.8_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -177,6 +183,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: lint_release-builder_release-1.8_priv
     path_alias: istio.io/release-builder
     spec:
@@ -214,6 +222,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: test_release-builder_release-1.8_priv
     path_alias: istio.io/release-builder
     spec:
@@ -251,6 +261,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_release-builder_release-1.8_priv
     path_alias: istio.io/release-builder
     spec:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
@@ -8,6 +8,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: lint_release-builder_release-1.9_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -44,6 +46,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: test_release-builder_release-1.9_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -80,6 +84,8 @@ postsubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_release-builder_release-1.9_postsubmit_priv
     path_alias: istio.io/release-builder
     spec:
@@ -177,6 +183,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: lint_release-builder_release-1.9_priv
     path_alias: istio.io/release-builder
     spec:
@@ -214,6 +222,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: test_release-builder_release-1.9_priv
     path_alias: istio.io/release-builder
     spec:
@@ -251,6 +261,8 @@ presubmits:
     clone_uri: git@github.com:istio-private/release-builder.git
     cluster: private
     decorate: true
+    labels:
+      preset-use-go-control-plane-api-private: "true"
     name: gencheck_release-builder_release-1.9_priv
     path_alias: istio.io/release-builder
     spec:

--- a/prow/config/istio-private_jobs/istio.yaml
+++ b/prow/config/istio-private_jobs/istio.yaml
@@ -20,5 +20,6 @@ transforms:
     preset-enable-ssh: "true"
     preset-override-envoy: "true"
     preset-override-deps: master-istio
+    preset-use-go-control-plane-api-private: "true"
   job-type: [presubmit, postsubmit]
   job-denylist: [benchmark-report_istio_postsubmit, release_istio_postsubmit, cache-experiment_istio_postsubmit, cache-experiment_istio, update-ref-docs-dry-run_istio]

--- a/prow/config/istio-private_jobs/istio_1.8.yml
+++ b/prow/config/istio-private_jobs/istio_1.8.yml
@@ -22,5 +22,6 @@ transforms:
     preset-enable-gomod-netrc: "true"
     preset-override-envoy: "true"
     preset-override-deps: release-1.8-istio
+    preset-use-go-control-plane-api-private: "true"
   job-type: [presubmit, postsubmit]
   job-denylist: [release_istio_release-1.8_postsubmit]

--- a/prow/config/istio-private_jobs/istio_1.9.yml
+++ b/prow/config/istio-private_jobs/istio_1.9.yml
@@ -22,5 +22,6 @@ transforms:
     preset-enable-gomod-netrc: "true"
     preset-override-envoy: "true"
     preset-override-deps: release-1.9-istio
+    preset-use-go-control-plane-api-private: "true"
   job-type: [presubmit, postsubmit]
   job-denylist: [release_istio_release-1.9_postsubmit]

--- a/prow/config/istio-private_jobs/proxy.yaml
+++ b/prow/config/istio-private_jobs/proxy.yaml
@@ -13,6 +13,7 @@ transforms:
     ENVOY_PREFIX: envoy
   labels:
     preset-enable-netrc: "true"
+    preset-use-go-control-plane-api-private: "true"
   job-type: [presubmit]
 
 # istio/proxy master build jobs(s) - postsubmit(s)
@@ -25,4 +26,5 @@ transforms:
     ENVOY_PREFIX: envoy
   labels:
     preset-enable-netrc: "true"
+    preset-use-go-control-plane-api-private: "true"
   job-type: [postsubmit]

--- a/prow/config/istio-private_jobs/proxy_1.8.yml
+++ b/prow/config/istio-private_jobs/proxy_1.8.yml
@@ -13,6 +13,7 @@ transforms:
     ENVOY_PREFIX: envoy
   labels:
     preset-enable-netrc: "true"
+    preset-use-go-control-plane-api-private: "true"
   job-type: [presubmit]
 
 
@@ -26,4 +27,5 @@ transforms:
     ENVOY_PREFIX: envoy
   labels:
     preset-enable-netrc: "true"
+    preset-use-go-control-plane-api-private: "true"
   job-type: [postsubmit]

--- a/prow/config/istio-private_jobs/proxy_1.9.yml
+++ b/prow/config/istio-private_jobs/proxy_1.9.yml
@@ -13,6 +13,7 @@ transforms:
     ENVOY_PREFIX: envoy
   labels:
     preset-enable-netrc: "true"
+    preset-use-go-control-plane-api-private: "true"
   job-type: [presubmit]
 
 
@@ -26,4 +27,5 @@ transforms:
     ENVOY_PREFIX: envoy
   labels:
     preset-enable-netrc: "true"
+    preset-use-go-control-plane-api-private: "true"
   job-type: [postsubmit]

--- a/prow/config/istio-private_jobs/release-builder.yaml
+++ b/prow/config/istio-private_jobs/release-builder.yaml
@@ -8,6 +8,8 @@ transforms:
 # istio/release-builder master test jobs(s) - pre/postsubmit(s)
 - job-type: [presubmit, postsubmit]
   job-allowlist: [lint_release-builder,lint_release-builder_postsubmit,test_release-builder,test_release-builder_postsubmit,gencheck_release-builder,gencheck_release-builder_postsubmit]
+  labels:
+    preset-use-go-control-plane-api-private: "true"
 
 # istio/release-builder master build warning jobs(s) - presubmit(s)
 - env:

--- a/prow/config/istio-private_jobs/release-builder_1.8.yml
+++ b/prow/config/istio-private_jobs/release-builder_1.8.yml
@@ -9,6 +9,8 @@ transforms:
 - job-type: [presubmit, postsubmit]
   repo-allowlist: [release-builder]
   job-allowlist: [lint_release-builder_release-1.8,lint_release-builder_release-1.8_postsubmit,test_release-builder_release-1.8,test_release-builder_release-1.8_postsubmit,gencheck_release-builder_release-1.8,gencheck_release-builder_release-1.8_postsubmit]
+  labels:
+    preset-use-go-control-plane-api-private: "true"
 
 # istio/release-builder release-1.8 build warning jobs(s) - presubmit(s)
 - env:

--- a/prow/config/istio-private_jobs/release-builder_1.9.yml
+++ b/prow/config/istio-private_jobs/release-builder_1.9.yml
@@ -9,6 +9,8 @@ transforms:
 - job-type: [presubmit, postsubmit]
   repo-allowlist: [release-builder]
   job-allowlist: [lint_release-builder_release-1.9,lint_release-builder_release-1.9_postsubmit,test_release-builder_release-1.9,test_release-builder_release-1.9_postsubmit,gencheck_release-builder_release-1.9,gencheck_release-builder_release-1.9_postsubmit]
+  labels:
+    preset-use-go-control-plane-api-private: "true"
 
 # istio/release-builder release-1.9 build warning jobs(s) - presubmit(s)
 - env:


### PR DESCRIPTION
The [GOPRIVATE](https://medium.com/swlh/go-modules-with-private-git-repository-3940b6835727) flag allows us to override repos with private versions using a `GOPRIVATE` variable and a `gitproxy` file. 