### PR TITLE
Fix automator script failing on exit code of 1 from grep

### DIFF
--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -284,7 +284,9 @@ merge() {
 # in the git_exclude list. If no files remain after exclusion, the automation script exits.
 validate_changes_exist_in_latest_commit() {
   if [ -n "$git_exclude" ]; then
+    set +e # grep will have an exit code of 1 if all files are excluded causing the script to fail
     changes=$(git show --name-only --pretty=oneline | sed 1d | grep -cvE "$git_exclude") # need to remove first line
+    set -e
     if [ "${changes}" -eq 0 ]
     then
       print_error_and_exit "No changes remaining in upstream PR after excluding" 0  # not really an error so return 0


### PR DESCRIPTION
Noting that the new automated jobs where we should be finding no changes after removing the common/ files from the list of caused changes are failing, ex: https://prow.istio.io/view/gs/istio-prow/logs/update_api_dep_api_postsubmit/1415020603940802560

I believe the grep is returning an exit code of 1, along with the 0 returned, and this is causing the script to fail with a rc of 1 instead of seeing a message and an exit code of 0.
