### PR TITLE
Fix filling up cache

### DIFF
--- a/prow/cluster/jobs/all-periodics.yaml
+++ b/prow/cluster/jobs/all-periodics.yaml
@@ -315,7 +315,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - hostPath:

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
@@ -37,7 +37,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -76,7 +76,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -120,7 +120,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -162,6 +162,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.10.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -119,7 +119,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -162,6 +162,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.11.gen.yaml
@@ -37,7 +37,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -76,7 +76,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -131,7 +131,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -190,7 +190,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.7.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -119,7 +119,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -162,6 +162,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.8.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -119,7 +119,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -162,6 +162,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.9.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -119,7 +119,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -162,6 +162,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
@@ -47,7 +47,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -94,7 +94,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -139,6 +139,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.10.gen.yaml
@@ -47,7 +47,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -94,7 +94,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -139,6 +139,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.7.gen.yaml
@@ -47,7 +47,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -94,7 +94,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -139,6 +139,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.8.gen.yaml
@@ -47,7 +47,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -94,7 +94,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -139,6 +139,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.9.gen.yaml
@@ -47,7 +47,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -94,7 +94,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -139,6 +139,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -331,7 +331,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -414,7 +414,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -470,7 +470,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -526,7 +526,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -584,7 +584,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -331,7 +331,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -414,7 +414,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -470,7 +470,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -526,7 +526,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -584,7 +584,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -331,7 +331,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -414,7 +414,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -470,7 +470,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -526,7 +526,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -584,7 +584,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -164,7 +164,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -201,7 +201,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -248,7 +248,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -331,7 +331,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -415,7 +415,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -472,7 +472,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -529,7 +529,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -588,7 +588,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -331,7 +331,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -414,7 +414,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -470,7 +470,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -526,7 +526,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -584,7 +584,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -98,7 +98,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -155,7 +155,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -228,7 +228,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -295,7 +295,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -364,7 +364,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -429,7 +429,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -496,7 +496,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -569,7 +569,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -634,7 +634,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -701,7 +701,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -774,7 +774,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -839,7 +839,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -901,7 +901,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -972,7 +972,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1043,7 +1043,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1114,7 +1114,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1185,7 +1185,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1254,7 +1254,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1323,7 +1323,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1392,7 +1392,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1459,7 +1459,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1520,7 +1520,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1567,7 +1567,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1615,7 +1615,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1671,7 +1671,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1739,7 +1739,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1805,7 +1805,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1871,7 +1871,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1939,7 +1939,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2014,7 +2014,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2082,7 +2082,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2153,7 +2153,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2221,7 +2221,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2291,7 +2291,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2357,7 +2357,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2425,7 +2425,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2500,7 +2500,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2568,7 +2568,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2643,7 +2643,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2706,7 +2706,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2775,7 +2775,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2829,7 +2829,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2873,7 +2873,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2917,6 +2917,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -98,7 +98,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -155,7 +155,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -222,7 +222,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -291,7 +291,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -356,7 +356,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -423,7 +423,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -488,7 +488,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -555,7 +555,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -620,7 +620,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -682,7 +682,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -751,7 +751,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -822,7 +822,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -891,7 +891,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -960,7 +960,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1029,7 +1029,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1098,7 +1098,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1159,7 +1159,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1206,7 +1206,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1254,7 +1254,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1310,7 +1310,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1376,7 +1376,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1442,7 +1442,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1510,7 +1510,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1578,7 +1578,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1646,7 +1646,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1716,7 +1716,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1782,7 +1782,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1850,7 +1850,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1918,7 +1918,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1981,7 +1981,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2035,7 +2035,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2079,7 +2079,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2123,6 +2123,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -98,7 +98,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -155,7 +155,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -228,7 +228,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -295,7 +295,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -364,7 +364,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -429,7 +429,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -496,7 +496,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -569,7 +569,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -634,7 +634,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -701,7 +701,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -774,7 +774,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -839,7 +839,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -901,7 +901,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -970,7 +970,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1041,7 +1041,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1110,7 +1110,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1179,7 +1179,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1248,7 +1248,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1317,7 +1317,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1384,7 +1384,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1445,7 +1445,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1492,7 +1492,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1540,7 +1540,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1596,7 +1596,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1664,7 +1664,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1730,7 +1730,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1796,7 +1796,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1864,7 +1864,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1939,7 +1939,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2007,7 +2007,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2078,7 +2078,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2146,7 +2146,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2216,7 +2216,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2282,7 +2282,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2350,7 +2350,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2425,7 +2425,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2493,7 +2493,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2568,7 +2568,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2631,7 +2631,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2685,7 +2685,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2729,7 +2729,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2773,6 +2773,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
@@ -45,7 +45,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -92,7 +92,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -135,7 +135,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -189,7 +189,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -255,7 +255,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -317,7 +317,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -379,7 +379,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -441,7 +441,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -509,7 +509,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -571,7 +571,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -633,7 +633,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -699,7 +699,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -765,7 +765,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -831,7 +831,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -888,7 +888,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -938,7 +938,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -982,7 +982,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1027,7 +1027,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1080,7 +1080,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1143,7 +1143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1206,7 +1206,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1269,7 +1269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1332,7 +1332,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1397,7 +1397,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1462,7 +1462,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1529,7 +1529,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1592,7 +1592,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1662,7 +1662,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1721,7 +1721,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1765,7 +1765,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1806,7 +1806,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1847,6 +1847,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -98,7 +98,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -144,7 +144,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -201,7 +201,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -268,7 +268,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -337,7 +337,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -402,7 +402,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -469,7 +469,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -542,7 +542,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -607,7 +607,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -674,7 +674,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -739,7 +739,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -801,7 +801,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -870,7 +870,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -939,7 +939,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1008,7 +1008,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1077,7 +1077,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1150,7 +1150,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1210,7 +1210,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1263,7 +1263,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1310,7 +1310,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1358,7 +1358,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1414,7 +1414,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1480,7 +1480,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1546,7 +1546,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1615,7 +1615,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1683,7 +1683,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1751,7 +1751,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1821,7 +1821,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1887,7 +1887,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1955,7 +1955,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2030,7 +2030,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2099,7 +2099,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2162,7 +2162,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2224,7 +2224,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -2270,7 +2270,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2314,7 +2314,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2358,6 +2358,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -48,7 +48,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -98,7 +98,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -155,7 +155,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -222,7 +222,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -291,7 +291,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -356,7 +356,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -423,7 +423,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -488,7 +488,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -555,7 +555,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -620,7 +620,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -682,7 +682,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -751,7 +751,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -820,7 +820,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -891,7 +891,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -960,7 +960,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1029,7 +1029,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1090,7 +1090,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1137,7 +1137,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1185,7 +1185,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1241,7 +1241,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1307,7 +1307,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1373,7 +1373,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1442,7 +1442,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1510,7 +1510,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1578,7 +1578,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1648,7 +1648,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1714,7 +1714,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1782,7 +1782,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1851,7 +1851,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1914,7 +1914,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1968,7 +1968,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2012,7 +2012,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2056,6 +2056,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -53,7 +53,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -107,7 +107,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -175,7 +175,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -227,7 +227,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -274,7 +274,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -321,7 +321,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -415,7 +415,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -465,7 +465,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.10.gen.yaml
@@ -53,7 +53,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -107,7 +107,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -174,7 +174,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -226,7 +226,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -273,7 +273,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -320,7 +320,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -367,7 +367,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -415,7 +415,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -465,7 +465,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
@@ -53,7 +53,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -107,7 +107,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -175,7 +175,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -227,7 +227,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -274,7 +274,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -321,7 +321,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -368,7 +368,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -415,7 +415,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -465,7 +465,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.7.gen.yaml
@@ -53,7 +53,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -122,7 +122,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -171,7 +171,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -215,7 +215,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -259,7 +259,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -351,7 +351,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
@@ -53,7 +53,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -107,7 +107,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -174,7 +174,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -226,7 +226,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -273,7 +273,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -320,7 +320,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -367,7 +367,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -415,7 +415,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -465,7 +465,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
@@ -53,7 +53,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -107,7 +107,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -174,7 +174,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -226,7 +226,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -273,7 +273,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -320,7 +320,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -367,7 +367,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -415,7 +415,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -465,7 +465,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -112,7 +112,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -165,7 +165,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -212,7 +212,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -251,7 +251,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -333,6 +333,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -158,7 +158,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -203,7 +203,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -240,7 +240,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -277,7 +277,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -320,6 +320,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -112,7 +112,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -165,7 +165,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -212,7 +212,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -251,7 +251,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -333,6 +333,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -155,7 +155,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -196,7 +196,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -233,7 +233,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -270,7 +270,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -313,6 +313,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -112,7 +112,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -165,7 +165,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -212,7 +212,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -251,7 +251,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -333,6 +333,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -74,7 +74,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -112,7 +112,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -165,7 +165,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -212,7 +212,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -251,7 +251,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -333,6 +333,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -121,7 +121,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -176,7 +176,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -216,7 +216,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -251,7 +251,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -299,7 +299,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -121,7 +121,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -161,7 +161,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -196,7 +196,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -244,7 +244,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -121,7 +121,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -176,7 +176,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -216,7 +216,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -251,7 +251,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -299,7 +299,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -121,7 +121,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -161,7 +161,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -196,6 +196,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -121,7 +121,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -161,7 +161,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -196,6 +196,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -121,7 +121,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -161,7 +161,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -196,7 +196,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -244,7 +244,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -222,7 +222,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -261,7 +261,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -296,7 +296,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -331,7 +331,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -366,6 +366,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -159,7 +159,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -199,7 +199,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -234,7 +234,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -269,6 +269,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -159,7 +159,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -199,7 +199,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -234,7 +234,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -269,6 +269,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -85,7 +85,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -139,7 +139,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -193,7 +193,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -251,7 +251,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -291,6 +291,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -85,7 +85,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -139,7 +139,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -197,7 +197,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -237,6 +237,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -85,7 +85,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -139,7 +139,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -197,7 +197,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -237,6 +237,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -85,7 +85,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -143,7 +143,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -183,6 +183,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -85,7 +85,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -143,7 +143,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -183,6 +183,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -85,7 +85,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -139,7 +139,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -197,7 +197,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -237,6 +237,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -69,7 +69,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -108,7 +108,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -147,7 +147,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -182,6 +182,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -179,7 +179,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -249,7 +249,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -284,6 +284,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
@@ -44,6 +44,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.11.gen.yaml
@@ -44,6 +44,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -53,7 +53,7 @@ periodics:
       testing: build-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - name: github
