### PR TITLE
Update automator exclude check to exclude files in PR causing event

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -139,6 +139,7 @@ postsubmits:
         - --labels=auto-merge,release-notes-none
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
+        - --git-exclude=^common/
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -98,6 +98,7 @@ postsubmits:
         - --labels=auto-merge,release-notes-none
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
+        - --git-exclude=^common/
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
         image: gcr.io/istio-testing/build-tools:master-2021-07-06T15-41-58
         name: ""

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -134,7 +134,7 @@ postsubmits:
         - --labels=auto-merge,release-notes-none
         - --modifier=update_client-go_dep
         - --token-path=/etc/github-token/oauth
-        - --git-exclude=common
+        - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean
           gen
         image: gcr.io/istio-testing/build-tools:master-2021-07-06T15-41-58

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
@@ -134,7 +134,7 @@ postsubmits:
         - --labels=auto-merge,release-notes-none
         - --modifier=update_gogo-genproto_dep
         - --token-path=/etc/github-token/oauth
-        - --git-exclude=common
+        - --git-exclude=^common/
         - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make
           clean gen
         image: gcr.io/istio-testing/build-tools:master-2021-07-06T15-41-58

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -170,7 +170,7 @@ postsubmits:
         - --labels=auto-merge,release-notes-none
         - --modifier=update_pkg_dep
         - --token-path=/etc/github-token/oauth
-        - --git-exclude=common
+        - --git-exclude=^common/
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
         image: gcr.io/istio-testing/build-tools:master-2021-07-06T15-41-58
         name: ""

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -110,6 +110,7 @@ postsubmits:
         - --labels=auto-merge,release-notes-none
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
+        - --git-exclude=^common/
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
         image: gcr.io/istio-testing/build-tools:master-2021-07-06T15-41-58
         name: ""

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -20,6 +20,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_api_dep
     - --token-path=/etc/github-token/oauth
+    - --git-exclude=^common/
     - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -23,7 +23,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_client-go_dep
     - --token-path=/etc/github-token/oauth
-    - --git-exclude=common
+    - --git-exclude=^common/
     - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]

--- a/prow/config/jobs/gogo-genproto.yaml
+++ b/prow/config/jobs/gogo-genproto.yaml
@@ -23,7 +23,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_gogo-genproto_dep
     - --token-path=/etc/github-token/oauth
-    - --git-exclude=common
+    - --git-exclude=^common/
     - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]

--- a/prow/config/jobs/pkg.yaml
+++ b/prow/config/jobs/pkg.yaml
@@ -26,7 +26,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_pkg_dep
     - --token-path=/etc/github-token/oauth
-    - --git-exclude=common
+    - --git-exclude=^common/
     - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -66,6 +66,7 @@ jobs:
   - --labels=auto-merge,release-notes-none
   - --modifier=update_proxy_dep
   - --token-path=/etc/github-token/oauth
+  - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
   requirements: [github]
   repos: [istio/test-infra@master]

--- a/tools/automator/README.md
+++ b/tools/automator/README.md
@@ -57,7 +57,7 @@ The following is a list of supported options for `automator.sh`. If an option is
 | `--verbose`     |            | Enable verbose output. Print commands and their arguments as they are executed. **WARNING**: this has the potential to print sensitive data to standard output.                                                                                             |                                                                                                 |
 | `--strict`      |            | Enable strict mode. When enabled, if the command does not produce a [git diff] it will exit with a non-zero exit code.                                                                                                                                      |                                                                                                 |
 | `--dry-run`     |            | Enable dry run mode. When enabled, the command will terminate early and **NOT** perform a commit, push, or pull request for any changes. This is useful for local testing/debugging or when concerned only with the [git diff] or exit code of the command. |                                                                                                 |
-| `--git-exclude` | string | Applied to list of file changes in the PR CAUSING this automator run using grep -vE '\<string\>'. If no additional changes remain, the automator task will stop. | `^common/`<br> `^pkg/\|^pilot/`|
+| `--git-exclude` | string | Applied to list of file changes in the commit CAUSING this automator run using grep -vE '\<string\>'. If no additional changes remain, the automator task will stop. | `^common/`<br> `^pkg/\|^pilot/`|
 
 ### Environment Variables
 

--- a/tools/automator/README.md
+++ b/tools/automator/README.md
@@ -57,7 +57,7 @@ The following is a list of supported options for `automator.sh`. If an option is
 | `--verbose`     |            | Enable verbose output. Print commands and their arguments as they are executed. **WARNING**: this has the potential to print sensitive data to standard output.                                                                                             |                                                                                                 |
 | `--strict`      |            | Enable strict mode. When enabled, if the command does not produce a [git diff] it will exit with a non-zero exit code.                                                                                                                                      |                                                                                                 |
 | `--dry-run`     |            | Enable dry run mode. When enabled, the command will terminate early and **NOT** perform a commit, push, or pull request for any changes. This is useful for local testing/debugging or when concerned only with the [git diff] or exit code of the command. |                                                                                                 |
