### PR TITLE
Add automation to update common-files for a new build image

### DIFF
--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -160,9 +160,21 @@ postsubmits:
     spec:
       containers:
       - command:
-        - entrypoint
         - make
         - containers
+        - '|&'
+        - tee
+        - make.out
+        - '&&'
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=common-files
+        - '--title=Automator: update build-tools image@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --labels=release-notes-none
+        - --modifier=update_tools_dep
+        - --token-path=/etc/github-token/oauth
+        - --cmd=bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out
+          | sed -e 's/.*=//')
         image: gcr.io/istio-testing/build-tools:master-2021-09-08T17-55-51
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -186,6 +186,9 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
       nodeSelector:
         testing: test-pool
       volumes:
@@ -195,6 +198,9 @@ postsubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+      - name: github
+        secret:
+          secretName: oauth-token
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_tools_postsubmit

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -152,6 +152,11 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
     labels:
       preset-service-account: "true"
     name: containers_tools_postsubmit
@@ -165,10 +170,9 @@ postsubmits:
         - --repo=common-files
         - '--title=Automator: update build-tools image@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=release-notes-none
-        - --modifier=update_tools_dep
+        - --modifier=update_image_version
         - --token-path=/etc/github-token/oauth
-        - --cmd=pushd ../tools && make containers |& tee make.out && popd && ./bin/update_build_image.sh
-          --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
+        - --script-path=./bin/create-buildtools-and-update.sh
         image: gcr.io/istio-testing/build-tools:master-2021-09-08T17-55-51
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -167,9 +167,8 @@ postsubmits:
         - --labels=release-notes-none
         - --modifier=update_tools_dep
         - --token-path=/etc/github-token/oauth
-        - --cmd=pushd ../tools && make containers-test |& tee make.out && popd &&
-          ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out
-          | sed -e 's/.*=//')
+        - --cmd=pushd ../tools && make containers |& tee make.out && popd && ./bin/update_build_image.sh
+          --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
         image: gcr.io/istio-testing/build-tools:master-2021-09-08T17-55-51
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -160,12 +160,6 @@ postsubmits:
     spec:
       containers:
       - command:
-        - make
-        - containers
-        - '|&'
-        - tee
-        - make.out
-        - '&&'
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=common-files
@@ -173,7 +167,8 @@ postsubmits:
         - --labels=release-notes-none
         - --modifier=update_tools_dep
         - --token-path=/etc/github-token/oauth
-        - --cmd=bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out
+        - --cmd=pushd ../tools && make containers-test |& tee make.out && popd &&
+          ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out
           | sed -e 's/.*=//')
         image: gcr.io/istio-testing/build-tools:master-2021-09-08T17-55-51
         name: ""

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -37,7 +37,7 @@ jobs:
     - --labels=release-notes-none
     - --modifier=update_tools_dep
     - --token-path=/etc/github-token/oauth
-    - --cmd=pushd ../tools && make containers-test |& tee make.out && popd && ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
+    - --cmd=pushd ../tools && make containers |& tee make.out && popd && ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [gcp, docker]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -30,12 +30,6 @@ jobs:
   - name: containers
     types: [postsubmit]
     command:
-    - make
-    - containers
-    - "|&"
-    - tee
-    - make.out
-    - "&&"
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
     - --repo=common-files
@@ -43,7 +37,7 @@ jobs:
     - --labels=release-notes-none
     - --modifier=update_tools_dep
     - --token-path=/etc/github-token/oauth
-    - --cmd=bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
+    - --cmd=pushd ../tools && make containers-test |& tee make.out && popd && ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [gcp, docker]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -40,7 +40,7 @@ jobs:
     - --cmd=pushd ../tools && make containers |& tee make.out && popd && ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
     resources: build
     regex: 'docker/.+|cmd/.+'
-    requirements: [gcp, docker]
+    requirements: [gcp, docker, github]
 
   - name: containers-test
     types: [presubmit]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -35,12 +35,13 @@ jobs:
     - --repo=common-files
     - "--title=Automator: update build-tools image@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=release-notes-none
-    - --modifier=update_tools_dep
+    - --modifier=update_image_version
     - --token-path=/etc/github-token/oauth
-    - --cmd=pushd ../tools && make containers |& tee make.out && popd && ./bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
+    - --script-path=./bin/create-buildtools-and-update.sh
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [gcp, docker, github]
+    repos: [istio/test-infra@master]
 
   - name: containers-test
     types: [presubmit]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -29,7 +29,21 @@ jobs:
 
   - name: containers
     types: [postsubmit]
-    command: [entrypoint, make, containers]
+    command:
+    - make
+    - containers
+    - "|&"
+    - tee
+    - make.out
+    - "&&"
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=common-files
+    - "--title=Automator: update build-tools image@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --labels=release-notes-none
+    - --modifier=update_tools_dep
+    - --token-path=/etc/github-token/oauth
+    - --cmd=bin/update_build_image.sh --image $(grep "+ VERSION" ../tools/make.out | sed -e 's/.*=//')
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [gcp, docker]


### PR DESCRIPTION
Requires https://github.com/istio/common-files/pull/464. Once that PR and this PR merges, it will fix: https://github.com/istio/test-infra/issues/2469.

I'm not sure of the appropriate way to combine a job in the current repo and running automator against another repo.

In this case, I'm doing the existing post submit to create the build-image and then in the automator sh running in the common-files I grep the build output from the tools directory and call the script.

Another option would be to simply call the automator script in the common-files repo, which cd's back to tools and does the `make` and then runs the script back in the common-files directory. This keeps the total command in the automator --cmd.