### PR TITLE
Simplify integ test definitions

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1246,7 +1246,7 @@ postsubmits:
         - kindest/node:v1.16.15
         - --kind-config
         - prow/config/trustworthy-jwt.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1317,7 +1317,7 @@ postsubmits:
         - kindest/node:v1.17.17
         - --kind-config
         - prow/config/endpointslice.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1388,7 +1388,7 @@ postsubmits:
         - kindest/node:v1.18.19
         - --kind-config
         - prow/config/trustworthy-jwt.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1459,7 +1459,7 @@ postsubmits:
         - kindest/node:v1.19.11
         - --kind-config
         - prow/config/trustworthy-jwt.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1528,7 +1528,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.20.7
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1597,7 +1597,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.22.2
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1666,7 +1666,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.23.0-alpha.2
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1733,7 +1733,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: TEST_SELECT
           value: -flaky
@@ -1802,7 +1802,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
@@ -3223,7 +3223,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -113,6 +113,68 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+    name: integ-telemetry-k8s-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.telemetry.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
     name: integ-telemetry-mc-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
@@ -419,6 +481,68 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: ipv6-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: integ-operator-controller-tests_istio_postsubmit_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.operator.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1000,68 +1124,6 @@ postsubmits:
             memory: 24Gi
           requests:
             cpu: "8"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-gomod-netrc: "true"
-      preset-enable-ssh: "true"
-      preset-override-deps: master-istio
-      preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_postsubmit_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1945,72 +2007,6 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-gomod-netrc: "true"
-      preset-enable-ssh: "true"
-      preset-override-deps: master-istio
-      preset-override-envoy: "true"
     name: integ-cni-k8s-tests_istio_priv
     path_alias: istio.io/istio
     spec:
@@ -2020,76 +2016,8 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
         env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/istio.git
-    cluster: private
-    decorate: true
-    labels:
-      preset-enable-gomod-netrc: "true"
-      preset-enable-ssh: "true"
-      preset-override-deps: master-istio
-      preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_priv
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.security.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
         image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
         name: ""
         resources:
@@ -2152,10 +2080,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.telemetry.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
+        - test.integration.telemetry.kube
         image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
         name: ""
         resources:
@@ -2557,10 +2482,70 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.operator.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
+        - test.integration.operator.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: integ-pilot-k8s-tests_istio_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.pilot.kube
         image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
         name: ""
         resources:
@@ -2846,6 +2831,69 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-gomod-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: integ-security-k8s-tests_istio_priv
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.security.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1244,7 +1244,7 @@ postsubmits:
         - kindest/node:v1.16.15
         - --kind-config
         - prow/config/trustworthy-jwt.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1310,7 +1310,7 @@ postsubmits:
         - kindest/node:v1.17.17
         - --kind-config
         - prow/config/endpointslice.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1376,7 +1376,7 @@ postsubmits:
         - kindest/node:v1.18.19
         - --kind-config
         - prow/config/trustworthy-jwt.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1442,7 +1442,7 @@ postsubmits:
         - kindest/node:v1.19.11
         - --kind-config
         - prow/config/trustworthy-jwt.yaml
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1506,7 +1506,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.20.7
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1570,7 +1570,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.22.2
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1634,7 +1634,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.23.0-alpha.2
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
@@ -1696,7 +1696,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: TEST_SELECT
           value: -flaky
@@ -1760,7 +1760,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
@@ -3027,7 +3027,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.kube.presubmit
+        - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -196,6 +196,63 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-telemetry-k8s-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.telemetry.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-telemetry-mc-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -482,6 +539,63 @@ postsubmits:
           name: docker-root
       nodeSelector:
         testing: ipv6-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-operator-controller-tests_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.operator.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1018,63 +1132,6 @@ postsubmits:
             memory: 24Gi
           requests:
             cpu: "8"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_istio_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
-    name: integ-telemetry-k8s-tests_istio_postsubmit
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true
@@ -1880,65 +1937,6 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-k8s-tests_istio
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.pilot.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_istio
-    branches:
-    - ^master$
-    decorate: true
     name: integ-cni-k8s-tests_istio
     path_alias: istio.io/istio
     spec:
