### PR TITLE
Fix the 'generate branch xxx' command

### DIFF
--- a/prow/config/cmd/generate.go
+++ b/prow/config/cmd/generate.go
@@ -73,6 +73,9 @@ func main() {
 
 	if os.Args[1] == "branch" {
 		if err := filepath.WalkDir(*inputDir, func(path string, d os.DirEntry, err error) error {
+			if !d.IsDir() {
+				return nil
+			}
 			if err != nil {
 				fmt.Printf("error: %s\n", err.Error())
 			}


### PR DESCRIPTION
The error is
```
go run ./generate.go branch 1.12
2021/10/28 09:01:15 skipping .base.yaml
failed to read ../jobs/.base.yaml/.base.yaml: open ../jobs/.base.yaml/.base.yaml: not a directory
exit status 1
```

This change should be able to fix it.

/cc @stewartbutler 