### PR TITLE
Add test selector to cni postsubmit job.

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1353,6 +1353,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.presubmit
         env:
+        - name: TEST_SELECT
+          value: -multicluster,-flaky
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         image: gcr.io/istio-testing/build-tools:master-2021-07-20T19-29-39

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1348,6 +1348,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.presubmit
         env:
+        - name: TEST_SELECT
+          value: -multicluster,-flaky
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         image: gcr.io/istio-testing/build-tools:master-2021-07-20T19-29-39

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -335,6 +335,8 @@ jobs:
     requirements: [kind]
     timeout: 4h
     env:
+      - name: TEST_SELECT
+        value: "-multicluster,-flaky"
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 --istio.test.istio.enableCNI=true "
 


### PR DESCRIPTION
Looks like without explicit TEST_SELECT, postsubmit job will have default selector as `selector=-flaky,-postsubmit`, for example https://storage.googleapis.com/istio-prow/logs/integ-cni-k8s-tests_istio_postsubmit/1420958097400139776/build-log.txt. Not sure if this is expected and override is needed, or should be fixed somewhere else.