### PR TITLE
Move more Prow jobs to use workload identity

### DIFF
--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -3,8 +3,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    iam.gke.io/gcp-service-account: istio-prow-test-job-default@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow
+  namespace: test-pods
+  name: prowjob-default-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
   labels:
     app.kubernetes.io/part-of: prow-build
   namespace: test-pods
-  name: prowjob-admin-sa
+  name: prowjob-advanced-sa

--- a/prow/cluster/jobs/all-presets.yaml
+++ b/prow/cluster/jobs/all-presets.yaml
@@ -1,33 +1,5 @@
 presets:
 - labels:
-    preset-prow-pusher-service-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /creds/service-account.json
-  volumeMounts:
-  - name: creds
-    mountPath: /creds
-    readOnly: true
-  volumes:
-  - name: creds
-    secret:
-      secretName: prow-pusher-service-account
-- labels:
-    preset-service-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/service-account/service-account.json
-  - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
-    value: /etc/service-account/service-account.json
-  volumeMounts:
-  - name: service
-    mountPath: /etc/service-account
-    readOnly: true
-  volumes:
-  - name: service
-    secret:
-      secretName: service-account
-- labels:
     preset-bazel: "true"
   volumeMounts:
   - name: cache-ssd

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
-      preset-service-account: "true"
     name: release_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -46,6 +45,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1850,7 +1850,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -1879,6 +1878,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
-      preset-service-account: "true"
     name: release_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -46,6 +45,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1175,7 +1175,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
@@ -1204,6 +1203,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
-      preset-service-account: "true"
     name: release_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -46,6 +45,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1461,7 +1461,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
@@ -1490,6 +1489,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
-      preset-service-account: "true"
     name: release_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -46,6 +45,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1850,7 +1850,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
@@ -1879,6 +1878,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
-      preset-service-account: "true"
     name: release_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -43,6 +42,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -107,7 +107,6 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -133,6 +132,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -954,7 +954,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
@@ -980,6 +979,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
-      preset-service-account: "true"
     name: release_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -46,6 +45,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -113,7 +113,6 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -142,6 +141,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1279,7 +1279,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
@@ -1308,6 +1307,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       preset-enable-gomod-netrc: "true"
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
-      preset-service-account: "true"
     name: release_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -46,6 +45,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1106,7 +1106,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-      preset-service-account: "true"
     name: release-test_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
@@ -1135,6 +1134,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -69,7 +69,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -105,6 +104,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -195,7 +195,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -225,6 +224,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -242,7 +242,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-asan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -272,6 +271,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -289,7 +289,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-tsan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -319,6 +318,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -336,7 +336,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -366,6 +365,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -383,7 +383,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos-test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -413,6 +412,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: check-wasm_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -463,6 +462,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.10.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_release-1.10_postsubmit_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -69,7 +69,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.10_postsubmit_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -105,6 +104,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -194,7 +194,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test_proxy_release-1.10_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -224,6 +223,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -241,7 +241,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.10_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -271,6 +270,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -288,7 +288,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.10_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -318,6 +317,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -335,7 +335,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_release-1.10_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -365,6 +364,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -382,7 +382,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.10_release-1.10_priv
     optional: true
     path_alias: istio.io/proxy
@@ -413,6 +412,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.10_release-1.10_priv
     path_alias: istio.io/proxy
     spec:
@@ -463,6 +462,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_release-1.11_postsubmit_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -69,7 +69,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.11_postsubmit_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -105,6 +104,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -195,7 +195,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -225,6 +224,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -242,7 +242,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -272,6 +271,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -289,7 +289,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -319,6 +318,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -336,7 +336,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -366,6 +365,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -383,7 +383,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -413,6 +412,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
     spec:
@@ -463,6 +462,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_release-1.12_postsubmit_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -69,7 +69,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.12_postsubmit_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -105,6 +104,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -195,7 +195,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -225,6 +224,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -242,7 +242,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -272,6 +271,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -289,7 +289,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -319,6 +318,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -336,7 +336,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -366,6 +365,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -383,7 +383,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -413,6 +412,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
     spec:
@@ -463,6 +462,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.7.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_release-1.7_postsubmit_release-1.7_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -272,7 +272,6 @@ presubmits:
     decorate: true
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_release-1.7_release-1.7_priv
     path_alias: istio.io/proxy
     spec:
@@ -302,6 +301,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.8.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_release-1.8_postsubmit_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -69,7 +69,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.8_postsubmit_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -105,6 +104,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -194,7 +194,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -224,6 +223,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -241,7 +241,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -271,6 +270,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -288,7 +288,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -318,6 +317,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -335,7 +335,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -365,6 +364,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -382,7 +382,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.8_release-1.8_priv
     optional: true
     path_alias: istio.io/proxy
@@ -413,6 +412,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.8_release-1.8_priv
     path_alias: istio.io/proxy
     spec:
@@ -463,6 +462,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.9.gen.yaml
@@ -12,7 +12,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release_proxy_release-1.9_postsubmit_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -51,6 +50,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -69,7 +69,6 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.9_postsubmit_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -105,6 +104,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -194,7 +194,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -224,6 +223,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -241,7 +241,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -271,6 +270,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -288,7 +288,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -318,6 +317,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -335,7 +335,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-test_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -365,6 +364,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -382,7 +382,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.9_release-1.9_priv
     optional: true
     path_alias: istio.io/proxy
