### PR TITLE
Remove `cla:yes` label check from queries for the istio.io repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -369,7 +369,6 @@ tide:
     - istio/api
     - istio/common-files
     - istio/community
-    - istio/istio.io
     - istio/gogo-genproto
     - istio/test-infra
     - istio/cni
@@ -394,7 +393,6 @@ tide:
     - istio/api
     - istio/common-files
     - istio/community
-    - istio/istio.io
     - istio/gogo-genproto
     - istio/test-infra
     - istio/cni
@@ -404,6 +402,20 @@ tide:
     - istio/release-builder
     labels:
     - "cla: yes"
+    - auto-merge
+    missingLabels: *istio_tide_missing_labels
+    author: istio-testing
+    reviewApprovedRequired: false
+  - repos:
+    - istio/istio.io
+    missingLabels: &istio_tide_missing_labels
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    reviewApprovedRequired: true
+  - repos:
+    - istio/istio.io
+    labels:
     - auto-merge
     missingLabels: *istio_tide_missing_labels
     author: istio-testing


### PR DESCRIPTION
The istio.io repo has a new check for determining the CLA status using a check, and no longer sets the `cla:yes` label. This removes the requirement for that label to exist in that specific repo.

This check might be able to be removed across all repos as there still is a **required** `cla/google` listed. I don't have enough history to know if removing the check makes sense across the repos. 

Two examples of PRs in the istio.io repos where the `cla: no` label is set and the `cla/google` check is failing are https://github.com/istio/istio.io/pull/10257 and https://github.com/istio/istio.io/pull/7554. Would be interesting if those PRs merge after this change meaning the negative required check will not hold out older (pre the new CLA check) PRs.