### PR TITLE
Add optional job for new istiodremote tests.

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2118,7 +2118,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-13T17-42-03
+        image: gcr.io/istio-testing/build-tools:master-2021-07-20T19-29-39
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2112,7 +2112,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - --istio.test.kube.topology
+        - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.isitodremote.kube.presubmit
         env:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2089,7 +2089,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-create-test-group: "false"
     branches:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2102,6 +2102,77 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+    name: integ-istiodremote-k8s-tests_istio_priv
+    optional: true
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --istio.test.kube.topology
+        - prow/config/topology/external-istiod.json
+        - test.integration.isitodremote.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,+multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-07-13T17-42-03
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
     name: integ-distroless-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -2033,6 +2033,77 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
+    name: integ-instiodremote-k8s-tests_istio_release-1.11_priv
+    optional: true
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --istio.test.kube.topology
+        - prow/config/topology/external-istiod.json
+        - test.integration.istiodremote.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,+multicluster
+        image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^release-1.11$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: release-1.11-istio
+      preset-override-envoy: "true"
     name: integ-distroless-k8s-tests_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -2033,7 +2033,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-instiodremote-k8s-tests_istio_release-1.11_priv
+    name: integ-istiodremote-k8s-tests_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -2043,7 +2043,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - --istio.test.kube.topology
+        - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.istiodremote.kube.presubmit
         env:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -2049,7 +2049,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
+        image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -2020,7 +2020,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-create-test-group: "false"
     branches:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2016,6 +2016,70 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-istiodremote-k8s-tests_istio
+    optional: true
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --istio.test.kube.topology
+        - prow/config/topology/external-istiod.json
+        - test.integration.isitodremote.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,+multicluster
+        image: gcr.io/istio-testing/build-tools:master-2021-07-13T17-42-03
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
     name: integ-distroless-k8s-tests_istio
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2010,7 +2010,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
     branches:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2032,7 +2032,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:master-2021-07-13T17-42-03
+        image: gcr.io/istio-testing/build-tools:master-2021-07-20T19-29-39
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2026,7 +2026,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - --istio.test.kube.topology
+        - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.isitodremote.kube.presubmit
         env:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -1968,7 +1968,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
+        image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -1952,7 +1952,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-instiodremote-k8s-tests_istio_release-1.11
+    name: integ-istiodremote-k8s-tests_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1962,7 +1962,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - --topology
         - MULTICLUSTER
-        - --istio.test.kube.topology
+        - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.istiodremote.kube.presubmit
         env:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -1946,7 +1946,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
     branches:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -1952,6 +1952,70 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
+    name: integ-instiodremote-k8s-tests_istio_release-1.11
+    optional: true
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --istio.test.kube.topology
+        - prow/config/topology/external-istiod.json
+        - test.integration.istiodremote.kube.presubmit
+        env:
+        - name: TEST_SELECT
+          value: -postsubmit,-flaky,+multicluster
+        image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_release-1.11_istio
+    branches:
+    - ^release-1.11$
+    decorate: true
     name: integ-distroless-k8s-tests_istio_release-1.11
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -215,7 +215,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - --topology
   - MULTICLUSTER
-  - --istio.test.kube.topology
+  - --topology-config
   - prow/config/topology/external-istiod.json
   - test.integration.istiodremote.kube.presubmit
   env:
@@ -224,7 +224,7 @@ jobs:
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
   modifiers:
     - optional
-  name: integ-instiodremote-k8s-tests
+  name: integ-istiodremote-k8s-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -224,6 +224,7 @@ jobs:
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
   modifiers:
     - optional
+    - skipped
   name: integ-istiodremote-k8s-tests
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -221,10 +221,10 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
+  image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-    - optional
-    - skipped
+    - presubmit_optional
+    - presubmit_skipped
   name: integ-istiodremote-k8s-tests
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -213,6 +213,30 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
+  - --topology
+  - MULTICLUSTER
+  - --istio.test.kube.topology
+  - prow/config/topology/external-istiod.json
+  - test.integration.istiodremote.kube.presubmit
+  env:
+  - name: TEST_SELECT
+    value: -postsubmit,-flaky,+multicluster
+  image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-14T19-43-48
+  modifiers:
+    - optional
+  name: integ-instiodremote-k8s-tests
+  node_selector:
+    testing: test-pool
+  requirements:
+  - cache
+  - kind
+  - gocache
+  resources: multicluster
+  types:
+  - presubmit
+- command:
+  - entrypoint
+  - prow/integ-suite-kind.sh
   - test.integration.kube.reachability
   env:
   - name: VARIANT

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -110,8 +110,8 @@ jobs:
 
   - name: integ-istiodremote-k8s-tests
     modifiers:
-      - optional
-      - skipped
+      - presubmit_optional
+      - presubmit_skipped
     types: [presubmit]
     command:
       - entrypoint

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -117,7 +117,7 @@ jobs:
       - prow/integ-suite-kind.sh
       - --topology
       - MULTICLUSTER
-      - --istio.test.kube.topology
+      - --topology-config
       - prow/config/topology/external-istiod.json
       - test.integration.isitodremote.kube.presubmit
     requirements: [kind]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -108,6 +108,24 @@ jobs:
       - name: TEST_SELECT
         value: "-postsubmit,-flaky,+multicluster"
 
+  - name: integ-istiodremote-k8s-tests
+    modifiers:
+      - optional
+    types: [presubmit]
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - --istio.test.kube.topology
+      - prow/config/topology/external-istiod.json
+      - test.integration.isitodremote.kube.presubmit
+    requirements: [kind]
+    resources: multicluster
+    env:
+      - name: TEST_SELECT
+        value: "-postsubmit,-flaky,+multicluster"
+
   - name: integ-distroless-k8s-tests
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.reachability]
     requirements: [kind]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -111,6 +111,7 @@ jobs:
   - name: integ-istiodremote-k8s-tests
     modifiers:
       - optional
+      - skipped
     types: [presubmit]
     command:
       - entrypoint


### PR DESCRIPTION
This defines new optional jobs which test the changes in https://github.com/istio/istio/pull/34262 and it's cherry-pick to release-11.

Once the tests are passing, will remove the optional here and remove the original tests in istio/istio tested by the multicluster job.