@@ -413,6 +412,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.9_release-1.9_priv
     path_alias: istio.io/proxy
     spec:
@@ -463,6 +462,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -152,8 +152,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: deploy-policybot_bots_postsubmit
     path_alias: istio.io/bots
     run_if_changed: ^policybot/
@@ -220,6 +218,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -112,8 +112,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -142,6 +140,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -156,8 +155,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -186,6 +183,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1801,8 +1799,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio
     path_alias: istio.io/istio
     spec:
@@ -1831,6 +1827,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -51,8 +51,6 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -81,6 +79,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -95,8 +94,6 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -125,6 +122,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1115,8 +1113,6 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio_release-1.10
     path_alias: istio.io/istio
     spec:
@@ -1145,6 +1141,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -112,8 +112,6 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -142,6 +140,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -156,8 +155,6 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -186,6 +183,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1442,8 +1440,6 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio_release-1.11
     path_alias: istio.io/istio
     spec:
@@ -1472,6 +1468,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -112,8 +112,6 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -142,6 +140,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -156,8 +155,6 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -186,6 +183,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1801,8 +1799,6 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio_release-1.12
     path_alias: istio.io/istio
     spec:
@@ -1831,6 +1827,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -48,8 +48,6 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -75,6 +73,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -89,8 +88,6 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -116,6 +113,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -863,8 +861,6 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio_release-1.7
     path_alias: istio.io/istio
     spec:
@@ -890,6 +886,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -51,8 +51,6 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -81,6 +79,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -95,8 +94,6 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -125,6 +122,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1168,8 +1166,6 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio_release-1.8
     path_alias: istio.io/istio
     spec:
@@ -1198,6 +1194,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -51,8 +51,6 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -81,6 +79,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -95,8 +94,6 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark-report_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -125,6 +122,7 @@ postsubmits:
           subPath: gocache
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1051,8 +1049,6 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_istio_release-1.9
     path_alias: istio.io/istio
     spec:
@@ -1081,6 +1077,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -68,8 +68,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -96,6 +94,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -112,8 +111,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -137,6 +134,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -208,8 +206,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test_proxy
     path_alias: istio.io/proxy
     spec:
@@ -233,6 +229,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -246,8 +243,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-asan_proxy
     path_alias: istio.io/proxy
     spec:
@@ -271,6 +266,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -284,8 +280,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-tsan_proxy
     path_alias: istio.io/proxy
     spec:
@@ -309,6 +303,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -322,8 +317,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy
     path_alias: istio.io/proxy
     spec:
@@ -347,6 +340,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -360,8 +354,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos-test_proxy
     path_alias: istio.io/proxy
     spec:
@@ -385,6 +377,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -398,8 +391,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: check-wasm_proxy
     path_alias: istio.io/proxy
     spec:
@@ -426,6 +417,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.10.gen.yaml
@@ -10,8 +10,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_release-1.10_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -38,6 +36,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -54,8 +53,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.10_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -79,6 +76,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -149,8 +147,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test_proxy_release-1.10
     path_alias: istio.io/proxy
     spec:
@@ -174,6 +170,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -187,8 +184,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.10
     path_alias: istio.io/proxy
     spec:
@@ -212,6 +207,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -225,8 +221,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.10
     path_alias: istio.io/proxy
     spec:
@@ -250,6 +244,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -263,8 +258,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy_release-1.10
     path_alias: istio.io/proxy
     spec:
@@ -288,6 +281,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -301,8 +295,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.10
     optional: true
     path_alias: istio.io/proxy
@@ -327,6 +319,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -340,8 +333,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.10
     path_alias: istio.io/proxy
     spec:
@@ -368,6 +359,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
@@ -68,8 +68,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_release-1.11_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -96,6 +94,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -112,8 +111,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.11_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -137,6 +134,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -208,8 +206,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test_proxy_release-1.11
     path_alias: istio.io/proxy
     spec:
@@ -233,6 +229,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -246,8 +243,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.11
     path_alias: istio.io/proxy
     spec:
@@ -271,6 +266,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -284,8 +280,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.11
     path_alias: istio.io/proxy
     spec:
@@ -309,6 +303,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -322,8 +317,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy_release-1.11
     path_alias: istio.io/proxy
     spec:
@@ -347,6 +340,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -360,8 +354,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.11
     path_alias: istio.io/proxy
     spec:
@@ -385,6 +377,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -398,8 +391,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.11
     path_alias: istio.io/proxy
     spec:
@@ -426,6 +417,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
@@ -68,8 +68,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_release-1.12_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -96,6 +94,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -112,8 +111,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.12_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -137,6 +134,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -208,8 +206,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test_proxy_release-1.12
     path_alias: istio.io/proxy
     spec:
@@ -233,6 +229,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -246,8 +243,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.12
     path_alias: istio.io/proxy
     spec:
@@ -271,6 +266,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -284,8 +280,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.12
     path_alias: istio.io/proxy
     spec:
@@ -309,6 +303,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -322,8 +317,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy_release-1.12
     path_alias: istio.io/proxy
     spec:
@@ -347,6 +340,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -360,8 +354,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.12
     path_alias: istio.io/proxy
     spec:
@@ -385,6 +377,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -398,8 +391,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.12
     path_alias: istio.io/proxy
     spec:
