### PR TITLE
Revert "Automator: update build-tools:master"

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -1,5 +1,5 @@
 istio_container_with_kind: &istio_container_with_kind
-  image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+  image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
   securityContext:
     privileged: true
   resources:
@@ -11,7 +11,7 @@ istio_container_with_kind: &istio_container_with_kind
       cpu: "3000m"
 
 istio_container_with_kind_mounts: &istio_container_with_kind_mounts
-  image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+  image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
   securityContext:
     privileged: true
   resources:

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -57,7 +57,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ presubmits:
         env:
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ presubmits:
         env:
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -312,7 +312,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -387,7 +387,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -499,7 +499,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -557,7 +557,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -24,7 +24,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -75,7 +75,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -192,7 +192,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -258,7 +258,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -326,7 +326,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -390,7 +390,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -456,7 +456,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -525,7 +525,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -589,7 +589,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -655,7 +655,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -724,7 +724,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -788,7 +788,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -849,7 +849,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -917,7 +917,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -987,7 +987,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1055,7 +1055,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1123,7 +1123,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1191,7 +1191,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1259,7 +1259,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1325,7 +1325,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1393,7 +1393,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1437,7 +1437,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1486,7 +1486,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1533,7 +1533,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1600,7 +1600,7 @@ presubmits:
           value: -postsubmit,-flaky,-multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1665,7 +1665,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1730,7 +1730,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1797,7 +1797,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1868,7 +1868,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1935,7 +1935,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2002,7 +2002,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2071,7 +2071,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2136,7 +2136,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2203,7 +2203,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2274,7 +2274,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2341,7 +2341,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2412,7 +2412,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2474,7 +2474,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2535,7 +2535,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2578,7 +2578,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2621,7 +2621,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2675,7 +2675,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -32,7 +32,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-centos:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -301,7 +301,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy
-        image: gcr.io/istio-testing/build-tools-centos:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-centos:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/envoyproxy/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -134,7 +134,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -184,7 +184,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -221,7 +221,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -258,7 +258,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -301,7 +301,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -177,7 +177,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -222,7 +222,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
             secretKeyRef:
               key: githubOauthClientSecret
               name: policybot
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -242,7 +242,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -312,7 +312,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -347,7 +347,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         - --git-exclude=common
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean
           gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -171,7 +171,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -229,7 +229,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -272,7 +272,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -14,7 +14,7 @@ postsubmits:
       containers:
       - command:
         - prow/community-lint.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -50,7 +50,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -86,7 +86,7 @@ postsubmits:
       - command:
         - sh
         - prow/sync-org.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ presubmits:
       containers:
       - command:
         - prow/community-lint.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
@@ -25,7 +25,7 @@ presubmits:
         - ../test-infra/scripts/validate_schema.sh
         - --document-path=./features.yaml
         - --schema-path=./features_schema.json
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=update_envoy_dep
       - --token-path=/etc/github-token/oauth
       - --cmd=scripts/update_envoy.sh $AUTOMATOR_SHA $AUTOMATOR_SHA_COMMIT_DATE
-      image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+      image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
       name: ""
       resources:
         limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         - --git-exclude=common
         - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make
           clean gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -27,7 +27,7 @@ periodics:
       - --modifier=refdocs
       - --token-path=/etc/github-token/oauth
       - --cmd=make update_ref_docs
-      image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+      image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
       name: ""
       resources:
         limits:
@@ -81,7 +81,7 @@ periodics:
       - --labels=release-notes-none
       - --token-path=/etc/github-token/oauth
       - --cmd=go get istio.io/istio@master && go mod tidy
-      image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+      image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
       name: ""
       resources:
         limits:
@@ -125,7 +125,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -161,7 +161,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -253,7 +253,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -308,7 +308,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -365,7 +365,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -420,7 +420,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -455,7 +455,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -491,7 +491,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -545,7 +545,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -599,7 +599,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -655,7 +655,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -718,7 +718,7 @@ presubmits:
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -106,7 +106,7 @@ postsubmits:
         - make
         - benchtest
         - report-benchtest
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -341,7 +341,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -401,7 +401,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -463,7 +463,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -528,7 +528,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -588,7 +588,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -650,7 +650,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -715,7 +715,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -775,7 +775,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -832,7 +832,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -896,7 +896,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -962,7 +962,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1026,7 +1026,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1090,7 +1090,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1154,7 +1154,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1218,7 +1218,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1280,7 +1280,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1342,7 +1342,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1381,7 +1381,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1424,7 +1424,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1465,7 +1465,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1526,7 +1526,7 @@ presubmits:
           value: -postsubmit,-flaky,-multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1585,7 +1585,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1644,7 +1644,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1705,7 +1705,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1770,7 +1770,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1831,7 +1831,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1892,7 +1892,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -1955,7 +1955,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2014,7 +2014,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2075,7 +2075,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2140,7 +2140,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2201,7 +2201,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2266,7 +2266,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2322,7 +2322,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2377,7 +2377,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2414,7 +2414,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2451,7 +2451,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -2497,7 +2497,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=common
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -320,7 +320,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -62,7 +62,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-centos:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -111,7 +111,7 @@ postsubmits:
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -157,7 +157,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -233,7 +233,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -309,7 +309,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-centos:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -219,7 +219,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -260,7 +260,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -295,7 +295,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -330,7 +330,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -368,7 +368,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -408,7 +408,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -444,7 +444,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --image=gcr.io/k8s-prow/.*
       - --tag=v[0-9]{8}-[a-f0-9]{10}
       - --var=image
