### PR TITLE
Make the integ-istiodremote-k8s-tests test required

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2109,7 +2109,6 @@ presubmits:
       preset-override-deps: master-istio
       preset-override-envoy: "true"
     name: integ-istiodremote-k8s-tests_istio_priv
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -2034,7 +2034,6 @@ presubmits:
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
     name: integ-istiodremote-k8s-tests_istio_release-1.11_priv
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2023,7 +2023,6 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-istiodremote-k8s-tests_istio
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -1953,7 +1953,6 @@ presubmits:
     - ^release-1.11$
     decorate: true
     name: integ-istiodremote-k8s-tests_istio_release-1.11
-    optional: true
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -222,8 +222,6 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-08-09T16-46-08
-  modifiers:
-    - presubmit_optional
   name: integ-istiodremote-k8s-tests
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -110,8 +110,6 @@ jobs:
 
   - name: integ-istiodremote-k8s-tests
     types: [presubmit]
-    modifiers:
-      - presubmit_optional
     command:
       - entrypoint
       - prow/integ-suite-kind.sh


### PR DESCRIPTION
Looking at the test results from: https://prow.istio.io/job-history/gs/istio-prow/pr-logs/directory/integ-istiodremote-k8s-tests_istio_release-1.11 and https://prow.istio.io/job-history/gs/istio-prow/pr-logs/directory/integ-istiodremote-k8s-tests_istio I see only one recent failure in the tests (timeout). The others were related to rebase/pipeline failures