@@ -426,6 +417,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.7.gen.yaml
@@ -10,8 +10,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_release-1.7_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -38,6 +36,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -210,8 +209,6 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy_release-1.7
     path_alias: istio.io/proxy
     spec:
@@ -235,6 +232,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.8.gen.yaml
@@ -10,8 +10,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_release-1.8_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -38,6 +36,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -54,8 +53,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.8_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -79,6 +76,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -149,8 +147,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -174,6 +170,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -187,8 +184,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -212,6 +207,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -225,8 +221,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -250,6 +244,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -263,8 +258,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -288,6 +281,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -301,8 +295,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.8
     optional: true
     path_alias: istio.io/proxy
@@ -327,6 +319,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -340,8 +333,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.8
     path_alias: istio.io/proxy
     spec:
@@ -368,6 +359,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.9.gen.yaml
@@ -10,8 +10,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release_proxy_release-1.9_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -38,6 +36,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -54,8 +53,6 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos_proxy_release-1.9_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -79,6 +76,7 @@ postsubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -149,8 +147,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -174,6 +170,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -187,8 +184,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-asan_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -212,6 +207,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -225,8 +221,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: test-tsan_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -250,6 +244,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -263,8 +258,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-test_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -288,6 +281,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -301,8 +295,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: release-centos-test_proxy_release-1.9
     optional: true
     path_alias: istio.io/proxy
@@ -327,6 +319,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -340,8 +333,6 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    labels:
-      preset-service-account: "true"
     name: check-wasm_proxy_release-1.9
     path_alias: istio.io/proxy
     spec:
@@ -368,6 +359,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -177,8 +177,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -206,6 +204,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -431,8 +430,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -460,6 +457,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
@@ -116,8 +116,6 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.10_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -145,6 +143,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -370,8 +369,6 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.10
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -399,6 +396,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
@@ -116,8 +116,6 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.11_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -145,6 +143,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -370,8 +369,6 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.11
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -399,6 +396,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
@@ -177,8 +177,6 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.12_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -206,6 +204,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -431,8 +430,6 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.12
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -460,6 +457,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
@@ -116,8 +116,6 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.7_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -145,6 +143,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -363,8 +362,6 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.7
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -392,6 +389,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
@@ -116,8 +116,6 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.8_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -145,6 +143,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -370,8 +369,6 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.8
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -399,6 +396,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
@@ -116,8 +116,6 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.9_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -145,6 +143,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -370,8 +369,6 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: dry-run_release-builder_release-1.9
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
@@ -399,6 +396,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -175,8 +175,6 @@ postsubmits:
     - ^master$
     cluster: test-infra-trusted
     decorate: true
-    labels:
-      preset-service-account: "true"
     max_concurrency: 1
     name: push-mason_test-infra_postsubmit
     path_alias: istio.io/test-infra
@@ -207,6 +205,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         prod: prow
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -222,8 +221,6 @@ postsubmits:
     - ^master$
     cluster: test-infra-trusted
     decorate: true
-    labels:
-      preset-service-account: "true"
     max_concurrency: 1
     name: push-prowbazel_test-infra_postsubmit
     path_alias: istio.io/test-infra
@@ -256,6 +253,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         prod: prow
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -271,8 +269,6 @@ postsubmits:
     - ^master$
     cluster: test-infra-trusted
     decorate: true
-    labels:
-      preset-service-account: "true"
     max_concurrency: 1
     name: push-authentikos_test-infra_postsubmit
     path_alias: istio.io/test-infra
@@ -304,6 +300,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         prod: prow
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -319,8 +316,6 @@ postsubmits:
     - ^master$
     cluster: test-infra-trusted
     decorate: true
-    labels:
-      preset-service-account: "true"
     max_concurrency: 1
     name: push-genjobs_test-infra_postsubmit
     path_alias: istio.io/test-infra
@@ -352,6 +347,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         prod: prow
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -510,8 +506,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: integ-test-authentikos_test-infra
     path_alias: istio.io/test-infra
     run_if_changed: ^authentikos/(test/.+|.+\.go|go\.mod)$
@@ -548,6 +542,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -161,8 +161,6 @@ postsubmits:
       org: istio
       path_alias: istio.io/common-files
       repo: common-files
-    labels:
-      preset-service-account: "true"
     name: containers_tools_postsubmit
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -200,6 +198,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -217,8 +216,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: deploy-perf-dashboard_tools_postsubmit
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
@@ -249,6 +246,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -404,8 +402,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: benchmark_check_tools
     optional: true
     path_alias: istio.io/tools
