### PR TITLE
Move release pipeline Prow jobs to use workload identity

### DIFF
--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -35,3 +35,13 @@ metadata:
   # with a Googler on what permissions it has.
   # Please only use it when you do need them.
   name: prowjob-advanced-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: 202987436673-compute@developer.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow-build
+  namespace: test-pods
+  name: rel-pipeline-service-account

--- a/prow/cluster/jobs/all-presets.yaml
+++ b/prow/cluster/jobs/all-presets.yaml
@@ -17,8 +17,6 @@ presets:
     value: /etc/github/rel-pipeline-github
   - name: GRAFANA_TOKEN_FILE
     value: /etc/grafana/token
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/service-account/rel-pipeline-service-account.json
   volumeMounts:
   - name: rel-pipeline-docker-config
     mountPath: /etc/rel-pipeline-docker-config
@@ -28,13 +26,7 @@ presets:
   - name: rel-pipeline-grafana
     mountPath: /etc/grafana
     readOnly: true
-  - name: rel-pipeline-service-account
-    mountPath: /etc/service-account
-    readOnly: true
   volumes:
-  - name: rel-pipeline-service-account
-    secret:
-      secretName: rel-pipeline-service-account
   - name: rel-pipeline-github
     secret:
       secretName: rel-pipeline-github

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -180,6 +180,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.10.gen.yaml
@@ -173,6 +173,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
@@ -180,6 +180,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.12.gen.yaml
@@ -180,6 +180,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.7.gen.yaml
@@ -170,6 +170,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.8.gen.yaml
@@ -180,6 +180,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.9.gen.yaml
@@ -180,6 +180,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -51,6 +51,7 @@ periodics:
         readOnly: true
     nodeSelector:
       testing: test-pool
+    serviceAccountName: rel-pipeline-service-account
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -259,6 +260,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -312,6 +314,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.10.gen.yaml
@@ -196,6 +196,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -249,6 +250,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
@@ -196,6 +196,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -249,6 +250,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
@@ -51,6 +51,7 @@ periodics:
         readOnly: true
     nodeSelector:
       testing: test-pool
+    serviceAccountName: rel-pipeline-service-account
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -259,6 +260,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -312,6 +314,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.7.gen.yaml
@@ -193,6 +193,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -242,6 +243,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.8.gen.yaml
@@ -196,6 +196,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -249,6 +250,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.9.gen.yaml
@@ -196,6 +196,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -249,6 +250,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: test-pool
+      serviceAccountName: rel-pipeline-service-account
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/config/jobs/api-1.10.yaml
+++ b/prow/config/jobs/api-1.10.yaml
@@ -123,12 +123,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/api-1.11.yaml
+++ b/prow/config/jobs/api-1.11.yaml
@@ -166,13 +166,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/api-1.12.yaml
+++ b/prow/config/jobs/api-1.12.yaml
@@ -167,19 +167,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/client-go-1.10.yaml
+++ b/prow/config/jobs/client-go-1.10.yaml
@@ -96,12 +96,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/client-go-1.11.yaml
+++ b/prow/config/jobs/client-go-1.11.yaml
@@ -139,13 +139,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/client-go-1.12.yaml
+++ b/prow/config/jobs/client-go-1.12.yaml
@@ -141,19 +141,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/common-files-1.10.yaml
+++ b/prow/config/jobs/common-files-1.10.yaml
@@ -144,12 +144,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/common-files-1.11.yaml
+++ b/prow/config/jobs/common-files-1.11.yaml
@@ -166,13 +166,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/common-files-1.12.yaml
+++ b/prow/config/jobs/common-files-1.12.yaml
@@ -168,19 +168,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/enhancements-1.11.yaml
+++ b/prow/config/jobs/enhancements-1.11.yaml
@@ -107,13 +107,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/enhancements-1.12.yaml
+++ b/prow/config/jobs/enhancements-1.12.yaml
@@ -112,19 +112,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/gogo-genproto-1.10.yaml
+++ b/prow/config/jobs/gogo-genproto-1.10.yaml
@@ -96,12 +96,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/gogo-genproto-1.11.yaml
+++ b/prow/config/jobs/gogo-genproto-1.11.yaml
@@ -140,13 +140,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/gogo-genproto-1.12.yaml
+++ b/prow/config/jobs/gogo-genproto-1.12.yaml
@@ -142,19 +142,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   default:
     limits:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -526,12 +526,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 requirements:
 - gocache
 resources_presets:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -728,13 +728,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 requirements:
 - gocache
 resources_presets:

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -748,19 +748,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 requirements:
 - gocache
 resources_presets:

