### PR TITLE
Update the modifier values for Prow configgen to disambiguate

### DIFF
--- a/prow/config/README.md
+++ b/prow/config/README.md
@@ -131,9 +131,9 @@ jobs:
     command: [echo, "hello world"]
     # modifiers change various parts of the test config. See the values below
     modifiers:
-    - skipped # if set, the test will run only in postsubmit or by explicitly calling /test on it
+    - presubmit_skipped # if set, the test will only be run in presubmit by explicitly calling /test on it
+    - presubmit_optional # if set, the test will not be required in presubmit
     - hidden # if set, the test will run but not be reported to the GitHub UI
-    - optional # if set, the test will not be required
   - name: $(matrix.greet)-$(matrix.name)
     # Prow jobs will be generated based on the combinations of each dimension.
     # In this case 3*2=6 Prow jobs will be generated.

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -54,9 +54,9 @@ const (
 
 	DefaultResource = "default"
 
-	ModifierHidden   = "hidden"
-	ModifierOptional = "optional"
-	ModifierSkipped  = "skipped"
+	ModifierHidden            = "hidden"
+	ModifierPresubmitOptional = "presubmit_optional"
+	ModifierPresubmitSkipped  = "presubmit_skipped"
 
 	TypePostsubmit = "postsubmit"
 	TypePresubmit  = "presubmit"
@@ -335,7 +335,7 @@ func (cli *Client) ValidateJobConfig(fileName string, jobsConfig JobsConfig) {
 			}
 		}
 		for _, mod := range job.Modifiers {
-			if e := validate(mod, []string{ModifierHidden, ModifierOptional, ModifierSkipped}, "status"); e != nil {
+			if e := validate(mod, []string{ModifierHidden, ModifierPresubmitOptional, ModifierPresubmitSkipped}, "status"); e != nil {
 				err = multierror.Append(err, e)
 			}
 		}
@@ -786,7 +786,7 @@ func applyRequirements(job *config.JobBase, requirements []string, presetMap map
 
 func applyModifiersPresubmit(presubmit *config.Presubmit, jobModifiers []string) {
 	for _, modifier := range jobModifiers {
-		if modifier == ModifierOptional {
+		if modifier == ModifierPresubmitOptional {
 			presubmit.Optional = true
 		} else if modifier == ModifierHidden {
 			presubmit.SkipReport = true
@@ -795,7 +795,7 @@ func applyModifiersPresubmit(presubmit *config.Presubmit, jobModifiers []string)
 					JobStatesToReport: []prowjob.ProwJobState{},
 				},
 			}
-		} else if modifier == ModifierSkipped {
+		} else if modifier == ModifierPresubmitSkipped {
 			presubmit.AlwaysRun = false
 		}
 	}
@@ -803,7 +803,7 @@ func applyModifiersPresubmit(presubmit *config.Presubmit, jobModifiers []string)
 
 func applyModifiersPostsubmit(postsubmit *config.Postsubmit, jobModifiers []string) {
 	for _, modifier := range jobModifiers {
-		if modifier == ModifierOptional {
+		if modifier == ModifierPresubmitOptional {
 			// Does not exist on postsubmit
 		} else if modifier == ModifierHidden {
 			postsubmit.SkipReport = true

--- a/prow/config/jobs/api-1.10.yaml
+++ b/prow/config/jobs/api-1.10.yaml
@@ -41,7 +41,7 @@ jobs:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
   modifiers:
-  - optional
+  - presubmit_optional
   name: release-notes
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/api-1.11.yaml
+++ b/prow/config/jobs/api-1.11.yaml
@@ -66,7 +66,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
   name: release-notes
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/api-1.9.yaml
+++ b/prow/config/jobs/api-1.9.yaml
@@ -30,7 +30,7 @@ jobs:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
   modifiers:
-  - optional
+  - presubmit_optional
   name: release-notes
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -41,7 +41,7 @@ jobs:
 
   - name: release-notes
     types: [presubmit]
-    modifiers: [optional]
+    modifiers: [presubmit_optional]
     command:
       - ../test-infra/tools/check_release_notes.sh
       - --token-path=/etc/github-token/oauth

--- a/prow/config/jobs/enhancements-1.11.yaml
+++ b/prow/config/jobs/enhancements-1.11.yaml
@@ -8,7 +8,7 @@ jobs:
   - --schema-path=./features_schema.json
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
   name: validate-features
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements.yaml
+++ b/prow/config/jobs/enhancements.yaml
@@ -6,7 +6,7 @@ image: gcr.io/istio-testing/build-tools:master-2021-07-20T19-29-39
 jobs:
 - name: validate-features
   types: [presubmit]
-  modifiers: [optional]
+  modifiers: [presubmit_optional]
   command:
     - ../test-infra/scripts/validate_schema.sh
     - --document-path=./features.yaml

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -47,8 +47,8 @@ jobs:
   - make
   - benchtest
   modifiers:
-  - optional
-  - skipped
+  - presubmit_optional
+  - presubmit_skipped
   name: benchmark
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -51,8 +51,8 @@ jobs:
   - benchtest
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
-  - skipped
+  - presubmit_optional
+  - presubmit_skipped
   name: benchmark
   node_selector:
     testing: test-pool
@@ -179,9 +179,9 @@ jobs:
     value: --istio.test.istio.istiodlessRemotes
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
+  - presubmit_skipped
   - hidden
-  - skipped
   name: integ-telemetry-istiodless-mc-k8s-tests
   node_selector:
     testing: test-pool
@@ -311,9 +311,9 @@ jobs:
     value: --istio.test.istio.istiodlessRemotes
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
+  - presubmit_skipped
   - hidden
-  - skipped
   name: integ-pilot-istiodless-multicluster-tests
   node_selector:
     testing: test-pool
@@ -385,9 +385,9 @@ jobs:
     value: --istio.test.istio.istiodlessRemotes
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
+  - presubmit_skipped
   - hidden
-  - skipped
   name: integ-security-istiodless-multicluster-tests
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -32,8 +32,8 @@ jobs:
   - make
   - benchtest
   modifiers:
-  - optional
-  - skipped
+  - presubmit_optional
+  - presubmit_skipped
   name: benchmark
   resources: benchmark
   types: [presubmit]
@@ -195,9 +195,9 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - optional
+  - presubmit_optional
+  - presubmit_skipped
   - hidden
-  - skipped
   name: integ-pilot-multicluster-tests
   requirements:
   - kind
@@ -271,7 +271,7 @@ jobs:
   - cni.install-test
   modifiers:
   - hidden
-  - optional
+  - presubmit_optional
   name: install-cni-test
   requirements:
   - docker
@@ -279,8 +279,8 @@ jobs:
   - make
   - test.integration.analyze
   modifiers:
-  - optional
-  - skipped
+  - presubmit_optional
+  - presubmit_skipped
   name: analyze-tests
   types: [presubmit]
 - command:

--- a/prow/config/jobs/istio-1.8.yaml
+++ b/prow/config/jobs/istio-1.8.yaml
@@ -32,8 +32,8 @@ jobs:
   - make
   - benchtest
   modifiers:
-  - optional
-  - skipped
+  - presubmit_optional
+  - presubmit_skipped
   name: benchmark
   resources: benchmark
   types: [presubmit]
@@ -90,7 +90,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - optional
+  - presubmit_optional
   name: integ-telemetry-mc-k8s-tests
   requirements:
   - kind
@@ -179,7 +179,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+externalistiod
   modifiers:
-  - optional
+  - presubmit_optional
   - hidden
   name: integ-external-istiod-mc-tests
   requirements:
@@ -205,7 +205,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - optional
+  - presubmit_optional
   name: integ-security-multicluster-tests
   requirements:
   - kind
@@ -305,7 +305,7 @@ jobs:
   - cni.install-test
   modifiers:
   - hidden
-  - optional
+  - presubmit_optional
   name: install-cni-test
   requirements:
   - docker

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -34,8 +34,8 @@ jobs:
   - make
   - benchtest
   modifiers:
-  - optional
-  - skipped
+  - presubmit_optional
+  - presubmit_skipped
   name: benchmark
   resources: benchmark
   types:
@@ -97,7 +97,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - optional
+  - presubmit_optional
   name: integ-telemetry-mc-k8s-tests
   requirements:
   - kind
@@ -202,7 +202,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   modifiers:
-  - optional
+  - presubmit_optional
   name: integ-security-multicluster-tests
   requirements:
   - kind

--- a/prow/config/jobs/istio.io-1.10.yaml
+++ b/prow/config/jobs/istio.io-1.10.yaml
@@ -68,7 +68,7 @@ jobs:
   - --cmd=make update_ref_docs
   - --dry-run
   modifiers:
-  - optional
+  - presubmit_optional
   name: update-ref-docs-dry-run
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.io-1.11.yaml
+++ b/prow/config/jobs/istio.io-1.11.yaml
@@ -75,7 +75,7 @@ jobs:
   - --dry-run
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
   name: update-ref-docs-dry-run
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.io-1.7.yaml
+++ b/prow/config/jobs/istio.io-1.7.yaml
@@ -15,7 +15,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.kube.presubmit
   modifiers:
-  - optional
+  - presubmit_optional
   name: k8s-tests
   requirements:
   - kind
@@ -27,7 +27,7 @@ jobs:
   - --cmd=make update_ref_docs
   - --dry-run
   modifiers:
-  - optional
+  - presubmit_optional
   name: update-ref-docs-dry-run
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/istio.io-1.8.yaml
+++ b/prow/config/jobs/istio.io-1.8.yaml
@@ -15,7 +15,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - doc.test.profile_default
   modifiers:
-  - optional
+  - presubmit_optional
   name: doc.test.profile_default
   requirements:
   - kind
@@ -24,7 +24,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - doc.test.profile_demo
   modifiers:
-  - optional
+  - presubmit_optional
   name: doc.test.profile_demo
   requirements:
   - kind
@@ -33,7 +33,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - doc.test.profile_none
   modifiers:
-  - optional
+  - presubmit_optional
   name: doc.test.profile_none
   requirements:
   - kind
@@ -44,7 +44,7 @@ jobs:
   - MULTICLUSTER
   - doc.test.multicluster
   modifiers:
-  - optional
+  - presubmit_optional
   name: doc.test.multicluster
   requirements:
   - kind
@@ -56,7 +56,7 @@ jobs:
   - --cmd=make update_ref_docs
   - --dry-run
   modifiers:
-  - optional
+  - presubmit_optional
   name: update-ref-docs-dry-run
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/istio.io-1.9.yaml
+++ b/prow/config/jobs/istio.io-1.9.yaml
@@ -48,7 +48,7 @@ jobs:
   - --cmd=make update_ref_docs
   - --dry-run
   modifiers:
-  - optional
+  - presubmit_optional
   name: update-ref-docs-dry-run
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -41,7 +41,7 @@ jobs:
     - --cmd=make update_ref_docs
     - --dry-run
     requirements: [github]
-    modifiers: [optional]
+    modifiers: [presubmit_optional]
     repos: [istio/test-infra@master]
 
   - name: update-ref-docs

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -18,7 +18,7 @@ jobs:
 
   - name: benchmark
     types: [presubmit]
-    modifiers: [optional, skipped]
+    modifiers: [presubmit_optional, presubmit_skipped]
     command: [entrypoint, make, benchtest]
     resources: benchmark
 
@@ -77,9 +77,9 @@ jobs:
 
   - name: integ-telemetry-istiodless-mc-k8s-tests
     modifiers:
-      - optional
+      - presubmit_optional
+      - presubmit_skipped
       - hidden
-      - skipped
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -162,9 +162,9 @@ jobs:
 
   - name: integ-pilot-istiodless-multicluster-tests
     modifiers:
-      - optional
+      - presubmit_optional
+      - presubmit_skipped
       - hidden
-      - skipped
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -208,9 +208,9 @@ jobs:
 
   - name: integ-security-istiodless-multicluster-tests
     modifiers:
-      - optional
+      - presubmit_optional
+      - presubmit_skipped
       - hidden
-      - skipped
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -340,7 +340,7 @@ jobs:
 
   # Test with assertions enabled.
   - name: integ-assertion-k8s-tests
-    modifiers: [optional, skipped] #  We run this in postsubmit always, but let developers explicitly run in presubmit
+    modifiers: [presubmit_optional, presubmit_skipped] #  We run this in postsubmit always, but let developers explicitly run in presubmit
     command:
       - entrypoint
       - prow/integ-suite-kind.sh

--- a/prow/config/jobs/proxy-1.10.yaml
+++ b/prow/config/jobs/proxy-1.10.yaml
@@ -50,7 +50,7 @@ jobs:
   - ./prow/proxy-presubmit-centos-release.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.10-2021-07-21T19-44-12
   modifiers:
-  - optional
+  - presubmit_optional
   name: release-centos-test
   node_selector:
     testing: build-pool

--- a/prow/config/jobs/proxy-1.8.yaml
+++ b/prow/config/jobs/proxy-1.8.yaml
@@ -34,7 +34,7 @@ jobs:
   - ./prow/proxy-presubmit-centos-release.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.8-2021-04-06T17-44-38
   modifiers:
-  - optional
+  - presubmit_optional
   name: release-centos-test
   requirements:
   - gcp

--- a/prow/config/jobs/proxy-1.9.yaml
+++ b/prow/config/jobs/proxy-1.9.yaml
@@ -38,7 +38,7 @@ jobs:
   - ./prow/proxy-presubmit-centos-release.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56 
   modifiers:
-  - optional
+  - presubmit_optional
   name: release-centos-test
   requirements:
   - gcp

--- a/prow/config/jobs/release-builder-1.10.yaml
+++ b/prow/config/jobs/release-builder-1.10.yaml
@@ -41,7 +41,7 @@ jobs:
 - command:
   - release/build-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: build-warning
   node_selector:
     testing: test-pool
@@ -53,7 +53,7 @@ jobs:
 - command:
   - release/publish-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: publish-warning
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/release-builder-1.11.yaml
+++ b/prow/config/jobs/release-builder-1.11.yaml
@@ -46,7 +46,7 @@ jobs:
   - release/build-warning.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
   name: build-warning
   node_selector:
     testing: test-pool
@@ -59,7 +59,7 @@ jobs:
   - release/publish-warning.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-07-23T13-28-18
   modifiers:
-  - optional
+  - presubmit_optional
   name: publish-warning
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/release-builder-1.7.yaml
+++ b/prow/config/jobs/release-builder-1.7.yaml
@@ -26,14 +26,14 @@ jobs:
 - command:
   - release/build-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: build-warning
   regex: ^release/trigger-build$
   types: [presubmit]
 - command:
   - release/publish-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: publish-warning
   regex: ^release/trigger-publish$
   types: [presubmit]

--- a/prow/config/jobs/release-builder-1.8.yaml
+++ b/prow/config/jobs/release-builder-1.8.yaml
@@ -26,14 +26,14 @@ jobs:
 - command:
   - release/build-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: build-warning
   regex: ^release/trigger-build$
   types: [presubmit]
 - command:
   - release/publish-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: publish-warning
   regex: ^release/trigger-publish$
   types: [presubmit]

--- a/prow/config/jobs/release-builder-1.9.yaml
+++ b/prow/config/jobs/release-builder-1.9.yaml
@@ -26,7 +26,7 @@ jobs:
 - command:
   - release/build-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: build-warning
   regex: ^release/trigger-build$
   types:
@@ -34,7 +34,7 @@ jobs:
 - command:
   - release/publish-warning.sh
   modifiers:
-  - optional
+  - presubmit_optional
   name: publish-warning
   regex: ^release/trigger-publish$
   types:

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -23,13 +23,13 @@ jobs:
     types: [presubmit]
     regex: '^release/trigger-build$'
     command: [release/build-warning.sh]
-    modifiers: [optional]
+    modifiers: [presubmit_optional]
 
   - name: publish-warning
     types: [presubmit]
     regex: '^release/trigger-publish$'
     command: [release/publish-warning.sh]
-    modifiers: [optional]
+    modifiers: [presubmit_optional]
 
   - name: build-release
     types: [postsubmit]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -24,7 +24,7 @@ jobs:
     env:
       - name: TRIALRUN
         value: "True"
-    modifiers: [optional]
+    modifiers: [presubmit_optional]
     requirements: [gcp]
 
   - name: containers

--- a/prow/config/testdata/simple.gen.yaml
+++ b/prow/config/testdata/simple.gen.yaml
@@ -40,6 +40,51 @@ periodics:
         path: /tmp/prow/cache
         type: DirectoryOrCreate
       name: build-cache
+- annotations:
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-dashboards: istio_istio_periodic
+    testgrid-num-failures-to-alert: "1"
+  cron: 0 2 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/istio
+    repo: istio
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/istio
+    repo: istio
+  name: presubmit-skipped_istio_periodic
+  spec:
+    containers:
+    - command:
+      - prow/command.sh
+      image: fooimage
+      name: ""
+      resources:
+        limits:
+          cpu: "5"
+          memory: 5Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/prow/go/pkg
+        name: build-cache
+        subPath: gomod
+      - mountPath: /gocache
+        name: build-cache
+        subPath: gocache
+    nodeSelector:
+      testing: test-pool
+    volumes:
+    - hostPath:
+        path: /tmp/prow/cache
+        type: DirectoryOrCreate
+      name: build-cache
 postsubmits:
   istio/istio:
   - annotations:
@@ -209,6 +254,48 @@ presubmits:
           subPath: gocache
       nodeSelector:
         foo: baz
+      volumes:
+      - hostPath:
+          path: /tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/istio
+      repo: istio
+    name: presubmit-skipped_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - prow/command.sh
+        image: fooimage
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 5Gi
+          requests:
+            cpu: "3"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
       volumes:
       - hostPath:
           path: /tmp/prow/cache

--- a/prow/config/testdata/simple.yaml
+++ b/prow/config/testdata/simple.yaml
@@ -35,6 +35,13 @@ jobs:
     annotations:
       whatever-annotation-name: whatever-annotation-value
     requirements: [desc]
+  
+  - name: presubmit-skipped
+    types: [presubmit, periodic]
+    resources: custom
+    command: [prow/command.sh]
+    repos: [istio/istio]
+    modifier: [presubmit_skipped]
 
 requirements: [gocache]
 


### PR DESCRIPTION
These has been some confusions on how `skipped` and `optional` modifier work for postsubmit and periodic Prow jobs. Rename them to `presubmit_skipped` and `presubmit_optional` to disambiguate.