### PR TITLE
prow autobump PR not assigned to anyone

### DIFF
--- a/prow/istio-autobump-config.yaml
+++ b/prow/istio-autobump-config.yaml
@@ -3,6 +3,7 @@ gitHubLogin: "istio-testing"
 gitHubToken: "/etc/github-token/oauth"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
+selfAssign: true # Commenting `/cc`, so that autobump PR is not assigned to anyone
 gitHubOrg: "istio"
 gitHubRepo: "test-infra"
 remoteName: "test-infra"


### PR DESCRIPTION
Prow is now auto-deployed, there is no need explicitly assigning to oncall. Opting out to avoid noise

It's proved to work as kubernetes/test-infra#24414