### PR TITLE
Add hidden,optional,skipped multicluster istiodremote pilot test

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -645,6 +645,79 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+    name: integ-pilot-istiodremote-multicluster-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    reporter_config:
+      slack:
+        job_states_to_report: []
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/external-istiod-multicluster.json
+        - test.integration.pilot.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
+        image: gcr.io/istio-testing/build-tools:master-2021-09-13T18-33-43
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
     name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
@@ -2774,6 +2847,81 @@ presubmits:
         - MULTICLUSTER
         - --topology-config
         - prow/config/topology/external-istiod.json
+        - test.integration.pilot.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
+        image: gcr.io/istio-testing/build-tools:master-2021-09-13T18-33-43
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: integ-pilot-istiodremote-multicluster-tests_istio_priv
+    optional: true
+    path_alias: istio.io/istio
+    reporter_config:
+      slack:
+        job_states_to_report: []
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -690,6 +690,74 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-pilot-istiodremote-multicluster-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    reporter_config:
+      slack:
+        job_states_to_report: []
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/external-istiod-multicluster.json
+        - test.integration.pilot.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
+        image: gcr.io/istio-testing/build-tools:master-2021-09-13T18-33-43
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
@@ -2626,6 +2694,74 @@ presubmits:
         - MULTICLUSTER
         - --topology-config
         - prow/config/topology/external-istiod.json
+        - test.integration.pilot.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
+        image: gcr.io/istio-testing/build-tools:master-2021-09-13T18-33-43
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-pilot-istiodremote-multicluster-tests_istio
+    optional: true
+    path_alias: istio.io/istio
+    reporter_config:
+      slack:
+        job_states_to_report: []
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --topology
+        - MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -192,6 +192,25 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
+  - name: integ-pilot-istiodremote-multicluster-tests
+    modifiers:
+      - presubmit_optional
+      - presubmit_skipped
+      - hidden
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --topology
+      - MULTICLUSTER
+      - --topology-config
+      - prow/config/topology/external-istiod-multicluster.json
+      - test.integration.pilot.kube
+    requirements: [kind]
+    resources: multicluster
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: --istio.test.skipVM
+
   - name: integ-pilot-istiodless-multicluster-tests
     modifiers:
       - presubmit_optional


### PR DESCRIPTION
Add a new test based on the `integ-pilot-istiodremote-tests` but use the multicluster prow/config/topology/external-istiod-multicluster.json. The istio test cases were updated to pass this test in https://github.com/istio/istio/pull/35320. Once that merges, we can run some tests before making this a permanent required test. Once this in in, we can remove the `integ-istiodremote-k8s-tests` test as this new test covers it. 