-| `--git-exclude` | string | Added to `git diff` to exclude a file/path when detrining changes | `common` |
+| `--git-exclude` | string | Applied to list of file changes in the PR CAUSING this automator run using grep -vE '\<string\>'. If no additional changes remain, the automator task will stop. | `^common/`<br> `^pkg/\|^pilot/`|
 
 ### Environment Variables
 

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -278,10 +278,7 @@ merge() {
 
 validate_changes_exist_in_prior_pr() {
   if [ -n "$git_exclude" ]; then
-    repo0=$(echo $repos | cut -d' ' -f1)  #just use first repo if multiple specified
-    pr="$(curl -sSfLH "Accept: application/vnd.github.groot-preview+json" "https://api.github.com/repos/$org/${repo0}/commits/$sha/pulls" | jq ".[0].number")"
-    export GITHUB_TOKEN="$token"
-    changes=$(gh pr view "$pr" --repo "$org"/"$repo0" --json files | jq -r '.files[].path' | grep -cvE "$git_exclude")
+    changes=$(git show --name-only --pretty=oneline | sed 1d | grep -cvE "$git_exclude") # need to remove first line
     if [ "${changes}" -eq 0 ]
     then
       print_error_and_exit "No changes remaining in upstream PR after excluding" 0  # not really an error so return 0

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -194,6 +194,10 @@ validate_opts() {
   if [ -z "${email:-}" ] && ! $dry_run; then
     email="$(curl -sSfLH "Authorization: token $token" "https://api.github.com/user" | jq --raw-output ".email")"
   fi
+
+  if [ -z "${git_exclude:-}" ]; then
+    git_exclude=""
+  fi
 }
 
 evaluate_opts() {

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -280,7 +280,9 @@ merge() {
   fi
 }
 
-validate_changes_exist_in_prior_pr() {
+# validate_changes_exist_in_latest_commit validates changes exist in the prior commit after removing files specified
+# in the git_exclude list. If no files remain after exclusion, the automation script exits.
+validate_changes_exist_in_latest_commit() {
   if [ -n "$git_exclude" ]; then
     changes=$(git show --name-only --pretty=oneline | sed 1d | grep -cvE "$git_exclude") # need to remove first line
     if [ "${changes}" -eq 0 ]
@@ -333,7 +335,7 @@ main() {
   get_opts "$@"
   validate_opts
   export_globals
-  validate_changes_exist_in_prior_pr
+  validate_changes_exist_in_latest_commit
 
   AUTOMATOR_ROOT_DIR="$(pwd)"
 

--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -278,9 +278,10 @@ merge() {
 
 validate_changes_exist_in_prior_pr() {
   if [ -n "$git_exclude" ]; then
-    pr="$(curl -sSfLH "Authorization: token $token" -H "Accept: application/vnd.github.groot-preview+json" "https://api.github.com/repos/$user/$repo/commits/$sha/pulls" | jq ".[0].number")"
+    repo0=$(echo $repos | cut -d' ' -f1)  #just use first repo if multiple specified
+    pr="$(curl -sSfLH "Accept: application/vnd.github.groot-preview+json" "https://api.github.com/repos/$org/${repo0}/commits/$sha/pulls" | jq ".[0].number")"
     export GITHUB_TOKEN="$token"
-    changes=$(gh pr view "$pr" --repo "$user"/"$repo" --json files | jq -r '.files[].path' | grep -cvE '$git_exclude')
+    changes=$(gh pr view "$pr" --repo "$org"/"$repo0" --json files | jq -r '.files[].path' | grep -cvE "$git_exclude")
     if [ "${changes}" -eq 0 ]
     then
       print_error_and_exit "No changes remaining in upstream PR after excluding" 0  # not really an error so return 0


### PR DESCRIPTION
Currently, a common-files update will cause 16 automated PRs to be generated. Some of the PRs end up in a race condition and need some help to finish. This is caused by a recent change as more automation was added to try and limit an exposure of not having the latest commits when building a release.

The 16 automated jobs:
- There are automator jobs from common-files to cause PRs directly in istio.io, istio, api, tools, release-builder, pkg, client-go, gogo-genproto, and proxy. (9 jobs)
- The updates in api, pkg, client-go, gogo-genproto and proxy will cause automated PRs in istio to pick up their new commits (with only the common-files change). (5 jobs)
- The initial update in api, will also push an update to client-go and that will cause yet another update to istio. (2 jobs)

If we can prevent some of the updates from happening, namely those in api, pkg, client-go, gogogen-proto and proxy caused by the common-files updates, we remove 7 of the automated PRs.

What is the drawback to not doing this? The istio repo will be pointing to older commits (but only ignoring commits with common files updates) of the 5 repos. The istio `update_deps.sh` script will update to the latest commits. This means we are still seeing commits in istio from the 5 repos for non common-files changes, so still ahead of where we used to be (no automation in one repos). If we added a pre-submit job in `release-builder` to test for changes from an update_deps run, we could get back to making sure all repo references are up to date and limit the number of automated jobs using this PR.

Thoughts?

Note that I am replacing the behavior with the --git-exclude parameter with new behavior as it was added recently and only used in a few cases.

Slack discussion: https://istio.slack.com/archives/C6FCV6WN4/p1625688978099700