### PR TITLE
Pin IPv6 jobs to ubuntu nodes

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -339,6 +339,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:
@@ -2031,6 +2032,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -339,6 +339,7 @@ postsubmits:
           name: build-cache
           subPath: gocache
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:
@@ -1716,6 +1717,7 @@ presubmits:
           name: build-cache
           subPath: gocache
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -321,6 +321,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:
@@ -1636,6 +1637,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -533,6 +533,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:
@@ -2067,6 +2068,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -302,6 +302,7 @@ postsubmits:
           name: build-cache
           subPath: gocache
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:
@@ -1534,6 +1535,7 @@ presubmits:
           name: build-cache
           subPath: gocache
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -284,6 +284,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:
@@ -1454,6 +1455,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-os-distribution: ubuntu
         testing: test-pool
       volumes:
       - hostPath:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -182,6 +182,11 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
+  node_selector:
+    # COS does not currently support IPv6
+    # Consider moving all nodes back to COS after https://github.com/istio/istio/issues/32985
+    testing: test-pool
+    cloud.google.com/gke-os-distribution: ubuntu
   name: integ-ipv6-k8s-tests
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -188,8 +188,6 @@ jobs:
     testing: test-pool
     cloud.google.com/gke-os-distribution: ubuntu
   name: integ-ipv6-k8s-tests
-  node_selector:
-    testing: test-pool
   requirements:
   - cache
   - kind

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -138,6 +138,11 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
+  node_selector:
+    # COS does not currently support IPv6
+    # Consider moving all nodes back to COS after https://github.com/istio/istio/issues/32985
+    testing: test-pool
+    cloud.google.com/gke-os-distribution: ubuntu
   name: integ-ipv6-k8s-tests
   requirements:
   - kind

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -177,6 +177,11 @@ jobs:
   - name: integ-ipv6-k8s-tests
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.reachability]
     requirements: [kind]
+    node_selector:
+      # COS does not currently support IPv6
+      # Consider moving all nodes back to COS after https://github.com/istio/istio/issues/32985
+      testing: test-pool
+      cloud.google.com/gke-os-distribution: ubuntu
     env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"


### PR DESCRIPTION
This will allow us to add COS nodes without breaking ipv6