### PR TITLE
Remove multicluster label

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -522,16 +522,13 @@ postsubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
-        env:
-        - name: TEST_SELECT
-          value: -multicluster
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""
         resources:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2500,16 +2497,13 @@ presubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
-        env:
-        - name: TEST_SELECT
-          value: -multicluster
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""
         resources:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -577,16 +577,13 @@ postsubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
-        env:
-        - name: TEST_SELECT
-          value: -multicluster
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""
         resources:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -2374,16 +2371,13 @@ presubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
-        env:
-        - name: TEST_SELECT
-          value: -multicluster
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""
         resources:
           limits:
             memory: 24Gi
           requests:
-            cpu: "5"
+            cpu: "8"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -171,13 +171,11 @@ jobs:
       - prow/config/topology/external-istiod.json
       - test.integration.pilot.kube
     requirements: [kind]
+    resources: multicluster
     modifiers:
       - presubmit_optional
       - presubmit_skipped
       - hidden
-    env:
-      - name: TEST_SELECT
-        value: "-multicluster"
 
   - name: integ-pilot-istiodless-multicluster-tests
     modifiers:


### PR DESCRIPTION
It looks like @su225 sent a PR to remove the `multicluster` labels at the same time I sent a PR to add the new istiodremote job, which also had the label.