### PR TITLE
Use KinD with `MixedLBProtocolSupport` feature gate turned on for K8s >= 1.20

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1215,6 +1215,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.20.7
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1284,6 +1286,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.22.0-beta.2
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1220,6 +1220,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.20.7
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1284,6 +1286,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.22.0-beta.2
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -305,6 +305,8 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.20.7
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -319,6 +321,8 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.22.0-beta.2
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
Required for https://github.com/istio/istio/pull/33817
Do not merge until https://github.com/istio/istio/pull/34475 is merged