@@ -105,7 +105,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -150,7 +150,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -193,6 +193,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.10.gen.yaml
@@ -53,7 +53,7 @@ periodics:
       testing: build-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - name: github
@@ -105,7 +105,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -150,7 +150,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -193,6 +193,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.7.gen.yaml
@@ -45,7 +45,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -90,7 +90,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -133,6 +133,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.8.gen.yaml
@@ -52,7 +52,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -104,7 +104,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -149,7 +149,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -192,6 +192,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
@@ -54,7 +54,7 @@ periodics:
       testing: build-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - name: github
@@ -113,7 +113,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -165,7 +165,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -210,7 +210,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -253,6 +253,6 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -159,7 +159,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -199,7 +199,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -234,7 +234,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -269,6 +269,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -159,7 +159,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -199,7 +199,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -234,7 +234,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -269,6 +269,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -143,7 +143,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -178,7 +178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -213,6 +213,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -49,7 +49,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - name: github
@@ -103,7 +103,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - name: github
@@ -144,7 +144,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -180,7 +180,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -280,7 +280,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -335,7 +335,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -392,7 +392,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -439,7 +439,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -474,7 +474,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -518,7 +518,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -572,7 +572,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -626,7 +626,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -682,7 +682,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -740,7 +740,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -329,7 +329,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -364,7 +364,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -408,7 +408,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -462,7 +462,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -516,7 +516,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -572,7 +572,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -630,7 +630,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -329,7 +329,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -364,7 +364,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -408,7 +408,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -462,7 +462,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -516,7 +516,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -572,7 +572,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -630,7 +630,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -162,7 +162,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -197,7 +197,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -242,7 +242,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -300,7 +300,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -329,7 +329,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -364,7 +364,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -409,7 +409,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -464,7 +464,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -519,7 +519,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -576,7 +576,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -634,7 +634,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -115,7 +115,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -170,7 +170,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -225,7 +225,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -282,7 +282,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -329,7 +329,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -364,7 +364,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -408,7 +408,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -462,7 +462,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -516,7 +516,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -572,7 +572,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -630,7 +630,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -47,7 +47,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - hostPath:
@@ -102,7 +102,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -144,7 +144,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -188,7 +188,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -308,7 +308,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -370,7 +370,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -434,7 +434,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -494,7 +494,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -556,7 +556,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -624,7 +624,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -684,7 +684,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -746,7 +746,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -814,7 +814,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -874,7 +874,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -931,7 +931,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -997,7 +997,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1063,7 +1063,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1129,7 +1129,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1195,7 +1195,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1259,7 +1259,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1323,7 +1323,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1387,7 +1387,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1449,7 +1449,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1503,7 +1503,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1544,7 +1544,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1585,7 +1585,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1634,7 +1634,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1695,7 +1695,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1754,7 +1754,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1813,7 +1813,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1874,7 +1874,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1942,7 +1942,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2003,7 +2003,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2067,7 +2067,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2128,7 +2128,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2191,7 +2191,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2250,7 +2250,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2311,7 +2311,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2379,7 +2379,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2440,7 +2440,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2508,7 +2508,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2564,7 +2564,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2626,7 +2626,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2673,7 +2673,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2710,7 +2710,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2747,7 +2747,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2796,7 +2796,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -41,7 +41,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -83,7 +83,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -127,7 +127,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -179,7 +179,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -241,7 +241,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -305,7 +305,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -365,7 +365,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -427,7 +427,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -487,7 +487,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -549,7 +549,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -609,7 +609,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -666,7 +666,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -730,7 +730,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -796,7 +796,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -860,7 +860,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -924,7 +924,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -988,7 +988,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1052,7 +1052,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1106,7 +1106,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1147,7 +1147,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1188,7 +1188,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1237,7 +1237,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1296,7 +1296,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1355,7 +1355,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1416,7 +1416,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1477,7 +1477,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1538,7 +1538,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1601,7 +1601,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1660,7 +1660,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1721,7 +1721,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1782,7 +1782,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1838,7 +1838,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1885,7 +1885,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1922,7 +1922,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1959,7 +1959,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2008,7 +2008,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -47,7 +47,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - hostPath:
@@ -102,7 +102,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -144,7 +144,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -188,7 +188,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -308,7 +308,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -370,7 +370,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -434,7 +434,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -494,7 +494,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -556,7 +556,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -624,7 +624,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -684,7 +684,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -746,7 +746,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -814,7 +814,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -874,7 +874,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -931,7 +931,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -995,7 +995,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1061,7 +1061,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1125,7 +1125,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1189,7 +1189,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1253,7 +1253,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1317,7 +1317,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1379,7 +1379,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1433,7 +1433,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1474,7 +1474,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1515,7 +1515,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1564,7 +1564,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1625,7 +1625,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1684,7 +1684,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1743,7 +1743,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1804,7 +1804,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1872,7 +1872,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1933,7 +1933,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1997,7 +1997,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2058,7 +2058,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2121,7 +2121,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2180,7 +2180,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2241,7 +2241,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2309,7 +2309,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2370,7 +2370,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2438,7 +2438,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2494,7 +2494,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2541,7 +2541,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2578,7 +2578,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2615,7 +2615,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2664,7 +2664,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -38,7 +38,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -77,7 +77,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -118,7 +118,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -167,7 +167,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -228,7 +228,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -285,7 +285,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -342,7 +342,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -399,7 +399,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -462,7 +462,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -519,7 +519,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -576,7 +576,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -637,7 +637,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -698,7 +698,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -759,7 +759,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -811,7 +811,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -854,7 +854,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -892,7 +892,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -930,7 +930,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -976,7 +976,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1032,7 +1032,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1088,7 +1088,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1144,7 +1144,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1200,7 +1200,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1258,7 +1258,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1316,7 +1316,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1376,7 +1376,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1432,7 +1432,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1495,7 +1495,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1547,7 +1547,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1584,7 +1584,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1618,7 +1618,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1652,7 +1652,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1698,7 +1698,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -41,7 +41,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -83,7 +83,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -127,7 +127,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -179,7 +179,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -241,7 +241,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -305,7 +305,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -365,7 +365,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -427,7 +427,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -495,7 +495,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -555,7 +555,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -617,7 +617,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -677,7 +677,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -734,7 +734,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -798,7 +798,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -862,7 +862,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -926,7 +926,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -990,7 +990,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1058,7 +1058,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1113,7 +1113,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1159,7 +1159,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1200,7 +1200,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1241,7 +1241,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1290,7 +1290,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1349,7 +1349,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1408,7 +1408,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1470,7 +1470,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1531,7 +1531,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1592,7 +1592,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1655,7 +1655,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1714,7 +1714,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1775,7 +1775,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1843,7 +1843,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1905,7 +1905,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1961,7 +1961,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -2016,7 +2016,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -2055,7 +2055,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2092,7 +2092,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2129,7 +2129,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -2178,7 +2178,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -41,7 +41,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -83,7 +83,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -127,7 +127,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -179,7 +179,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -241,7 +241,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -305,7 +305,7 @@ postsubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -365,7 +365,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -427,7 +427,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -487,7 +487,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -549,7 +549,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -609,7 +609,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -666,7 +666,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -730,7 +730,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -794,7 +794,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -860,7 +860,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -924,7 +924,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -988,7 +988,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1042,7 +1042,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1083,7 +1083,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -1124,7 +1124,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1173,7 +1173,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1232,7 +1232,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1291,7 +1291,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1353,7 +1353,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1414,7 +1414,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1475,7 +1475,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1538,7 +1538,7 @@ presubmits:
         testing: ipv6-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1597,7 +1597,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1658,7 +1658,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1720,7 +1720,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1776,7 +1776,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1823,7 +1823,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1860,7 +1860,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1897,7 +1897,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1946,7 +1946,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -194,7 +194,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -234,7 +234,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -269,7 +269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -339,6 +339,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -179,7 +179,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -249,7 +249,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -284,6 +284,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -194,7 +194,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -234,7 +234,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -269,7 +269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -339,6 +339,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -179,7 +179,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -249,7 +249,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -284,6 +284,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -179,7 +179,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -249,7 +249,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -284,6 +284,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -179,7 +179,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -249,7 +249,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -284,6 +284,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -40,7 +40,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -81,7 +81,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -134,7 +134,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -177,7 +177,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -215,7 +215,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -253,7 +253,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -291,7 +291,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -329,7 +329,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -370,7 +370,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.10.gen.yaml