-      image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+      image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
       name: ""
       resources:
         limits:
@@ -73,7 +73,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -109,7 +109,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ postsubmits:
         - deploy-monitoring
         - deploy-build
         - deploy-private
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -247,7 +247,7 @@ postsubmits:
         - -C
         - boskos
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -290,7 +290,7 @@ postsubmits:
         - -C
         - boskos
         - boskos-config
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -333,7 +333,7 @@ postsubmits:
         - -C
         - boskos
         - mason-image
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -382,7 +382,7 @@ postsubmits:
         - docker/prowbazel
         - image
         - push-safe
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -430,7 +430,7 @@ postsubmits:
         - -C
         - authentikos
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -478,7 +478,7 @@ postsubmits:
         - -C
         - prow/genjobs
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -519,7 +519,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -554,7 +554,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -589,7 +589,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -627,7 +627,7 @@ presubmits:
         - -C
         - authentikos
         - unit-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -668,7 +668,7 @@ presubmits:
         - -C
         - authentikos
         - integ-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -209,7 +209,7 @@ postsubmits:
         - -C
         - perf_dashboard
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -320,7 +320,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -397,7 +397,7 @@ presubmits:
         env:
         - name: TRIALRUN
           value: "True"
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:
@@ -436,7 +436,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+        image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: api
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: bots
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: client-go
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -1,7 +1,7 @@
 org: istio
 support_release_branching: true
 repo: common-files
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: lint

--- a/prow/config/jobs/community.yaml
+++ b/prow/config/jobs/community.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: community
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: lint

--- a/prow/config/jobs/cri.yaml
+++ b/prow/config/jobs/cri.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: cri
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build

--- a/prow/config/jobs/enhancements.yaml
+++ b/prow/config/jobs/enhancements.yaml
@@ -2,7 +2,7 @@ org: istio
 repo: enhancements
 branches: [master]
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 jobs:
 - name: validate-features
   types: [presubmit]

--- a/prow/config/jobs/envoy.yaml
+++ b/prow/config/jobs/envoy.yaml
@@ -52,7 +52,7 @@ jobs:
   - --cmd=scripts/update_envoy.sh $AUTOMATOR_SHA $AUTOMATOR_SHA_COMMIT_DATE
   requirements: [github]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+  image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
   timeout: 4h
 
 resources:

--- a/prow/config/jobs/gogo-genproto.yaml
+++ b/prow/config/jobs/gogo-genproto.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: gogo-genproto
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio.io
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: lint

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 jobs:
   - name: unit-tests
     command: [entrypoint, make, -e, "T=-v -count=1", build, racetest, binaries-test]

--- a/prow/config/jobs/pkg.yaml
+++ b/prow/config/jobs/pkg.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: pkg
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: proxy
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools-proxy:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools-proxy:master-2021-06-28T18-08-04
 node_selector:
   testing: build-pool
 
@@ -34,7 +34,7 @@ jobs:
   types: [presubmit]
   command: [./prow/proxy-presubmit-centos-release.sh]
   requirements: [gcp]
-  image: gcr.io/istio-testing/build-tools-centos:master-2021-07-01T20-30-56
+  image: gcr.io/istio-testing/build-tools-centos:master-2021-06-28T18-08-04
   timeout: 4h
 
 - name: check-wasm
@@ -53,7 +53,7 @@ jobs:
   types: [postsubmit]
   command: [./prow/proxy-postsubmit-centos.sh]
   requirements: [gcp]
-  image: gcr.io/istio-testing/build-tools-centos:master-2021-07-01T20-30-56
+  image: gcr.io/istio-testing/build-tools-centos:master-2021-06-28T18-08-04
   timeout: 4h
 
 - name: update-istio
@@ -69,7 +69,7 @@ jobs:
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
   requirements: [github]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+  image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
   timeout: 4h
 
 resources:

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: release-builder
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: lint

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: test-infra
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: lint

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: tools
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-2021-07-01T20-30-56
+image: gcr.io/istio-testing/build-tools:master-2021-06-28T18-08-04
 
 jobs:
   - name: build


### PR DESCRIPTION
Reverts istio/test-infra#3414

This caused a regression due to removing `buf`: https://github.com/istio/tools/commit/acd500e45a456c525fdad500c4b0986e33a53914#diff-e745cd0a09abcac8d5a5871665f5c3be19ccb570a71a603b302d7655ed51f9a2L226

Will forward fix later, need to unblock api repo for now