### PR TITLE
Explicitly define slack report config in each job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -178,6 +178,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-istiodless-mc-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -511,6 +513,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -710,6 +714,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-security-istiodless-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1854,6 +1860,8 @@ presubmits:
     name: integ-telemetry-istiodless-mc-k8s-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -2260,6 +2268,8 @@ presubmits:
     name: integ-pilot-istiodless-multicluster-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -2398,6 +2408,8 @@ presubmits:
     name: integ-security-istiodless-multicluster-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
@@ -468,6 +468,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster-tests_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -855,6 +857,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: install-cni-test_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1615,6 +1619,8 @@ presubmits:
     name: integ-pilot-multicluster-tests_istio_release-1.7_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1682,6 +1688,8 @@ presubmits:
     name: install-cni-test_istio_release-1.7_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -496,6 +496,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1103,6 +1105,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-k8s-120_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1171,6 +1175,8 @@ postsubmits:
       preset-override-envoy: "true"
     name: install-cni-test_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1975,6 +1981,8 @@ presubmits:
     name: integ-external-istiod-mc-tests_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -2179,6 +2187,8 @@ presubmits:
     name: install-cni-test_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -201,6 +201,8 @@ postsubmits:
     decorate: true
     name: integ-telemetry-istiodless-mc-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -514,6 +516,8 @@ postsubmits:
     decorate: true
     name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -701,6 +705,8 @@ postsubmits:
     decorate: true
     name: integ-security-istiodless-multicluster-tests_istio_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1756,6 +1762,8 @@ presubmits:
     name: integ-telemetry-istiodless-mc-k8s-tests_istio
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -2126,6 +2134,8 @@ presubmits:
     name: integ-pilot-istiodless-multicluster-tests_istio
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -2252,6 +2262,8 @@ presubmits:
     name: integ-security-istiodless-multicluster-tests_istio
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -421,6 +421,8 @@ postsubmits:
     decorate: true
     name: integ-pilot-multicluster-tests_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -778,6 +780,8 @@ postsubmits:
     decorate: true
     name: install-cni-test_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1448,6 +1452,8 @@ presubmits:
     name: integ-pilot-multicluster-tests_istio_release-1.7
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1508,6 +1514,8 @@ presubmits:
     name: install-cni-test_istio_release-1.7
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -449,6 +449,8 @@ postsubmits:
     decorate: true
     name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1011,6 +1013,8 @@ postsubmits:
       timeout: 4h0m0s
     name: integ-k8s-120_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1074,6 +1078,8 @@ postsubmits:
     decorate: true
     name: install-cni-test_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1788,6 +1794,8 @@ presubmits:
     name: integ-external-istiod-mc-tests_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1971,6 +1979,8 @@ presubmits:
     name: install-cni-test_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
+    reporter_config:
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -726,6 +726,11 @@ func applyModifiersPresubmit(presubmit *config.Presubmit, jobModifiers []string)
 			presubmit.Optional = true
 		} else if modifier == ModifierHidden {
 			presubmit.SkipReport = true
+			presubmit.ReporterConfig = &prowjob.ReporterConfig{
+				Slack: &prowjob.SlackReporterConfig{
+					JobStatesToReport: []prowjob.ProwJobState{},
+				},
+			}
 		} else if modifier == ModifierSkipped {
 			presubmit.AlwaysRun = false
 		}
@@ -738,6 +743,11 @@ func applyModifiersPostsubmit(postsubmit *config.Postsubmit, jobModifiers []stri
 			// Does not exist on postsubmit
 		} else if modifier == ModifierHidden {
 			postsubmit.SkipReport = true
+			postsubmit.ReporterConfig = &prowjob.ReporterConfig{
+				Slack: &prowjob.SlackReporterConfig{
+					JobStatesToReport: []prowjob.ProwJobState{},
+				},
+			}
 		}
 		// Cannot skip a postsubmit; instead just make `type: presubmit`
 	}


### PR DESCRIPTION
Since https://github.com/kubernetes/test-infra/pull/22486, prow has "fixed" the usage of `skip_report` to only work for reporting back to CI systems. This PR:
- removed global slack configs
- define slack report in individual jobs instead

Recommended files to review:
- prow/config.yaml
- prow/config/generate.go
- prow/config/istio-private_jobs/.defaults.yaml
- prow/config/jobs/.global.yaml