@@ -40,7 +40,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -81,7 +81,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -133,7 +133,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -176,7 +176,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -252,7 +252,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -329,7 +329,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -370,7 +370,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
@@ -40,7 +40,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -81,7 +81,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -134,7 +134,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -177,7 +177,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -215,7 +215,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -253,7 +253,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -291,7 +291,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -329,7 +329,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -370,7 +370,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.7.gen.yaml
@@ -40,7 +40,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -94,7 +94,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -133,7 +133,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -167,7 +167,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -201,7 +201,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -237,7 +237,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -274,7 +274,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
@@ -40,7 +40,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -81,7 +81,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -133,7 +133,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -176,7 +176,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -252,7 +252,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -329,7 +329,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -370,7 +370,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
@@ -40,7 +40,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -81,7 +81,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -133,7 +133,7 @@ postsubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - name: github
@@ -176,7 +176,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -214,7 +214,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -252,7 +252,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -290,7 +290,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -329,7 +329,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -370,7 +370,7 @@ presubmits:
         testing: build-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -147,7 +147,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -193,7 +193,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -279,7 +279,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -314,7 +314,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -349,7 +349,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -389,7 +389,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -427,7 +427,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -463,6 +463,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -147,7 +147,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -193,7 +193,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -279,7 +279,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -314,7 +314,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -349,7 +349,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -389,7 +389,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -427,7 +427,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -463,6 +463,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -147,7 +147,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -193,7 +193,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -279,7 +279,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -314,7 +314,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -349,7 +349,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -389,7 +389,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -427,7 +427,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -463,6 +463,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -147,7 +147,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -190,7 +190,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -233,7 +233,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -272,7 +272,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -307,7 +307,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -342,7 +342,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -382,7 +382,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -420,7 +420,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -456,6 +456,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -147,7 +147,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -193,7 +193,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -279,7 +279,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -314,7 +314,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -349,7 +349,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -389,7 +389,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -427,7 +427,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -463,6 +463,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -147,7 +147,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -193,7 +193,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -240,7 +240,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -279,7 +279,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -314,7 +314,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -349,7 +349,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -389,7 +389,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -427,7 +427,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -463,6 +463,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -51,7 +51,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
     - name: github