@@ -435,6 +431,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -446,8 +443,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers-test_tools
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -476,6 +471,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.10.gen.yaml
@@ -152,8 +152,6 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers_tools_release-1.10_postsubmit
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -182,6 +180,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -196,8 +195,6 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: deploy-perf-dashboard_tools_release-1.10_postsubmit
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
@@ -228,6 +225,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -383,8 +381,6 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers-test_tools_release-1.10
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -413,6 +409,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
@@ -152,8 +152,6 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers_tools_release-1.11_postsubmit
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -182,6 +180,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -196,8 +195,6 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: deploy-perf-dashboard_tools_release-1.11_postsubmit
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
@@ -228,6 +225,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -383,8 +381,6 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers-test_tools_release-1.11
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -413,6 +409,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.12.gen.yaml
@@ -198,7 +198,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
-      serviceAccountName: prowjob-admin-sa
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -246,7 +246,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
-      serviceAccountName: prowjob-admin-sa
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -430,7 +430,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
-      serviceAccountName: prowjob-admin-sa
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.7.gen.yaml
@@ -152,8 +152,6 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers_tools_release-1.7_postsubmit
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -182,6 +180,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -337,8 +336,6 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers-test_tools_release-1.7
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -367,6 +364,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.8.gen.yaml
@@ -152,8 +152,6 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers_tools_release-1.8_postsubmit
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -182,6 +180,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -196,8 +195,6 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: deploy-perf-dashboard_tools_release-1.8_postsubmit
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
@@ -383,8 +380,6 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers-test_tools_release-1.8
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -413,6 +408,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.9.gen.yaml
@@ -152,8 +152,6 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers_tools_release-1.9_postsubmit
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -182,6 +180,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -337,8 +336,6 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    labels:
-      preset-service-account: "true"
     name: containers-test_tools_release-1.9
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+
@@ -367,6 +364,7 @@ presubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -3,11 +3,21 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    iam.gke.io/gcp-service-account: istio-prow-test-job-default@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow
+  namespace: test-pods
+  name: prowjob-default-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
   labels:
     app.kubernetes.io/part-of: prow
   namespace: test-pods
-  name: prowjob-admin-sa
+  name: prowjob-advanced-sa
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -22,9 +22,11 @@ plank:
   - cluster: default
     config:
       gcs_credentials_secret: ""
+      default_service_account_name: "prowjob-default-sa"
   - cluster: test-infra-trusted
     config:
       gcs_credentials_secret: ""
+      default_service_account_name: "prowjob-default-sa"
   - repo: istio-private
     config:
       gcs_configuration:

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -98,6 +98,3 @@ requirement_presets:
           secretKeyRef:
             name: "cosign-key"
             key: "key"
-  gcp:
-    labels:
-      preset-service-account: "true"

--- a/prow/config/jobs/api-1.10.yaml
+++ b/prow/config/jobs/api-1.10.yaml
@@ -77,12 +77,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/api-1.11.yaml
+++ b/prow/config/jobs/api-1.11.yaml
@@ -104,13 +104,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/api-1.12.yaml
+++ b/prow/config/jobs/api-1.12.yaml
@@ -101,14 +101,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -16,6 +16,7 @@ jobs:
     command: [make, gen-check]
 
   - name: deploy-policybot
+    service_account_name: prowjob-advanced-sa
     regex: '^policybot/'
     types: [postsubmit]
     command:
@@ -24,7 +25,7 @@ jobs:
     - -C
     - policybot
     - deploy
-    requirements: [docker, gcp]
+    requirements: [docker]
     env:
     - name: GITHUB_WEBHOOK_SECRET
       valueFrom:

--- a/prow/config/jobs/client-go-1.10.yaml
+++ b/prow/config/jobs/client-go-1.10.yaml
@@ -50,12 +50,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/client-go-1.11.yaml
+++ b/prow/config/jobs/client-go-1.11.yaml
@@ -77,13 +77,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/client-go-1.12.yaml
+++ b/prow/config/jobs/client-go-1.12.yaml
@@ -75,14 +75,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/common-files-1.10.yaml
+++ b/prow/config/jobs/common-files-1.10.yaml
@@ -98,12 +98,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/common-files-1.11.yaml
+++ b/prow/config/jobs/common-files-1.11.yaml
@@ -104,13 +104,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/common-files-1.12.yaml
+++ b/prow/config/jobs/common-files-1.12.yaml
@@ -102,14 +102,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/enhancements-1.11.yaml
+++ b/prow/config/jobs/enhancements-1.11.yaml
@@ -45,13 +45,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/enhancements-1.12.yaml
+++ b/prow/config/jobs/enhancements-1.12.yaml
@@ -46,14 +46,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/gogo-genproto-1.10.yaml
+++ b/prow/config/jobs/gogo-genproto-1.10.yaml
@@ -50,12 +50,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/gogo-genproto-1.11.yaml
+++ b/prow/config/jobs/gogo-genproto-1.11.yaml
@@ -78,13 +78,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/gogo-genproto-1.12.yaml
+++ b/prow/config/jobs/gogo-genproto-1.12.yaml
@@ -76,14 +76,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -20,11 +20,11 @@ jobs:
   - entrypoint
   - prow/release-test.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - docker
   - gocache
   types:
@@ -33,11 +33,11 @@ jobs:
   - entrypoint
   - prow/release-commit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - docker
   - gocache
   types:
@@ -64,11 +64,11 @@ jobs:
   - benchtest
   - report-benchtest
   name: benchmark-report
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - gocache
   resources: benchmark
   types:
@@ -480,12 +480,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -22,11 +22,11 @@ jobs:
   - prow/release-test.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: release-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - docker
   - gocache
   types:
@@ -36,11 +36,11 @@ jobs:
   - prow/release-commit.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: release
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - docker
   - gocache
   types:
@@ -69,11 +69,11 @@ jobs:
   - report-benchtest
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: benchmark-report
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - gocache
   resources: benchmark
   types:
@@ -666,13 +666,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -20,11 +20,11 @@ jobs:
   - entrypoint
   - prow/release-test.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - docker
   - gocache
   types:
