### PR TITLE
Fix release-1.12 automated proxy jobs failing with unbound variable

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
@@ -153,7 +153,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2021-10-28T19-42-57
+        image: gcr.io/istio-testing/build-tools:release-1.12-2021-10-28T19-42-57
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=update_envoy_dep
       - --token-path=/etc/github-token/oauth
       - --cmd=UPDATE_BRANCH=release/v1.20 scripts/update_envoy.sh
-      image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2021-10-28T19-42-57
+      image: gcr.io/istio-testing/build-tools:release-1.12-2021-10-28T19-42-57
       name: ""
       resources:
         limits:
@@ -170,7 +170,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2021-10-28T19-42-57
+        image: gcr.io/istio-testing/build-tools:release-1.12-2021-10-28T19-42-57
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/proxy-1.12.yaml
+++ b/prow/config/jobs/proxy-1.12.yaml
@@ -106,6 +106,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
+  image: gcr.io/istio-testing/build-tools:release-1.12-2021-10-28T19-42-57
   name: update-istio
   node_selector:
     testing: build-pool
@@ -126,6 +127,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.20 scripts/update_envoy.sh
+  image: gcr.io/istio-testing/build-tools:release-1.12-2021-10-28T19-42-57
   interval: 24h
   name: update-proxy
   node_selector:


### PR DESCRIPTION
Using the inherited  build-tools-proxy image causes the failure. The jobs in the other releases use the build-tools image so adding here.