### PR TITLE
Convert args to use equals instead of space

### DIFF
--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
@@ -23,8 +23,8 @@ presubmits:
       containers:
       - command:
         - ../test-infra/scripts/validate_schema.sh
-        - --document-path ./features.yaml
-        - --schema-path ./features_schema.yaml
+        - --document-path=./features.yaml
+        - --schema-path=./features_schema.yaml
         image: gcr.io/istio-testing/build-tools:master-2021-05-07T04-05-01
         name: ""
         resources:

--- a/prow/config/jobs/enhancements.yaml
+++ b/prow/config/jobs/enhancements.yaml
@@ -9,6 +9,6 @@ jobs:
   modifiers: [optional]
   command:
     - ../test-infra/scripts/validate_schema.sh
-    - --document-path ./features.yaml
-    - --schema-path ./features_schema.yaml
+    - --document-path=./features.yaml
+    - --schema-path=./features_schema.yaml
   repos: [istio/test-infra@master,istio/tools@master]


### PR DESCRIPTION
Running the enhancements job yields:
```
validate_schema.sh: unrecognized option '--document-path ./features.yaml'
validate_schema.sh: unrecognized option '--schema-path ./features_schema.yaml'

unable to parse options
```
Running it locally works fine without error.

Not sure if this is the problem, but I noticed that the prow script includes spaces between the arguments and their values. Automator and release notes both use an equals, which also works locally. Converting the job to use that. 
