### PR TITLE
Disable go cache

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -40,9 +40,6 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -90,9 +87,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -147,9 +141,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -217,9 +208,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -284,9 +272,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -353,9 +338,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -418,9 +400,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -485,9 +464,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -555,9 +531,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -620,9 +593,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -687,9 +657,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -757,9 +724,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -822,9 +786,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -884,9 +845,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -953,9 +911,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1024,9 +979,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1093,9 +1045,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1162,9 +1111,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1231,9 +1177,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1300,9 +1243,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1367,9 +1307,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1428,9 +1365,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1475,9 +1409,6 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1523,9 +1454,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1579,9 +1507,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1648,9 +1573,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1714,9 +1636,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1780,9 +1699,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1848,9 +1764,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1920,9 +1833,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1988,9 +1898,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2056,9 +1963,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2126,9 +2030,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2192,9 +2093,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2260,9 +2158,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2332,9 +2227,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2400,9 +2292,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2472,9 +2361,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2535,9 +2421,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2589,9 +2472,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2633,9 +2513,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2677,9 +2554,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2735,9 +2609,6 @@ presubmits:
         - mountPath: /etc/github-token
           name: github
           readOnly: true
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -41,9 +41,6 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -92,9 +89,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -139,9 +133,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -197,9 +188,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -265,9 +253,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -335,9 +320,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -401,9 +383,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -469,9 +448,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -535,9 +511,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -603,9 +576,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -669,9 +639,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -732,9 +699,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -802,9 +766,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -872,9 +833,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -944,9 +902,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1014,9 +969,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1084,9 +1036,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1146,9 +1095,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1194,9 +1140,6 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1243,9 +1186,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1300,9 +1240,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1367,9 +1304,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1434,9 +1368,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1504,9 +1435,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1573,9 +1501,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1642,9 +1567,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1713,9 +1635,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1780,9 +1699,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1849,9 +1765,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1919,9 +1832,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1983,9 +1893,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2038,9 +1945,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2083,9 +1987,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2128,9 +2029,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -45,9 +45,6 @@ periodics:
         readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
-      - mountPath: /gocache
-        name: build-cache
-        subPath: gocache
     nodeSelector:
       testing: test-pool
     volumes:
@@ -110,9 +107,6 @@ periodics:
         readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
-      - mountPath: /gocache
-        name: build-cache
-        subPath: gocache
     nodeSelector:
       testing: test-pool-n2
     volumes:
@@ -175,9 +169,6 @@ periodics:
         readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
-      - mountPath: /gocache
-        name: build-cache
-        subPath: gocache
     nodeSelector:
       testing: test-pool-e2
     volumes:
@@ -230,9 +221,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -272,9 +260,6 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -316,9 +301,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -368,9 +350,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -433,9 +412,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -495,9 +471,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -559,9 +532,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -619,9 +589,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -681,9 +648,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -746,9 +710,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -806,9 +767,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -868,9 +826,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -933,9 +888,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -993,9 +945,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1050,9 +999,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1114,9 +1060,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1180,9 +1123,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1244,9 +1184,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1308,9 +1245,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1372,9 +1306,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1436,9 +1367,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1498,9 +1426,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1552,9 +1477,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1593,9 +1515,6 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1634,9 +1553,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1683,9 +1599,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1745,9 +1658,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1804,9 +1714,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1863,9 +1770,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1924,9 +1828,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1989,9 +1890,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2050,9 +1948,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2111,9 +2006,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2174,9 +2066,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2233,9 +2122,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2294,9 +2180,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2359,9 +2242,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2420,9 +2300,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2485,9 +2362,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2541,9 +2415,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2588,9 +2459,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2625,9 +2493,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2662,9 +2527,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -2711,9 +2573,6 @@ presubmits:
         - mountPath: /etc/github-token
           name: github
           readOnly: true
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -34,9 +34,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -76,9 +73,6 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -120,9 +114,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -172,9 +163,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -234,9 +222,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -298,9 +283,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -358,9 +340,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -420,9 +399,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -480,9 +456,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -542,9 +515,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -602,9 +572,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -659,9 +626,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -723,9 +687,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -787,9 +748,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -853,9 +811,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -917,9 +872,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -981,9 +933,6 @@ postsubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1035,9 +984,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1076,9 +1022,6 @@ presubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1117,9 +1060,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1166,9 +1106,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1225,9 +1162,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1284,9 +1218,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1346,9 +1277,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1407,9 +1335,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1468,9 +1393,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1531,9 +1453,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1590,9 +1509,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1651,9 +1567,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1713,9 +1626,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1769,9 +1679,6 @@ presubmits:
           readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1816,9 +1723,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1853,9 +1757,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1890,9 +1791,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:
@@ -1939,9 +1837,6 @@ presubmits:
         - mountPath: /etc/github-token
           name: github
           readOnly: true
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
       nodeSelector:
         testing: test-pool
       volumes:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -530,8 +530,8 @@ requirement_presets:
       preset-release-pipeline: "true"
     volumeMounts: null
     volumes: null
-requirements:
-- gocache
+# https://github.com/istio/istio/issues/32985
+# requirements: [gocache]
 resources:
   benchmark:
     limits:

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -331,8 +331,8 @@ jobs:
   - presubmit
 org: istio
 repo: istio
-requirements:
-- gocache
+# https://github.com/istio/istio/issues/32985
+# requirements: [gocache]
 resources:
   benchmark:
     limits:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -436,4 +436,5 @@ resources:
       cpu: "15000m"
     limits:
       memory: "24Gi"
-requirements: [gocache]
+# https://github.com/istio/istio/issues/32985
+# requirements: [gocache]


### PR DESCRIPTION
Wild attempt...

I did see in the logs of one node "device is unavailable" for build
cache, and it is something that is persistent on nodes, so it seems
*plausibly* related. We will revert if not