### PR TITLE
Revert "Update Prow to v20210924-1544aef1b6"

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
   run_if_changed: '^(\.prow|prow/(config|plugins|cluster/jobs/.*))\.yaml$'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20210924-1544aef1b6
+    - image: gcr.io/k8s-prow/checkconfig:v20210922-3d09bce713
       command:
       - /checkconfig
       args:

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/cherrypicker:v20210922-3d09bce713
         args:
         - --create-issue-on-conflict
         - --dry-run=false

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/crier:v20210922-3d09bce713
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/deck:v20210922-3d09bce713
         ports:
         - name: http
           containerPort: 8080

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-private
-        image: gcr.io/k8s-prow/deck:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/deck:v20210922-3d09bce713
         ports:
         - name: http
           containerPort: 8080

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/ghproxy:v20210922-3d09bce713
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/hook:v20210922-3d09bce713
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/horologium:v20210922-3d09bce713
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -45,7 +45,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/branchprotector:v20210924-1544aef1b6
+    - image: gcr.io/k8s-prow/branchprotector:v20210922-3d09bce713
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -75,7 +75,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210924-1544aef1b6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210922-3d09bce713
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -106,7 +106,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210924-1544aef1b6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210922-3d09bce713
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/needs-rebase:v20210922-3d09bce713
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210922-3d09bce713
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/sinker:v20210922-3d09bce713
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/status-reconciler:v20210922-3d09bce713
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210924-1544aef1b6
+        image: gcr.io/k8s-prow/tide:v20210922-3d09bce713
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11,10 +11,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210924-1544aef1b6"
-        initupload: "gcr.io/k8s-prow/initupload:v20210924-1544aef1b6"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210924-1544aef1b6"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210924-1544aef1b6"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210922-3d09bce713"
+        initupload: "gcr.io/k8s-prow/initupload:v20210922-3d09bce713"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210922-3d09bce713"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210922-3d09bce713"
       gcs_configuration:
         bucket: "istio-prow"
         path_strategy: "explicit"


### PR DESCRIPTION
Reverts istio/test-infra#3580

The timing of this exactly correlates to https://github.com/istio/istio/issues/35384; see https://testgrid.k8s.io/istio_istio#integ-security-k8s-tests_istio&exclude-non-failed-tests=20&width=20.

Note: it sounds very likely its NOT a prow issue but a GKE issue. However, since this occurred at literally the exact same time as the prow bump, revert seems like a reasonable first step. See https://github.com/kubernetes/test-infra/issues/23741