### PR TITLE
fix authentikos integ test

### DIFF
--- a/authentikos/test/integ-simple.sh
+++ b/authentikos/test/integ-simple.sh
@@ -38,26 +38,26 @@ run_test() {
   local tokeninfo="$1"
 
   echo "Test 'error' is null"
-  echo "$tokeninfo" | jq -r '.error' | xargs -r -I% test % = "null"
+  test "$(echo "$tokeninfo" | jq -r '.error')" = "null"
 
   echo "Test 'issued_to' exists"
-  echo "$tokeninfo" | jq -r '.issued_to' | xargs -r test -n
+  test -n "$(echo "$tokeninfo" | jq -r '.issued_to')"
 
   echo "Test 'audience' exists"
-  echo "$tokeninfo" | jq -r '.audience' | xargs -r test -n
+  test -n "$(echo "$tokeninfo" | jq -r '.audience')"
 
   echo "Test 'user_id' exists"
-  echo "$tokeninfo" | jq -r '.user_id' | xargs -r test -n
+  test -n "$(echo "$tokeninfo" | jq -r '.user_id')"
 
   echo "Test 'email' exists"
-  echo "$tokeninfo" | jq -r '.email' | xargs -r test -n
+  test -n "$(echo "$tokeninfo" | jq -r '.email')"
 
   echo "Test 'expires_in' greater than 0"
-  echo "$tokeninfo" | jq -r '.expires_in' | xargs -r -I% test % -lt 0
+  test "$(echo "$tokeninfo" | jq -r '.expires_in')" -gt 0
 
   echo "Test 'scope' includes 'userinfo.email', 'cloud-platform', and 'openid'"
   echo "$tokeninfo" | jq -r '.scope' |
-    grep -w "openi" |
+    grep -w "openid" |
     grep -w "https://www.googleapis.com/auth/cloud-platform" |
     grep -w "https://www.googleapis.com/auth/userinfo.email" >/dev/null
 }
@@ -68,6 +68,7 @@ main() {
   kubectl wait deployment authentikos --for="condition=available" --timeout="$timout"
 
   run_test "$(with_timeout get_tokeninfo "$timout")"
+  kubectl logs -l app=authentikos
 }
 
 main


### PR DESCRIPTION
Fixes towards https://github.com/istio/test-infra/issues/3309. AFACT, this will not resolve the issue with the secret not being created: 

`"Error from server (NotFound): secrets "authentikos-token" not found"` ([e.g.](https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_test-infra/3342/integ-test-authentikos_test-infra/1396039731891933184/build-log.txt)). 

I presume the cause is some state change in the cluster no longer working with the test setup/execution. Possibly an issue with `GOOGLE_APPLICATION_CREDENTIALS`?

https://github.com/istio/test-infra/blob/784193f780e93c8ac32d3b8e05cced0af0350073/authentikos/test/integ-simple.sh#L66

I added a log line after the test concludes for more visibility and debugability.