### PR TITLE
run pilot and security tests with Mixed protocol LB service feature gate turned on

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -396,6 +396,8 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube
         env:
         - name: TEST_SELECT
@@ -601,6 +603,8 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube
         env:
         - name: TEST_SELECT
@@ -1636,6 +1640,8 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube.presubmit
         env:
         - name: TEST_SELECT
@@ -1770,6 +1776,8 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -396,8 +396,6 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube
         env:
         - name: TEST_SELECT
@@ -603,8 +601,6 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube
         env:
         - name: TEST_SELECT
@@ -941,6 +937,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.16.15
+        - --kind-config
+        - prow/config/trustworthy-jwt.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1081,6 +1079,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.18.19
+        - --kind-config
+        - prow/config/trustworthy-jwt.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1150,6 +1150,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.19.11
+        - --kind-config
+        - prow/config/trustworthy-jwt.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1219,8 +1221,6 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.20.7
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1290,8 +1290,6 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.22.0
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1640,8 +1638,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube.presubmit
         env:
         - name: TEST_SELECT
@@ -1776,8 +1772,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -461,8 +461,6 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube
         env:
         - name: TEST_SELECT
@@ -653,8 +651,6 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube
         env:
         - name: TEST_SELECT
@@ -966,6 +962,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.16.15
+        - --kind-config
+        - prow/config/trustworthy-jwt.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1096,6 +1094,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.18.19
+        - --kind-config
+        - prow/config/trustworthy-jwt.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1160,6 +1160,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - kindest/node:v1.19.11
+        - --kind-config
+        - prow/config/trustworthy-jwt.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1224,8 +1226,6 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.20.7
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1290,8 +1290,6 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.22.0
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.kube.presubmit
         env:
         - name: INTEGRATION_TEST_FLAGS
@@ -1603,8 +1601,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube.presubmit
         env:
         - name: TEST_SELECT
@@ -1725,8 +1721,6 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - --kind-config
-        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -461,6 +461,8 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube
         env:
         - name: TEST_SELECT
@@ -651,6 +653,8 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube
         env:
         - name: TEST_SELECT
@@ -1599,6 +1603,8 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.pilot.kube.presubmit
         env:
         - name: TEST_SELECT
@@ -1719,6 +1725,8 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.security.kube.presubmit
         env:
         - name: TEST_SELECT

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -30,12 +30,7 @@ jobs:
 
   - name: integ-pilot-k8s-tests
     types: [presubmit]
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --kind-config
-      - prow/config/mixedlb-service.yaml
-      - test.integration.pilot.kube.presubmit
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -53,12 +48,7 @@ jobs:
 
   - name: integ-security-k8s-tests
     types: [presubmit]
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --kind-config
-      - prow/config/mixedlb-service.yaml
-      - test.integration.security.kube.presubmit
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube.presubmit]
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -169,12 +159,7 @@ jobs:
 
   - name: integ-pilot-k8s-tests
     types: [postsubmit]
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --kind-config
-      - prow/config/mixedlb-service.yaml
-      - test.integration.pilot.kube
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -214,12 +199,7 @@ jobs:
 
   - name: integ-security-k8s-tests
     types: [postsubmit]
-    command:
-      - entrypoint
-      - prow/integ-suite-kind.sh
-      - --kind-config
-      - prow/config/mixedlb-service.yaml
-      - test.integration.security.kube
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube]
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -285,6 +265,8 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - kindest/node:v1.16.15
+      - --kind-config
+      - prow/config/trustworthy-jwt.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -315,6 +297,8 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - kindest/node:v1.18.19
+      - --kind-config
+      - prow/config/trustworthy-jwt.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -329,6 +313,8 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - kindest/node:v1.19.11
+      - --kind-config
+      - prow/config/trustworthy-jwt.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -343,8 +329,6 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.20.7
-      - --kind-config
-      - prow/config/mixedlb-service.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h
@@ -359,8 +343,6 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.22.0
-      - --kind-config
-      - prow/config/mixedlb-service.yaml
       - test.integration.kube.presubmit
     requirements: [kind]
     timeout: 4h

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -30,7 +30,12 @@ jobs:
 
   - name: integ-pilot-k8s-tests
     types: [presubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
+      - test.integration.pilot.kube.presubmit
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -48,7 +53,12 @@ jobs:
 
   - name: integ-security-k8s-tests
     types: [presubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube.presubmit]
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
+      - test.integration.security.kube.presubmit
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -159,7 +169,12 @@ jobs:
 
   - name: integ-pilot-k8s-tests
     types: [postsubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
+      - test.integration.pilot.kube
     requirements: [kind]
     env:
       - name: TEST_SELECT
@@ -199,7 +214,12 @@ jobs:
 
   - name: integ-security-k8s-tests
     types: [postsubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube]
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
+      - test.integration.security.kube
     requirements: [kind]
     env:
       - name: TEST_SELECT


### PR DESCRIPTION
Follow up of https://github.com/istio/test-infra/pull/3481
Required for https://github.com/istio/istio/pull/33817
I had missed turning it on for presubmit and some postsubmit. Doing it in this PR

Signed-off-by: su225 <suchithjn22@gmail.com>