### PR TITLE
Make default build cluster use Workload Identity.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -19,6 +19,10 @@ plank:
         bucket: "istio-prow"
         path_strategy: "explicit"
       gcs_credentials_secret: "service-account"
+  - cluster: default
+    config:
+      gcs_credentials_secret: ""
+      default_service_account_name: "prowjob-default-sa"
   - cluster: test-infra-trusted
     config:
       gcs_credentials_secret: ""


### PR DESCRIPTION
This a follow up to https://github.com/istio/test-infra/pull/3517 and https://github.com/istio/test-infra/pull/3520.
I think this is the last piece.
Hold until Monday so that we can monitor in case the default service account had permissions that were being relied on.
/cc @chaodaiG 
/hold