### PR TITLE
Skip VM tests in pilot-istiodremote job for now

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -521,6 +521,7 @@ postsubmits:
         - MULTICLUSTER
         - --topology-config
         - prow/config/topology/external-istiod.json
+        - --istio.test.skipVM
         - test.integration.pilot.kube
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""
@@ -2496,6 +2497,7 @@ presubmits:
         - MULTICLUSTER
         - --topology-config
         - prow/config/topology/external-istiod.json
+        - --istio.test.skipVM
         - test.integration.pilot.kube
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -576,6 +576,7 @@ postsubmits:
         - MULTICLUSTER
         - --topology-config
         - prow/config/topology/external-istiod.json
+        - --istio.test.skipVM
         - test.integration.pilot.kube
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""
@@ -2370,6 +2371,7 @@ presubmits:
         - MULTICLUSTER
         - --topology-config
         - prow/config/topology/external-istiod.json
+        - --istio.test.skipVM
         - test.integration.pilot.kube
         image: gcr.io/istio-testing/build-tools:master-2021-08-06T18-11-12
         name: ""

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -169,6 +169,7 @@ jobs:
       - MULTICLUSTER
       - --topology-config
       - prow/config/topology/external-istiod.json
+      - --istio.test.skipVM
       - test.integration.pilot.kube
     requirements: [kind]
     resources: multicluster


### PR DESCRIPTION
VM instance isn't set up properly in the framework which is causes many otherwise working tests to fail. Disable the VM part for now.