@@ -92,7 +92,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -128,7 +128,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -164,7 +164,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -223,7 +223,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -266,7 +266,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -309,7 +309,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -354,7 +354,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -403,7 +403,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -451,7 +451,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -499,7 +499,7 @@ postsubmits:
         prod: prow
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -538,7 +538,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -573,7 +573,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -608,7 +608,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -646,7 +646,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -695,7 +695,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -184,7 +184,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -230,7 +230,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -269,7 +269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -339,7 +339,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -374,7 +374,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -416,7 +416,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -457,7 +457,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.10.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -184,7 +184,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -230,7 +230,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -269,7 +269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -339,7 +339,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -374,7 +374,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -415,7 +415,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -184,7 +184,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -230,7 +230,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -269,7 +269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -339,7 +339,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -374,7 +374,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -415,7 +415,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.7.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -184,7 +184,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -223,7 +223,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -258,7 +258,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -293,7 +293,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -328,7 +328,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -369,7 +369,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.8.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -184,7 +184,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -230,7 +230,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -269,7 +269,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -304,7 +304,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -339,7 +339,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -374,7 +374,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -415,7 +415,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
@@ -34,7 +34,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -70,7 +70,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -106,7 +106,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -142,7 +142,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -184,7 +184,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}
@@ -223,7 +223,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -258,7 +258,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -293,7 +293,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -328,7 +328,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: false
@@ -369,7 +369,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - emptyDir: {}