@@ -33,11 +33,11 @@ jobs:
   - entrypoint
   - prow/release-commit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - docker
   - gocache
   types:
@@ -64,11 +64,11 @@ jobs:
   - benchtest
   - report-benchtest
   name: benchmark-report
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   requirements:
   - cache
-  - gcp
   - gocache
   resources: benchmark
   types:
@@ -682,14 +682,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -15,16 +15,16 @@ jobs:
   - entrypoint
   - prow/release-test.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   types: [presubmit]
 - command:
   - entrypoint
   - prow/release-commit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   types: [postsubmit]
 - command:
@@ -43,8 +43,7 @@ jobs:
   - benchtest
   - report-benchtest
   name: benchmark-report
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   resources: benchmark
   types: [postsubmit]
 - command:

--- a/prow/config/jobs/istio-1.8.yaml
+++ b/prow/config/jobs/istio-1.8.yaml
@@ -15,16 +15,16 @@ jobs:
   - entrypoint
   - prow/release-test.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   types: [presubmit]
 - command:
   - entrypoint
   - prow/release-commit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   types: [postsubmit]
 - command:
@@ -43,8 +43,7 @@ jobs:
   - benchtest
   - report-benchtest
   name: benchmark-report
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   resources: benchmark
   types: [postsubmit]
 - command:

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -15,8 +15,8 @@ jobs:
   - entrypoint
   - prow/release-test.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   types:
   - presubmit
@@ -24,8 +24,8 @@ jobs:
   - entrypoint
   - prow/release-commit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   types:
   - postsubmit
@@ -46,8 +46,7 @@ jobs:
   - benchtest
   - report-benchtest
   name: benchmark-report
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   resources: benchmark
   types:
   - postsubmit

--- a/prow/config/jobs/istio.io-1.10.yaml
+++ b/prow/config/jobs/istio.io-1.10.yaml
@@ -103,12 +103,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/istio.io-1.11.yaml
+++ b/prow/config/jobs/istio.io-1.11.yaml
@@ -112,13 +112,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/istio.io-1.12.yaml
+++ b/prow/config/jobs/istio.io-1.12.yaml
@@ -107,14 +107,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -7,14 +7,16 @@ jobs:
     command: [entrypoint, make, -e, "T=-v -count=1", build, racetest, binaries-test]
 
   - name: release-test
+    service_account_name: prowjob-advanced-sa
     types: [presubmit]
     command: [entrypoint, prow/release-test.sh]
-    requirements: [gcp, docker]
+    requirements: [docker]
 
   - name: release
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     command: [entrypoint, prow/release-commit.sh]
-    requirements: [gcp, docker]
+    requirements: [docker]
 
   - name: benchmark
     types: [presubmit]
@@ -23,9 +25,9 @@ jobs:
     resources: benchmark
 
   - name: benchmark-report
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     command: [entrypoint, make, benchtest, report-benchtest]
-    requirements: [gcp]
     resources: benchmark
 
   - name: integ-pilot-k8s-tests

--- a/prow/config/jobs/pkg-1.10.yaml
+++ b/prow/config/jobs/pkg-1.10.yaml
@@ -58,12 +58,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/pkg-1.11.yaml
+++ b/prow/config/jobs/pkg-1.11.yaml
@@ -85,13 +85,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/pkg-1.12.yaml
+++ b/prow/config/jobs/pkg-1.12.yaml
@@ -82,14 +82,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/proxy-1.10.yaml
+++ b/prow/config/jobs/proxy-1.10.yaml
@@ -5,44 +5,44 @@ jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   name: test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-asan.sh
   name: test-asan
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-tsan.sh
   name: test-tsan
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-release.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -52,11 +52,11 @@ jobs:
   modifiers:
   - presubmit_optional
   name: release-centos-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -64,11 +64,11 @@ jobs:
   - entrypoint
   - ./prow/proxy-presubmit-wasm.sh
   name: check-wasm
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -77,11 +77,11 @@ jobs:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -90,11 +90,11 @@ jobs:
   - ./prow/proxy-postsubmit-centos.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.10-2021-10-13T21-19-05
   name: release-centos
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - postsubmit
@@ -145,12 +145,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/proxy-1.11.yaml
+++ b/prow/config/jobs/proxy-1.11.yaml
@@ -6,11 +6,11 @@ jobs:
   - ./prow/proxy-presubmit.sh
   image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-10-12T18-10-18
   name: test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -18,11 +18,11 @@ jobs:
   - ./prow/proxy-presubmit-asan.sh
   image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-10-12T18-10-18
   name: test-asan
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -30,11 +30,11 @@ jobs:
   - ./prow/proxy-presubmit-tsan.sh
   image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-10-12T18-10-18
   name: test-tsan
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -42,11 +42,11 @@ jobs:
   - ./prow/proxy-presubmit-release.sh
   image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-10-12T18-10-18
   name: release-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -54,11 +54,11 @@ jobs:
   - ./prow/proxy-presubmit-centos-release.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-10-12T18-10-18
   name: release-centos-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -67,11 +67,11 @@ jobs:
   - ./prow/proxy-presubmit-wasm.sh
   image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-10-12T18-10-18
   name: check-wasm
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -81,11 +81,11 @@ jobs:
   - ./prow/proxy-postsubmit.sh
   image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-10-12T18-10-18
   name: release
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -94,11 +94,11 @@ jobs:
   - ./prow/proxy-postsubmit-centos.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-10-12T18-10-18
   name: release-centos
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - postsubmit
@@ -171,13 +171,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/proxy-1.12.yaml
+++ b/prow/config/jobs/proxy-1.12.yaml
@@ -5,44 +5,44 @@ jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   name: test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-asan.sh
   name: test-asan
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-tsan.sh
   name: test-tsan
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-release.sh
   name: release-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -50,11 +50,11 @@ jobs:
   - ./prow/proxy-presubmit-centos-release.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.12-2021-11-12T20-52-48
   name: release-centos-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - presubmit
