### PR TITLE
Use the latest build tools image for 1.9

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.9.gen.yaml
@@ -17,7 +17,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -55,7 +55,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -100,7 +100,7 @@ presubmits:
         env:
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ presubmits:
         env:
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -312,7 +312,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -387,7 +387,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -499,7 +499,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -557,7 +557,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -25,7 +25,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -77,7 +77,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -262,7 +262,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -327,7 +327,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -394,7 +394,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -459,7 +459,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -526,7 +526,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -591,7 +591,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -653,7 +653,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -722,7 +722,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -791,7 +791,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -862,7 +862,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -931,7 +931,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1000,7 +1000,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1069,7 +1069,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1114,7 +1114,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1164,7 +1164,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1212,7 +1212,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1278,7 +1278,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1344,7 +1344,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1413,7 +1413,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1481,7 +1481,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1549,7 +1549,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1619,7 +1619,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1685,7 +1685,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1753,7 +1753,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1822,7 +1822,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1885,7 +1885,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1947,7 +1947,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1991,7 +1991,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -2035,7 +2035,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
@@ -32,7 +32,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -301,7 +301,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -396,7 +396,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -444,7 +444,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
@@ -17,7 +17,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -55,7 +55,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -93,7 +93,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -141,7 +141,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -232,7 +232,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -314,7 +314,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -177,7 +177,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -222,7 +222,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common gen
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -175,7 +175,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.9.gen.yaml
@@ -30,7 +30,7 @@ periodics:
       - --token-path=/etc/github-token/oauth
       - --merge-repository=https://github.com/envoyproxy/envoy.git
       - --merge-branch=release/v1.17
-      image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+      image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
       name: ""
       resources:
         limits:
@@ -89,7 +89,7 @@ postsubmits:
         - --modifier=update_envoy_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=UPDATE_BRANCH=release-1.9 scripts/update_envoy.sh $AUTOMATOR_SHA $AUTOMATOR_SHA_COMMIT_DATE
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -381,7 +381,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -435,7 +435,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -545,7 +545,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -608,7 +608,7 @@ presubmits:
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -106,7 +106,7 @@ postsubmits:
         - make
         - benchtest
         - report-benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -276,7 +276,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -336,7 +336,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -398,7 +398,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -458,7 +458,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -520,7 +520,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -580,7 +580,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -637,7 +637,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -701,7 +701,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -765,7 +765,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -831,7 +831,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -895,7 +895,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -959,7 +959,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1021,7 +1021,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1060,7 +1060,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1103,7 +1103,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1144,7 +1144,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1203,7 +1203,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1262,7 +1262,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1324,7 +1324,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1385,7 +1385,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1446,7 +1446,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1509,7 +1509,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1568,7 +1568,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1629,7 +1629,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1691,7 +1691,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1747,7 +1747,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1802,7 +1802,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1839,7 +1839,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1876,7 +1876,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -1922,7 +1922,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -62,7 +62,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -111,7 +111,7 @@ postsubmits:
         - --modifier=update_proxy_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -157,7 +157,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -233,7 +233,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/build.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -219,7 +219,7 @@ postsubmits:
       - command:
         - entrypoint
         - release/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -260,7 +260,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -295,7 +295,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -330,7 +330,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -368,7 +368,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -408,7 +408,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -444,7 +444,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -163,7 +163,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -239,7 +239,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -274,7 +274,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -309,7 +309,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+        image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.9.yaml
+++ b/prow/config/jobs/api-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.9.yaml
+++ b/prow/config/jobs/client-go-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.9.yaml
+++ b/prow/config/jobs/common-files-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/envoy-1.9.yaml
+++ b/prow/config/jobs/envoy-1.9.yaml
@@ -51,7 +51,7 @@ jobs:
   - --cmd=UPDATE_BRANCH=release-1.9 scripts/update_envoy.sh $AUTOMATOR_SHA $AUTOMATOR_SHA_COMMIT_DATE
   requirements: [github]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+  image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
   timeout: 4h
 
 - name: update-envoy
@@ -69,7 +69,7 @@ jobs:
   - --merge-branch=release/v1.17
   requirements: [github]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+  image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
   timeout: 4h
 
 resources:

--- a/prow/config/jobs/gogo-genproto-1.9.yaml
+++ b/prow/config/jobs/gogo-genproto-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.9.yaml
+++ b/prow/config/jobs/istio.io-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.9.yaml
+++ b/prow/config/jobs/pkg-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.9.yaml
+++ b/prow/config/jobs/proxy-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools-proxy:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -36,7 +36,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56 
+  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-08-11T04-49-07 
   modifiers:
   - presubmit_optional
   name: release-centos-test
@@ -67,7 +67,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-07-13T16-45-56 
+  image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-08-11T04-49-07 
   name: release-centos
   requirements:
   - gcp
@@ -83,7 +83,7 @@ jobs:
   - --modifier=update_proxy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+  image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
   name: update-istio
   repos:
   - istio/test-infra@master

--- a/prow/config/jobs/release-builder-1.9.yaml
+++ b/prow/config/jobs/release-builder-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.9.yaml
+++ b/prow/config/jobs/tools-1.9.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.9
-image: gcr.io/istio-testing/build-tools:release-1.9-2021-07-13T16-45-56
+image: gcr.io/istio-testing/build-tools:release-1.9-2021-08-11T04-49-07
 jobs:
 - command:
   - make


### PR DESCRIPTION
Automator failed to put up a PR to update the images. Doing it manually.

Ran `find . -name '*.yaml' -exec sed -i 's/release-1.9-2021-07-13T16-45-56/release-1.9-2021-08-11T04-49-07/g' {} \;` to replace all instances.