### PR TITLE
Restore api dep update on client-go in all cases

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -85,14 +85,68 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_api_dep_api_postsubmit
+    name: update_api_dep_client_go_api_postsubmit
     path_alias: istio.io/api
     spec:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,client-go
+        - --repo=client-go
+        - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
+          $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --labels=auto-merge,release-notes-none
+        - --modifier=update_api_dep
+        - --token-path=/etc/github-token/oauth
+        - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
+        image: gcr.io/istio-testing/build-tools:master-2021-07-13T15-25-11
+        name: ""
+        resources:
+          limits:
+            cpu: "3"
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: github
+        secret:
+          secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_api_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    name: update_api_dep_istio_api_postsubmit
+    path_alias: istio.io/api
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=istio
         - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
           $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2021-07-13T15-25-11
+        image: gcr.io/istio-testing/build-tools:master-2021-07-13T17-42-03
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -10,12 +10,26 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-  - name: update_api_dep
+  - name: update_api_dep_client_go
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
-    - --repo=istio,client-go
+    - --repo=client-go
+    - "--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --labels=auto-merge,release-notes-none
+    - --modifier=update_api_dep
+    - --token-path=/etc/github-token/oauth
+    - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
+    requirements: [github]
+    repos: [istio/test-infra@master]
+
+  - name: update_api_dep_istio
+    types: [postsubmit]
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=istio
     - "--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
     - --modifier=update_api_dep


### PR DESCRIPTION
I noted that the `client-go` repo isn't updated after `api` was updated with a common-files update. 

I think we still want to cause that update to happen, so all non common-files caused updates happen in all repos except `istio`. Then the update_deps in istio will get everything updated.