@@ -62,11 +62,11 @@ jobs:
   - entrypoint
   - ./prow/proxy-presubmit-wasm.sh
   name: check-wasm
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -75,11 +75,11 @@ jobs:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -88,11 +88,11 @@ jobs:
   - ./prow/proxy-postsubmit-centos.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.12-2021-11-12T20-52-48
   name: release-centos
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: build-pool
   requirements:
   - cache
-  - gcp
   timeout: 4h0m0s
   types:
   - postsubmit
@@ -170,14 +170,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/proxy-1.7.yaml
+++ b/prow/config/jobs/proxy-1.7.yaml
@@ -17,8 +17,7 @@ jobs:
 - command:
   - ./prow/proxy-presubmit-release.sh
   name: release-test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
 - command:
   - entrypoint
@@ -31,8 +30,8 @@ jobs:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   timeout: 4h0m0s
   types: [postsubmit]

--- a/prow/config/jobs/proxy-1.8.yaml
+++ b/prow/config/jobs/proxy-1.8.yaml
@@ -5,29 +5,25 @@ jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   name: test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types: [presubmit]
 - command:
   - ./prow/proxy-presubmit-asan.sh
   name: test-asan
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types: [presubmit]
 - command:
   - ./prow/proxy-presubmit-tsan.sh
   name: test-tsan
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types: [presubmit]
 - command:
   - ./prow/proxy-presubmit-release.sh
   name: release-test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types: [presubmit]
 - command:
@@ -36,16 +32,15 @@ jobs:
   modifiers:
   - presubmit_optional
   name: release-centos-test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types: [presubmit]
 - command:
   - entrypoint
   - ./prow/proxy-presubmit-wasm.sh
   name: check-wasm
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   timeout: 4h0m0s
   types: [presubmit]
@@ -53,8 +48,8 @@ jobs:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   timeout: 4h0m0s
   types: [postsubmit]
@@ -62,8 +57,7 @@ jobs:
   - ./prow/proxy-postsubmit-centos.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.8-2021-04-06T17-44-38
   name: release-centos
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types: [postsubmit]
 - command:

--- a/prow/config/jobs/proxy-1.9.yaml
+++ b/prow/config/jobs/proxy-1.9.yaml
@@ -5,32 +5,28 @@ jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   name: test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-asan.sh
   name: test-asan
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-tsan.sh
   name: test-tsan
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-release.sh
   name: release-test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types:
   - presubmit
@@ -40,8 +36,7 @@ jobs:
   modifiers:
   - presubmit_optional
   name: release-centos-test
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types:
   - presubmit
@@ -49,8 +44,8 @@ jobs:
   - entrypoint
   - ./prow/proxy-presubmit-wasm.sh
   name: check-wasm
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -59,8 +54,8 @@ jobs:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
   name: release
+  service_account_name: prowjob-advanced-sa
   requirements:
-  - gcp
   - docker
   timeout: 4h0m0s
   types:
@@ -69,8 +64,7 @@ jobs:
   - ./prow/proxy-postsubmit-centos.sh
   image: gcr.io/istio-testing/build-tools-centos:release-1.9-2021-09-09T06-24-57
   name: release-centos
-  requirements:
-  - gcp
+  service_account_name: prowjob-advanced-sa
   timeout: 4h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -7,52 +7,54 @@ node_selector:
 
 jobs:
 - name: test
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
-  requirements: [gcp]
   timeout: 4h
 
 - name: test-asan
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
-  requirements: [gcp]
   timeout: 4h
 
 - name: test-tsan
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-tsan.sh]
-  requirements: [gcp]
   timeout: 4h
 
 - name: release-test
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
-  requirements: [gcp]
   timeout: 4h
 
 - name: release-centos-test
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-centos-release.sh]
-  requirements: [gcp]
   image: gcr.io/istio-testing/build-tools-centos:master-2021-11-09T05-16-46
   timeout: 4h
 
 - name: check-wasm
+  service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [entrypoint, ./prow/proxy-presubmit-wasm.sh]
-  requirements: [gcp, docker]
+  requirements: [docker]
   timeout: 4h
 
 - name: release
+  service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
-  requirements: [gcp, docker]
+  requirements: [docker]
   timeout: 4h
 
 - name: release-centos
+  service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [./prow/proxy-postsubmit-centos.sh]
-  requirements: [gcp]
   image: gcr.io/istio-testing/build-tools-centos:master-2021-11-09T05-16-46
   timeout: 4h
 

--- a/prow/config/jobs/release-builder-1.10.yaml
+++ b/prow/config/jobs/release-builder-1.10.yaml
@@ -30,12 +30,12 @@ jobs:
   - entrypoint
   - test/publish.sh
   name: dry-run
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: \.go$|\.sh$
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
 - command:

