### PR TITLE
Fixes to the Prow configgen tool

### DIFF
--- a/prow/config/testdata/simple-matrix.gen.yaml
+++ b/prow/config/testdata/simple-matrix.gen.yaml
@@ -62,7 +62,9 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg1-val1_istio_postsubmit
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg1-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -152,7 +154,9 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg1-val2_istio_postsubmit
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg1-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -242,7 +246,9 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg2-val1_istio_postsubmit
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg2-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -332,7 +338,9 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg2-val2_istio_postsubmit
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg2-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -422,7 +430,9 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg3-val1_istio_postsubmit
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg3-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -512,7 +522,9 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg3-val2_istio_postsubmit
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg3-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -602,7 +614,9 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg1-val1_istio
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg1-val1_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -690,7 +704,9 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg1-val2_istio
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg1-val2_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -778,7 +794,9 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg2-val1_istio
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg2-val1_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -866,7 +884,9 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg2-val2_istio
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg2-val2_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -954,7 +974,9 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg3-val1_istio
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg3-val1_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1042,7 +1064,9 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: test-gcloud-arg3-val2_istio
+    labels:
+      preset-service-account: "true"
+    name: test-gcp-arg3-val2_istio
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/config/testdata/simple-matrix.yaml
+++ b/prow/config/testdata/simple-matrix.yaml
@@ -5,7 +5,7 @@ branches:
   - master
 matrix:
   command-arg: [arg1, arg2, arg3]
-  requirement: [kind, gcloud]
+  requirement: [kind, gcp]
   env-val: [val1, val2]
 
 jobs:


### PR DESCRIPTION
1. Validate the requirements when applying, instead of from the raw job config, since we may want to use the matrix syntax to simplify the requirements config.

2. The `deepcopier` library isn't really doing deepcopy and causing some issues. I haven't figured out a proper way to fix it yet, but for now resetting the `BaseRequirements` to an empty slice as a workaround.