### PR TITLE
Update Envoy images

### DIFF
--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
@@ -26,7 +26,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -73,7 +73,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -118,7 +118,7 @@ presubmits:
             --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.10.gen.yaml
@@ -26,7 +26,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -73,7 +73,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -118,7 +118,7 @@ presubmits:
             --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -84,7 +84,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ presubmits:
             --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.10.gen.yaml
@@ -84,7 +84,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -129,7 +129,7 @@ presubmits:
           value: /home/prow/go/src/istio.io/envoy
         - name: FILTER_WORKSPACE_SET
           value: "false"
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ presubmits:
             --flaky_test_attempts=9
         - name: ENVOY_SRCDIR
           value: /home/prow/go/src/istio.io/envoy
-        image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+        image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/envoy-1.10.yaml
+++ b/prow/config/jobs/envoy-1.10.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: envoy
 branches: [release-1.10]
-image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
 node_selector:
   testing: build-pool
 

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: envoy
 branches: [master]
-image: piotrsikora/envoy-build-ubuntu@sha256:e2775df4cf57e86920ca39886a877b4ccc12dbcfaa2a7c2a804f4cb83c797952
+image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
 node_selector:
   testing: build-pool
 


### PR DESCRIPTION
Per https://github.com/istio/test-infra/pull/3284/files#r615907514:

```
this should match version from .bazelrc file in Envoy repo for a given version.
```
This updates the Envoy 1.10 image to use the version from .bazelrc and synchronizes master with that as 1.10 was recently cut from master. 