--- a/prow/config/jobs/release-builder-1.11.yaml
+++ b/prow/config/jobs/release-builder-1.11.yaml
@@ -34,12 +34,12 @@ jobs:
   - test/publish.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: dry-run
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: \.go$|\.sh$
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
 - command:

--- a/prow/config/jobs/release-builder-1.12.yaml
+++ b/prow/config/jobs/release-builder-1.12.yaml
@@ -30,12 +30,12 @@ jobs:
   - entrypoint
   - test/publish.sh
   name: dry-run
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: \.go$|\.sh$
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
 - command:
@@ -137,14 +137,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: {}
-    args: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: {}
     args: null

--- a/prow/config/jobs/release-builder-1.7.yaml
+++ b/prow/config/jobs/release-builder-1.7.yaml
@@ -18,9 +18,9 @@ jobs:
   - entrypoint
   - test/publish.sh
   name: dry-run
+  service_account_name: prowjob-advanced-sa
   regex: \.go$|\.sh$
   requirements:
-  - gcp
   - docker
   resources: build
 - command:

--- a/prow/config/jobs/release-builder-1.8.yaml
+++ b/prow/config/jobs/release-builder-1.8.yaml
@@ -18,9 +18,9 @@ jobs:
   - entrypoint
   - test/publish.sh
   name: dry-run
+  service_account_name: prowjob-advanced-sa
   regex: \.go$|\.sh$
   requirements:
-  - gcp
   - docker
   resources: build
 - command:

--- a/prow/config/jobs/release-builder-1.9.yaml
+++ b/prow/config/jobs/release-builder-1.9.yaml
@@ -18,9 +18,9 @@ jobs:
   - entrypoint
   - test/publish.sh
   name: dry-run
+  service_account_name: prowjob-advanced-sa
   regex: \.go$|\.sh$
   requirements:
-  - gcp
   - docker
   resources: build
 - command:

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -14,8 +14,9 @@ jobs:
     command: [make, gen-check]
 
   - name: dry-run
+    service_account_name: prowjob-advanced-sa
     command: [entrypoint, test/publish.sh]
-    requirements: [gcp, docker]
+    requirements: [docker]
     resources: build
     regex: '\.go$|\.sh$'
 

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -21,6 +21,7 @@ jobs:
     command: [make, -C, authentikos, unit-test]
 
   - name: integ-test-authentikos
+    service_account_name: prowjob-advanced-sa
     types: [presubmit]
     # trigger on changes in `authentikos/` directory to the following:
     # - `test/`  : integration test library, scripts, and object configuration files.
@@ -29,9 +30,10 @@ jobs:
     # - `go.mod` : Golang module dependencies. When the dependencies change, test the compatibility of the change.
     regex: '^authentikos/(test/.+|.+\.go|go\.mod)$'
     command: [entrypoint, make, -C, authentikos, integ-test]
-    requirements: [kind, gcp]
+    requirements: [kind]
 
   - name: push-mason
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     regex: '^boskos/cmd/mason/.+'
     cluster: test-infra-trusted
@@ -41,11 +43,12 @@ jobs:
     - -C
     - boskos
     - mason-image
-    requirements: [docker, gcp]
+    requirements: [docker]
     node_selector:
         prod: prow
 
   - name: push-prowbazel
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     regex: '^docker/prowbazel/Makefile$'
     cluster: test-infra-trusted
@@ -57,11 +60,12 @@ jobs:
     - docker/prowbazel
     - image
     - push-safe
-    requirements: [docker, gcp]
+    requirements: [docker]
     node_selector:
         prod: prow
 
   - name: push-authentikos
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     regex: '^authentikos/Makefile$'
     cluster: test-infra-trusted
@@ -72,11 +76,12 @@ jobs:
     - -C
     - authentikos
     - deploy
-    requirements: [docker, gcp]
+    requirements: [docker]
     node_selector:
       prod: prow
 
   - name: push-genjobs
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     regex: '^prow/genjobs/Makefile$'
     cluster: test-infra-trusted
@@ -87,7 +92,7 @@ jobs:
     - -C
     - prow/genjobs
     - deploy
-    requirements: [docker, gcp]
+    requirements: [docker]
     node_selector:
       prod: prow
 

--- a/prow/config/jobs/tools-1.10.yaml
+++ b/prow/config/jobs/tools-1.10.yaml
@@ -39,12 +39,12 @@ jobs:
   - make
   - containers
   name: containers
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: docker/.+|cmd/.+
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
   types:
@@ -54,12 +54,12 @@ jobs:
   - make
   - containers-test
   name: containers-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: docker/.+|cmd/.+
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
   types:
@@ -71,13 +71,13 @@ jobs:
   - perf_dashboard
   - deploy
   name: deploy-perf-dashboard
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: ^perf_dashboard/
   requirements:
   - cache
   - docker
-  - gcp
   types:
   - postsubmit
 org: istio
@@ -104,12 +104,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     env: null
     labels: null

--- a/prow/config/jobs/tools-1.11.yaml
+++ b/prow/config/jobs/tools-1.11.yaml
@@ -44,12 +44,12 @@ jobs:
   - containers
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: containers
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: docker/.+|cmd/.+
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
   types:
@@ -60,12 +60,12 @@ jobs:
   - containers-test
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: containers-test
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: docker/.+|cmd/.+
   requirements:
   - cache
