### PR TITLE
Isolate multicluster jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -131,7 +131,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -201,7 +201,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -469,7 +469,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -539,7 +539,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -671,7 +671,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -741,7 +741,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1832,7 +1832,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1904,7 +1904,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1972,7 +1972,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2244,7 +2244,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2316,7 +2316,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2384,7 +2384,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2456,7 +2456,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -156,7 +156,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -221,7 +221,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -469,7 +469,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -534,7 +534,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -656,7 +656,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -721,7 +721,7 @@ postsubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1712,7 +1712,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1777,7 +1777,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1838,7 +1838,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2082,7 +2082,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2147,7 +2147,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2208,7 +2208,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2273,7 +2273,7 @@ presubmits:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -72,6 +72,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.telemetry.kube
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -88,6 +89,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.telemetry.kube
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -103,6 +105,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.multicluster.kube.presubmit
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-postsubmit,-flaky,+multicluster"
@@ -151,6 +154,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.pilot.kube
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -167,6 +171,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.pilot.kube
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -189,6 +194,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.security.kube
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -205,6 +211,7 @@ jobs:
       - MULTICLUSTER
       - test.integration.security.kube
     requirements: [kind]
+    resources: multicluster
     env:
       - name: TEST_SELECT
         value: "-multicluster"
@@ -349,6 +356,16 @@ resources:
     requests:
       memory: "3Gi"
       cpu: "5000m"
+    limits:
+      memory: "24Gi"
+  # TODO: this was set while investigating https://github.com/istio/istio/issues/32985
+  # We should consider if this is needed long term, as its expensive
+  multicluster:
+    requests:
+      memory: "3Gi"
+      # This ensures we have at most one multicluster job on a node
+      # Nodes have 16CPUs, with some overhead
+      cpu: "8000m"
     limits:
       memory: "24Gi"
   lint:


### PR DESCRIPTION
I have seen cases where we have 3 multicluster jobs on a node, so 9 k8s.
The node ends up pinned at 100% cpu the whole time which may be causing
flakes.

With this change, we can get the following arangements of jobs:
* 3 non-mc jobs (unchanged)
* 1 mc job and 1 non-mc job