@@ -1948,69 +1946,8 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
         env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
-        name: ""
-        resources:
-          limits:
-            memory: 24Gi
-          requests:
-            cpu: "5"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /gocache
-          name: build-cache
-          subPath: gocache
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_istio
-    branches:
-    - ^master$
-    decorate: true
-    name: integ-security-k8s-tests_istio
-    path_alias: istio.io/istio
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - prow/integ-suite-kind.sh
-        - test.integration.security.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
         image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
         name: ""
         resources:
@@ -2066,10 +2003,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.telemetry.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
+        - test.integration.telemetry.kube
         image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
         name: ""
         resources:
@@ -2429,10 +2363,63 @@ presubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - test.integration.operator.kube.presubmit
-        env:
-        - name: TEST_SELECT
-          value: -postsubmit,-flaky
+        - test.integration.operator.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-pilot-k8s-tests_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.pilot.kube
         image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
         name: ""
         resources:
@@ -2690,6 +2677,62 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "8"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-security-k8s-tests_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.security.kube
+        image: gcr.io/istio-testing/build-tools:master-2021-11-09T05-16-46
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "5"
             memory: 3Gi
         securityContext:
           privileged: true

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -30,39 +30,17 @@ jobs:
     command: [entrypoint, make, benchtest, report-benchtest]
     resources: benchmark
 
-  - name: integ-pilot-k8s-tests
-    types: [presubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
-    requirements: [kind]
-    env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky"
-
   - name: integ-cni-k8s-tests
     types: [presubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
     requirements: [kind]
     env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky"
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.istio.enableCNI=true "
 
-  - name: integ-security-k8s-tests
-    types: [presubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube.presubmit]
-    requirements: [kind]
-    env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky"
-
   - name: integ-telemetry-k8s-tests
-    types: [presubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.telemetry.kube.presubmit]
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.telemetry.kube]
     requirements: [kind]
-    env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky"
 
   - name: integ-telemetry-mc-k8s-tests
     command:
@@ -123,15 +101,11 @@ jobs:
         value: "ipv6"
 
   - name: integ-operator-controller-tests
-    types: [presubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.operator.kube.presubmit]
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.operator.kube]
     requirements: [kind]
-    env:
-      - name: TEST_SELECT
-        value: "-postsubmit,-flaky"
+
 
   - name: integ-pilot-k8s-tests
-    types: [postsubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
 
@@ -193,7 +167,6 @@ jobs:
         value: --istio.test.istio.istiodlessRemotes
 
   - name: integ-security-k8s-tests
-    types: [postsubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube]
     requirements: [kind]
 
@@ -244,11 +217,6 @@ jobs:
     env:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.istio.istiodlessRemotes
-
-  - name: integ-telemetry-k8s-tests
-    types: [postsubmit]
-    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.telemetry.kube]
-    requirements: [kind]
 
   - name: integ-helm-tests
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.helm.kube]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -234,7 +234,7 @@ jobs:
       - kindest/node:v1.16.15
       - --kind-config
       - prow/config/trustworthy-jwt.yaml
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -250,7 +250,7 @@ jobs:
       - kindest/node:v1.17.17
       - --kind-config
       - prow/config/endpointslice.yaml
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -266,7 +266,7 @@ jobs:
       - kindest/node:v1.18.19
       - --kind-config
       - prow/config/trustworthy-jwt.yaml
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -282,7 +282,7 @@ jobs:
       - kindest/node:v1.19.11
       - --kind-config
       - prow/config/trustworthy-jwt.yaml
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -296,7 +296,7 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.20.7
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -310,7 +310,7 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.22.2
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -324,7 +324,7 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.23.0-alpha.2
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -336,7 +336,7 @@ jobs:
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:
@@ -351,7 +351,7 @@ jobs:
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
-      - test.integration.kube.presubmit
+      - test.integration.kube
     requirements: [kind]
     timeout: 4h
     env:


### PR DESCRIPTION
Depends on https://github.com/istio/istio/pull/35354/files. This just cleans things up mostly. There is 1 real change - operator test now runs in postsubmit as well, as all tests are expected to run in pre+postsubmit.

Justifications inline