--- a/prow/config/README.md
+++ b/prow/config/README.md
@@ -70,7 +70,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   gcp:

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -198,6 +199,7 @@ func (cli *Client) ReadJobsConfig(file string) JobsConfig {
 		jobsConfig.Branches = []string{"master"}
 	}
 
+	log.Println("GLOBAL", cli.GlobalConfig.RequirementPresets["cache"])
 	return resolveOverwrites(cli.GlobalConfig, jobsConfig)
 }
 
@@ -211,15 +213,17 @@ func resolveOverwrites(globalConfig GlobalConfig, jobsConfig JobsConfig) JobsCon
 		resources[k] = v
 	}
 	jobsConfig.ResourcePresets = resources
-
-	requirementPresets := globalConfig.RequirementPresets
+	requirementPresets := copyRequirementsMap(globalConfig.RequirementPresets)
 	if requirementPresets == nil {
 		requirementPresets = map[string]RequirementPreset{}
 	}
+	log.Println(jobsConfig.Repo, jobsConfig.Branches)
+	log.Println("before", requirementPresets["cache"])
 	for k, v := range jobsConfig.RequirementPresets {
 		requirementPresets[k] = v
 	}
 	jobsConfig.RequirementPresets = requirementPresets
+	log.Println("after", requirementPresets["cache"])
 
 	// Resolve jobsConfig -> job overwriting
 	for i, job := range jobsConfig.Jobs {

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -199,7 +198,6 @@ func (cli *Client) ReadJobsConfig(file string) JobsConfig {
 		jobsConfig.Branches = []string{"master"}
 	}
 
-	log.Println("GLOBAL", cli.GlobalConfig.RequirementPresets["cache"])
 	return resolveOverwrites(cli.GlobalConfig, jobsConfig)
 }
 
