### PR TITLE
Update master istio.io automated job to use master istio repo.

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -80,7 +80,7 @@ periodics:
       - '--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference'
       - --labels=release-notes-none
       - --token-path=/etc/github-token/oauth
-      - --cmd=go get istio.io/istio@release-1.10 && go mod tidy
+      - --cmd=go get istio.io/istio@master && go mod tidy
       image: gcr.io/istio-testing/build-tools:master-2021-05-07T04-05-01
       name: ""
       resources:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -71,7 +71,7 @@ jobs:
     - "--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference"
     - --labels=release-notes-none
     - --token-path=/etc/github-token/oauth
-    - --cmd=go get istio.io/istio@release-1.10 && go mod tidy
+    - --cmd=go get istio.io/istio@master && go mod tidy
     requirements: [github]
     repos: [istio/test-infra@master]
 


### PR DESCRIPTION
Fixes failure noted in job last week. Need to update istio.io docs to point to update the job, or rework job to use make file which already has the update release to use. Follow-on PR(s) for that coming soon.