### PR TITLE
Fix gogo-gen automator job - update repo name

### DIFF
--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
@@ -135,7 +135,7 @@ postsubmits:
         - --modifier=update_gogo-genproto_dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=common
-        - --cmd=go get istio.io/gogo_genproto@$AUTOMATOR_SHA && go mod tidy && make
+        - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make
           clean gen
         image: gcr.io/istio-testing/build-tools:master-2021-06-16T23-16-54
         name: ""

--- a/prow/config/jobs/gogo-genproto.yaml
+++ b/prow/config/jobs/gogo-genproto.yaml
@@ -24,6 +24,6 @@ jobs:
     - --modifier=update_gogo-genproto_dep
     - --token-path=/etc/github-token/oauth
     - --git-exclude=common
-    - --cmd=go get istio.io/gogo_genproto@$AUTOMATOR_SHA && go mod tidy && make clean gen
+    - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]


### PR DESCRIPTION
Test has repeatedly failed: https://prow.istio.io/job-history/gs/istio-prow/logs/update_gogo-genproto_dep_gogo-genproto_postsubmit

Wrong repo name (had _ instead of -).