@@ -217,13 +215,11 @@ func resolveOverwrites(globalConfig GlobalConfig, jobsConfig JobsConfig) JobsCon
 	if requirementPresets == nil {
 		requirementPresets = map[string]RequirementPreset{}
 	}
-	log.Println(jobsConfig.Repo, jobsConfig.Branches)
-	log.Println("before", requirementPresets["cache"])
+
 	for k, v := range jobsConfig.RequirementPresets {
 		requirementPresets[k] = v
 	}
 	jobsConfig.RequirementPresets = requirementPresets
-	log.Println("after", requirementPresets["cache"])
 
 	// Resolve jobsConfig -> job overwriting
 	for i, job := range jobsConfig.Jobs {

--- a/prow/config/jobs/.global.yaml
+++ b/prow/config/jobs/.global.yaml
@@ -57,7 +57,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   gocache:
@@ -67,7 +67,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   github:

--- a/prow/config/jobs/api-1.10.yaml
+++ b/prow/config/jobs/api-1.10.yaml
@@ -65,7 +65,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -109,7 +109,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/api-1.11.yaml
+++ b/prow/config/jobs/api-1.11.yaml
@@ -91,7 +91,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -153,7 +153,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/client-go-1.10.yaml
+++ b/prow/config/jobs/client-go-1.10.yaml
@@ -38,7 +38,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -82,7 +82,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/client-go-1.11.yaml
+++ b/prow/config/jobs/client-go-1.11.yaml
@@ -64,7 +64,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -126,7 +126,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/common-files-1.10.yaml
+++ b/prow/config/jobs/common-files-1.10.yaml
@@ -86,7 +86,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -130,7 +130,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/common-files-1.11.yaml
+++ b/prow/config/jobs/common-files-1.11.yaml
@@ -91,7 +91,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -153,7 +153,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/enhancements-1.11.yaml
+++ b/prow/config/jobs/enhancements-1.11.yaml
@@ -32,7 +32,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -94,7 +94,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/gogo-genproto-1.10.yaml
+++ b/prow/config/jobs/gogo-genproto-1.10.yaml
@@ -38,7 +38,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -82,7 +82,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/gogo-genproto-1.11.yaml
+++ b/prow/config/jobs/gogo-genproto-1.11.yaml
@@ -65,7 +65,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -127,7 +127,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -468,7 +468,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -512,7 +512,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -655,7 +655,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -717,7 +717,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/istio.io-1.10.yaml
+++ b/prow/config/jobs/istio.io-1.10.yaml
@@ -91,7 +91,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -135,7 +135,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/istio.io-1.11.yaml
+++ b/prow/config/jobs/istio.io-1.11.yaml
@@ -99,7 +99,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -161,7 +161,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/pkg-1.10.yaml
+++ b/prow/config/jobs/pkg-1.10.yaml
@@ -46,7 +46,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -90,7 +90,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/pkg-1.11.yaml
+++ b/prow/config/jobs/pkg-1.11.yaml
@@ -72,7 +72,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -134,7 +134,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/proxy-1.10.yaml
+++ b/prow/config/jobs/proxy-1.10.yaml
@@ -133,7 +133,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -177,7 +177,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/proxy-1.11.yaml
+++ b/prow/config/jobs/proxy-1.11.yaml
@@ -139,7 +139,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -201,7 +201,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/release-builder-1.10.yaml
+++ b/prow/config/jobs/release-builder-1.10.yaml
@@ -103,7 +103,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -147,7 +147,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/release-builder-1.11.yaml
+++ b/prow/config/jobs/release-builder-1.11.yaml
@@ -112,7 +112,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -174,7 +174,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/tools-1.10.yaml
+++ b/prow/config/jobs/tools-1.10.yaml
@@ -92,7 +92,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -136,7 +136,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/jobs/tools-1.11.yaml
+++ b/prow/config/jobs/tools-1.11.yaml
@@ -100,7 +100,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   deploy:
@@ -162,7 +162,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   kind:

--- a/prow/config/requirement.go
+++ b/prow/config/requirement.go
@@ -46,15 +46,9 @@ func (r RequirementPreset) DeepCopy() RequirementPreset {
 	for k, v := range r.Labels {
 		ret.Labels[k] = v
 	}
-	for _, v := range r.Env {
-		ret.Env = append(ret.Env, v)
-	}
-	for _, v := range r.Volumes {
-		ret.Volumes = append(ret.Volumes, v)
-	}
-	for _, v := range r.VolumeMounts {
-		ret.VolumeMounts = append(ret.VolumeMounts, v)
-	}
+	ret.Env = append(ret.Env, r.Env...)
+	ret.Volumes = append(ret.Volumes, r.Volumes...)
+	ret.VolumeMounts = append(ret.VolumeMounts, r.VolumeMounts...)
 	return ret
 }
 
@@ -67,7 +61,6 @@ func resolveRequirements(annotations, labels map[string]string, spec *v1.PodSpec
 }
 
 func mergeRequirement(req RequirementPreset, annotations, labels map[string]string, containers []v1.Container, volumes *[]v1.Volume) {
-	// log.Println(req.Volumes)
 	for a, v := range req.Annotations {
 		annotations[a] = v
 	}

--- a/prow/config/requirement.go
+++ b/prow/config/requirement.go
@@ -27,6 +27,37 @@ type RequirementPreset struct {
 	VolumeMounts []v1.VolumeMount  `json:"volumeMounts"`
 }
 
+func copyRequirementsMap(m map[string]RequirementPreset) map[string]RequirementPreset {
+	ret := map[string]RequirementPreset{}
+	for k, v := range m {
+		ret[k] = v.DeepCopy()
+	}
+	return ret
+}
+
+func (r RequirementPreset) DeepCopy() RequirementPreset {
+	ret := RequirementPreset{
+		Annotations: map[string]string{},
+		Labels:      map[string]string{},
+	}
+	for k, v := range r.Annotations {
+		ret.Annotations[k] = v
+	}
+	for k, v := range r.Labels {
+		ret.Labels[k] = v
+	}
+	for _, v := range r.Env {
+		ret.Env = append(ret.Env, v)
+	}
+	for _, v := range r.Volumes {
+		ret.Volumes = append(ret.Volumes, v)
+	}
+	for _, v := range r.VolumeMounts {
+		ret.VolumeMounts = append(ret.VolumeMounts, v)
+	}
+	return ret
+}
+
 func resolveRequirements(annotations, labels map[string]string, spec *v1.PodSpec, requirements []RequirementPreset) {
 	if spec != nil {
 		for _, req := range requirements {
@@ -36,6 +67,7 @@ func resolveRequirements(annotations, labels map[string]string, spec *v1.PodSpec
 }
 
 func mergeRequirement(req RequirementPreset, annotations, labels map[string]string, containers []v1.Container, volumes *[]v1.Volume) {
+	// log.Println(req.Volumes)
 	for a, v := range req.Annotations {
 		annotations[a] = v
 	}

--- a/prow/config/testdata/.global.yaml
+++ b/prow/config/testdata/.global.yaml
@@ -57,7 +57,7 @@ requirement_presets:
       subPath: gomod
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   gocache:
@@ -67,7 +67,7 @@ requirement_presets:
       subPath: gocache
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
   github:

--- a/prow/config/testdata/simple-matrix.gen.yaml
+++ b/prow/config/testdata/simple-matrix.gen.yaml
@@ -42,7 +42,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -88,7 +88,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -132,7 +132,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -178,7 +178,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -222,7 +222,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -268,7 +268,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -312,7 +312,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -358,7 +358,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -402,7 +402,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -448,7 +448,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - annotations:
@@ -492,7 +492,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -538,7 +538,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -583,7 +583,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -628,7 +628,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -671,7 +671,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -716,7 +716,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -759,7 +759,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -804,7 +804,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -847,7 +847,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -892,7 +892,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -935,7 +935,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -980,7 +980,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -1023,7 +1023,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -1068,6 +1068,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache

--- a/prow/config/testdata/simple.gen.yaml
+++ b/prow/config/testdata/simple.gen.yaml
@@ -37,7 +37,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
 - annotations:
@@ -82,7 +82,7 @@ periodics:
       testing: test-pool
     volumes:
     - hostPath:
-        path: /tmp/prow/cache
+        path: /prow/cache
         type: DirectoryOrCreate
       name: build-cache
 postsubmits:
@@ -120,7 +120,7 @@ postsubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
 presubmits:
@@ -157,7 +157,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -210,7 +210,7 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
       - hostPath:
@@ -256,7 +256,7 @@ presubmits:
         foo: baz
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache
   - always_run: true
@@ -298,6 +298,6 @@ presubmits:
         testing: test-pool
       volumes:
       - hostPath:
-          path: /tmp/prow/cache
+          path: /prow/cache
           type: DirectoryOrCreate
         name: build-cache


### PR DESCRIPTION
In ubuntu, /tmp is part of the / mount, which has 500gb. So we have no issues there.

On COS, /tmp is a 32gb tmpfs, which we hit the limit of.

Instead, we just write to the /mount.

This required fixes to the generator logic to avoid mutating the global config

Note to googlers - I opened internal bug 195975657 to the COS team to see if this can/should be changed