-  - gcp
   - docker
   resources: build
   types:
@@ -78,13 +78,13 @@ jobs:
   - deploy
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-10-12T18-10-18
   name: deploy-perf-dashboard
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: ^perf_dashboard/
   requirements:
   - cache
   - docker
-  - gcp
   types:
   - postsubmit
 org: istio
@@ -113,13 +113,6 @@ requirement_presets:
     volumes:
     - emptyDir: {}
       name: docker-root
-  gcp:
-    annotations: null
-    env: null
-    labels:
-      preset-service-account: "true"
-    volumeMounts: null
-    volumes: null
   github:
     annotations: null
     env: null

--- a/prow/config/jobs/tools-1.12.yaml
+++ b/prow/config/jobs/tools-1.12.yaml
@@ -45,7 +45,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --script-path=../common-files/bin/create-buildtools-and-update.sh
   name: containers
-  service_account_name: prowjob-admin-sa
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: docker/.+|cmd/.+
@@ -64,7 +64,7 @@ jobs:
   - make
   - containers-test
   name: containers-test
-  service_account_name: prowjob-admin-sa
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: docker/.+|cmd/.+
@@ -81,7 +81,7 @@ jobs:
   - perf_dashboard
   - deploy
   name: deploy-perf-dashboard
-  service_account_name: prowjob-admin-sa
+  service_account_name: prowjob-advanced-sa
   node_selector:
     testing: test-pool
   regex: ^perf_dashboard/

--- a/prow/config/jobs/tools-1.7.yaml
+++ b/prow/config/jobs/tools-1.7.yaml
@@ -23,9 +23,9 @@ jobs:
   - make
   - containers
   name: containers
+  service_account_name: prowjob-advanced-sa
   regex: docker/.+|cmd/.+
   requirements:
-  - gcp
   - docker
   resources: build
   types: [postsubmit]
@@ -34,9 +34,9 @@ jobs:
   - make
   - containers-test
   name: containers-test
+  service_account_name: prowjob-advanced-sa
   regex: docker/.+|cmd/.+
   requirements:
-  - gcp
   - docker
   resources: build
   types: [presubmit]

--- a/prow/config/jobs/tools-1.8.yaml
+++ b/prow/config/jobs/tools-1.8.yaml
@@ -23,9 +23,9 @@ jobs:
   - make
   - containers
   name: containers
+  service_account_name: prowjob-advanced-sa
   regex: docker/.+|cmd/.+
   requirements:
-  - gcp
   - docker
   resources: build
   types: [postsubmit]
@@ -34,9 +34,9 @@ jobs:
   - make
   - containers-test
   name: containers-test
+  service_account_name: prowjob-advanced-sa
   regex: docker/.+|cmd/.+
   requirements:
-  - gcp
   - docker
   resources: build
   types: [presubmit]
@@ -50,7 +50,6 @@ jobs:
   regex: ^perf_dashboard/
   requirements:
   - docker
-  - gcp
   types: [postsubmit]
 org: istio
 repo: tools

--- a/prow/config/jobs/tools-1.9.yaml
+++ b/prow/config/jobs/tools-1.9.yaml
@@ -23,9 +23,9 @@ jobs:
   - make
   - containers
   name: containers
+  service_account_name: prowjob-advanced-sa
   regex: docker/.+|cmd/.+
   requirements:
-  - gcp
   - docker
   resources: build
   types:
@@ -35,9 +35,9 @@ jobs:
   - make
   - containers-test
   name: containers-test
+  service_account_name: prowjob-advanced-sa
   regex: docker/.+|cmd/.+
   requirements:
-  - gcp
   - docker
   resources: build
   types:

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -17,6 +17,7 @@ jobs:
     command: [make, gen-check]
 
   - name: benchmark_check
+    service_account_name: prowjob-advanced-sa
     disable_release_branching: true
     regex: '^perf/benchmark/'
     types: [presubmit]
@@ -25,9 +26,9 @@ jobs:
       - name: TRIALRUN
         value: "True"
     modifiers: [presubmit_optional]
-    requirements: [gcp]
 
   - name: containers
+    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     command:
     - entrypoint
@@ -41,21 +42,23 @@ jobs:
     - --script-path=../common-files/bin/create-buildtools-and-update.sh
     resources: build
     regex: 'docker/.+|cmd/.+'
-    requirements: [gcp, docker, github]
+    requirements: [docker, github]
     repos: [istio/test-infra@master,istio/common-files@master]
 
   - name: containers-test
+    service_account_name: prowjob-advanced-sa
     types: [presubmit]
     command: [entrypoint, make, containers-test]
     resources: build
     regex: 'docker/.+|cmd/.+'
-    requirements: [gcp, docker]
+    requirements: [docker]
 
   - name: deploy-perf-dashboard
+    service_account_name: prowjob-advanced-sa
     regex: '^perf_dashboard/'
     types: [postsubmit]
     command: [entrypoint, make, -C, perf_dashboard, deploy]
-    requirements: [docker, gcp]
+    requirements: [docker]
 
 resources_presets:
   build:


### PR DESCRIPTION
1. Move all jobs except release pipelines to use workload identity
2. Set a service account that only has storage object admin permissions as the default (to fix https://prow.istio.io/view/gs/istio-prow/logs/ci-test-infra-branchprotector/1460471385561239552)