### PR TITLE
Initial steps to replace `prow-bot`, `prow-deployer`, `istio-prow-test-job`, and `boskos` SA keys with Workload Identity.

### DIFF
--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow
+  namespace: test-pods
+  name: prowjob-default-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: boskos@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow
+  namespace: boskos
+  name: boskos

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -23,7 +23,6 @@ spec:
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
-        - --gcs-credentials-file=/etc/service-account/service-account.json
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
@@ -39,9 +38,6 @@ spec:
           readOnly: true
         - name: slack
           mountPath: /etc/slack
-          readOnly: true
-        - name: service-account
-          mountPath: /etc/service-account
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
@@ -59,9 +55,6 @@ spec:
       - name: slack
         secret:
           secretName: slack-token
-      - name: service-account
-        secret:
-          secretName: prow-service-account
       - name: kubeconfig
         secret:
           defaultMode: 420

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow
+  namespace: test-pods
+  name: prowjob-default-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-deployer@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow
+  namespace: test-pods
+  name: prow-deployer

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -22,7 +22,6 @@ spec:
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
-        - --gcs-credentials-file=/etc/service-account/service-account.json
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
@@ -42,9 +41,6 @@ spec:
         - name: oauth
           mountPath: /etc/github
           readOnly: true
-        - name: service-account
-          mountPath: /etc/service-account
-          readOnly: true
       volumes:
       - name: oauth
         secret:
@@ -55,6 +51,3 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      - name: service-account
-        secret:
-          secretName: prow-service-account


### PR DESCRIPTION
The Prow components using the SA key in the `prow-service-account` secret should be able to rely on the already configured workload identity. I updated the IAM rules so we can just remove those mounts entirely.

After this merges I'll bind the SAs and make another PR to start using them.

/assign @chaodaiG 