### PR TITLE
Revert "Skip release test"

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1438,7 +1438,7 @@ presubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -1453,7 +1453,6 @@ presubmits:
       preset-service-account: "true"
       preset-use-go-control-plane-api-private: "true"
     name: release-test_istio_priv
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1562,7 +1562,7 @@ presubmits:
           path: /tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:
@@ -1571,7 +1571,6 @@ presubmits:
     labels:
       preset-service-account: "true"
     name: release-test_istio
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -6,10 +6,8 @@ jobs:
   - name: unit-tests
     command: [entrypoint, make, -e, "T=-v -count=1", build, racetest, binaries-test]
 
-  # TODO(https://github.com/istio/istio/issues/32985) make this required again
   - name: release-test
     types: [presubmit]
-    modifiers: [optional, skipped]
     command: [entrypoint, prow/release-test.sh]
     requirements: [gcp, docker]
 


### PR DESCRIPTION
Reverts istio/test-infra#3352

Tests are still failing just as much, I think it was just a coincidence that we saw correlation before