### PR TITLE
temporary jobs for istiodless remotes

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -179,6 +179,76 @@ postsubmits:
       preset-override-deps: master-istio
       preset-override-envoy: "true"
       preset-use-go-control-plane-api-private: "true"
+    name: integ-telemetry-istiodless-mc-k8s-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.telemetry.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-distroless-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -447,6 +517,76 @@ postsubmits:
       preset-override-deps: master-istio
       preset-override-envoy: "true"
       preset-use-go-control-plane-api-private: "true"
+    name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
     name: integ-security-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -525,6 +665,76 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
+    name: integ-security-istiodless-multicluster-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.security.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
         image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
         name: ""
         resources:
@@ -1659,6 +1869,78 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
+    name: integ-telemetry-istiodless-mc-k8s-tests_istio_priv
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.telemetry.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1999,6 +2281,78 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
+    name: integ-pilot-istiodless-multicluster-tests_istio_priv
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2025,6 +2379,78 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+      preset-use-go-control-plane-api-private: "true"
+    name: integ-security-istiodless-multicluster-tests_istio_priv
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.security.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
         image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -199,6 +199,71 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-telemetry-istiodless-mc-k8s-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.telemetry.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-distroless-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -447,6 +512,71 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-security-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -520,6 +650,71 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-security-istiodless-multicluster-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.security.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
         image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
         name: ""
         resources:
@@ -1554,6 +1749,71 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-telemetry-istiodless-mc-k8s-tests_istio
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.telemetry.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1859,6 +2119,71 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-pilot-istiodless-multicluster-tests_istio
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.pilot.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1878,6 +2203,71 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-security-istiodless-multicluster-tests_istio
+    optional: true
+    path_alias: istio.io/istio
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - test.integration.security.kube
+        env:
+        - name: TEST_SELECT
+          value: -multicluster
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istiodlessRemotes
         image: gcr.io/istio-testing/build-tools:master-2021-04-12T17-40-14
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -76,6 +76,24 @@ jobs:
       - name: TEST_SELECT
         value: "-multicluster"
 
+  - name: integ-telemetry-istiodless-mc-k8s-tests
+    modifiers:
+      - optional
+      - hidden
+      - skipped
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - test.integration.telemetry.kube
+    requirements: [kind]
+    env:
+      - name: TEST_SELECT
+        value: "-multicluster"
+      - name: INTEGRATION_TEST_FLAGS
+        value: --istio.test.istiodlessRemotes
+
   - name: integ-multicluster-k8s-tests
     types: [presubmit]
     command:
@@ -137,6 +155,24 @@ jobs:
       - name: TEST_SELECT
         value: "-multicluster"
 
+  - name: integ-pilot-istiodless-multicluster-tests
+    modifiers:
+      - optional
+      - hidden
+      - skipped
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - test.integration.pilot.kube
+    requirements: [kind]
+    env:
+      - name: TEST_SELECT
+        value: "-multicluster"
+      - name: INTEGRATION_TEST_FLAGS
+        value: --istio.test.istiodlessRemotes
+
   - name: integ-security-k8s-tests
     types: [postsubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube]
@@ -156,6 +192,24 @@ jobs:
     env:
       - name: TEST_SELECT
         value: "-multicluster"
+
+  - name: integ-security-istiodless-multicluster-tests
+    modifiers:
+      - optional
+      - hidden
+      - skipped
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - test.integration.security.kube
+    requirements: [kind]
+    env:
+      - name: TEST_SELECT
+        value: "-multicluster"
+      - name: INTEGRATION_TEST_FLAGS
+        value: --istio.test.istiodlessRemotes
 
   - name: integ-telemetry-k8s-tests
     types: [postsubmit]


### PR DESCRIPTION
These jobs are likely broken (tested networking in https://github.com/istio/istio/pull/32601 and it fails for an unknown reason)

We should have a quick way to trigger these, but eventually we should change our main mc jobs to use this mode. 