### PR TITLE
Update to use `make` for conistency across branching

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -80,7 +80,7 @@ periodics:
       - '--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference'
       - --labels=release-notes-none
       - --token-path=/etc/github-token/oauth
-      - --cmd=go get istio.io/istio@master && go mod tidy
+      - --cmd=make update_test_reference
       image: gcr.io/istio-testing/build-tools:master-2021-07-13T17-42-03
       name: ""
       resources:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -71,7 +71,7 @@ jobs:
     - "--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference"
     - --labels=release-notes-none
     - --token-path=/etc/github-token/oauth
-    - --cmd=go get istio.io/istio@master && go mod tidy
+    - --cmd=make update_test_reference
     requirements: [github]
     repos: [istio/test-infra@master]
 


### PR DESCRIPTION
Using `make` we pick up the SOURCE_BRANCH_NAME change from the repo and not hardcoding it in the job. This will eliminate the need to change the job at branch cutting times.