### PR TITLE
Bump kubernetes versions used in tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1066,7 +1066,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.18.15
+        - kindest/node:v1.18.19
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1135,7 +1135,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.19.7
+        - kindest/node:v1.19.11
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1204,7 +1204,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.20.5
+        - gcr.io/istio-testing/kind-node:v1.20.7
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1273,7 +1273,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.22.0-alpha.0
+        - gcr.io/istio-testing/kind-node:v1.22.0-alpha.1
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -917,7 +917,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.18.15
+        - kindest/node:v1.18.19
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -987,7 +987,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.19.7
+        - kindest/node:v1.19.11
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1057,7 +1057,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.21.0
+        - gcr.io/istio-testing/kind-node:v1.21.1
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1021,7 +1021,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.18.15
+        - kindest/node:v1.18.19
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1085,7 +1085,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.19.7
+        - kindest/node:v1.19.11
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1149,7 +1149,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.20.5
+        - gcr.io/istio-testing/kind-node:v1.20.7
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1213,7 +1213,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.22.0-alpha.0
+        - gcr.io/istio-testing/kind-node:v1.22.0-alpha.1
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -826,7 +826,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.18.15
+        - kindest/node:v1.18.19
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -890,7 +890,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - kindest/node:v1.19.7
+        - kindest/node:v1.19.11
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -954,7 +954,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.21.0
+        - gcr.io/istio-testing/kind-node:v1.21.1
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -340,7 +340,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - kindest/node:v1.18.15
+  - kindest/node:v1.18.19
   - test.integration.kube.presubmit
   env:
   - name: INTEGRATION_TEST_FLAGS
@@ -359,7 +359,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - kindest/node:v1.19.7
+  - kindest/node:v1.19.11
   - test.integration.kube.presubmit
   env:
   - name: INTEGRATION_TEST_FLAGS
@@ -378,7 +378,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - gcr.io/istio-testing/kind-node:v1.21.0
+  - gcr.io/istio-testing/kind-node:v1.21.1
   - test.integration.kube.presubmit
   env:
   - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -262,7 +262,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.18.15
+      - kindest/node:v1.18.19
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -276,7 +276,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - kindest/node:v1.19.7
+      - kindest/node:v1.19.11
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -290,7 +290,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.20.5
+      - gcr.io/istio-testing/kind-node:v1.20.7
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -304,7 +304,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.22.0-alpha.0
+      - gcr.io/istio-testing/kind-node:v1.22.0-alpha.1
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
put a hold on to minimize variables to analyze the flakes