--- a/prow/config/jobs/istio.io-1.10.yaml
+++ b/prow/config/jobs/istio.io-1.10.yaml
@@ -149,12 +149,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/istio.io-1.11.yaml
+++ b/prow/config/jobs/istio.io-1.11.yaml
@@ -174,13 +174,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/istio.io-1.12.yaml
+++ b/prow/config/jobs/istio.io-1.12.yaml
@@ -173,19 +173,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/pkg-1.10.yaml
+++ b/prow/config/jobs/pkg-1.10.yaml
@@ -104,12 +104,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/pkg-1.11.yaml
+++ b/prow/config/jobs/pkg-1.11.yaml
@@ -147,13 +147,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/pkg-1.12.yaml
+++ b/prow/config/jobs/pkg-1.12.yaml
@@ -148,19 +148,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/proxy-1.10.yaml
+++ b/prow/config/jobs/proxy-1.10.yaml
@@ -191,12 +191,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/proxy-1.11.yaml
+++ b/prow/config/jobs/proxy-1.11.yaml
@@ -233,13 +233,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/proxy-1.12.yaml
+++ b/prow/config/jobs/proxy-1.12.yaml
@@ -236,19 +236,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/release-builder-1.10.yaml
+++ b/prow/config/jobs/release-builder-1.10.yaml
@@ -66,6 +66,7 @@ jobs:
   - entrypoint
   - release/build.sh
   name: build-release
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   regex: ^release/trigger-build$
@@ -81,6 +82,7 @@ jobs:
   - entrypoint
   - release/publish.sh
   name: publish-release
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   regex: ^release/trigger-publish$

--- a/prow/config/jobs/release-builder-1.11.yaml
+++ b/prow/config/jobs/release-builder-1.11.yaml
@@ -73,6 +73,7 @@ jobs:
   - release/build.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
   name: build-release
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   regex: ^release/trigger-build$
@@ -89,6 +90,7 @@ jobs:
   - release/publish.sh
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
   name: publish-release
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   regex: ^release/trigger-publish$

--- a/prow/config/jobs/release-builder-1.12.yaml
+++ b/prow/config/jobs/release-builder-1.12.yaml
@@ -66,6 +66,7 @@ jobs:
   - entrypoint
   - release/build.sh
   name: build-release
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   regex: ^release/trigger-build$
@@ -81,6 +82,7 @@ jobs:
   - entrypoint
   - release/publish.sh
   name: publish-release
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   regex: ^release/trigger-publish$
@@ -101,6 +103,7 @@ jobs:
   - name: VERSION
     value: "1.12"
   name: build-base-images
+  service_account_name: rel-pipeline-service-account
   node_selector:
     testing: test-pool
   requirements:
@@ -205,19 +208,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/release-builder-1.7.yaml
+++ b/prow/config/jobs/release-builder-1.7.yaml
@@ -41,6 +41,7 @@ jobs:
   - entrypoint
   - release/build.sh
   name: build-release
+  service_account_name: rel-pipeline-service-account
   regex: ^release/trigger-build$
   requirements:
   - release
@@ -51,6 +52,7 @@ jobs:
   - entrypoint
   - release/publish.sh
   name: publish-release
+  service_account_name: rel-pipeline-service-account
   regex: ^release/trigger-publish$
   requirements:
   - release

--- a/prow/config/jobs/release-builder-1.8.yaml
+++ b/prow/config/jobs/release-builder-1.8.yaml
@@ -41,6 +41,7 @@ jobs:
   - entrypoint
   - release/build.sh
   name: build-release
+  service_account_name: rel-pipeline-service-account
   regex: ^release/trigger-build$
   requirements:
   - release
@@ -52,6 +53,7 @@ jobs:
   - entrypoint
   - release/publish.sh
   name: publish-release
+  service_account_name: rel-pipeline-service-account
   regex: ^release/trigger-publish$
   requirements:
   - release

--- a/prow/config/jobs/release-builder-1.9.yaml
+++ b/prow/config/jobs/release-builder-1.9.yaml
@@ -43,6 +43,7 @@ jobs:
   - entrypoint
   - release/build.sh
   name: build-release
+  service_account_name: rel-pipeline-service-account
   regex: ^release/trigger-build$
   requirements:
   - release
@@ -55,6 +56,7 @@ jobs:
   - entrypoint
   - release/publish.sh
   name: publish-release
+  service_account_name: rel-pipeline-service-account
   regex: ^release/trigger-publish$
   requirements:
   - release

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -33,6 +33,7 @@ jobs:
     modifiers: [presubmit_optional]
 
   - name: build-release
+    service_account_name: rel-pipeline-service-account
     types: [postsubmit]
     regex: '^release/trigger-build$'
     command: [entrypoint, release/build.sh]
@@ -40,6 +41,7 @@ jobs:
     resources: build
 
   - name: publish-release
+    service_account_name: rel-pipeline-service-account
     types: [postsubmit]
     regex: '^release/trigger-publish$'
     command: [entrypoint, release/publish.sh]
@@ -47,6 +49,7 @@ jobs:
     resources: build
 
   - name: build-base-images
+    service_account_name: rel-pipeline-service-account
     types: [periodic]
     cron: "0 19 * * *"  # every day at 07:00 PM UTC (12:00 PM PST)
     env:

--- a/prow/config/jobs/tools-1.10.yaml
+++ b/prow/config/jobs/tools-1.10.yaml
@@ -150,12 +150,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/tools-1.11.yaml
+++ b/prow/config/jobs/tools-1.11.yaml
@@ -175,13 +175,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: null
-    env: null
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:

--- a/prow/config/jobs/tools-1.12.yaml
+++ b/prow/config/jobs/tools-1.12.yaml
@@ -184,19 +184,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    annotations: {}
-    args: null
-    env:
-    - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
-    labels:
-      preset-release-pipeline: "true"
-    volumeMounts: null
-    volumes: null
 resources_presets:
   benchmark:
     limits:


### PR DESCRIPTION
I'm not sure if this works or not. Probably we have to use the secret key?

/hold