### PR TITLE
Fix CLA check

### DIFF
--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -26,7 +26,6 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
-        - "--labels=cla: yes"
         - --labels=release-notes-none
         - --use-prow-assignments=false
         ports:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -359,7 +359,6 @@ tide:
     labels:
     - lgtm
     - approved
-    - "cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/hold
@@ -384,8 +383,6 @@ tide:
     - istio/cri
     - istio/client-go
     - istio/release-builder
-    labels:
-    - "cla: yes"
     missingLabels: &istio_tide_missing_labels
     - do-not-merge
     - do-not-merge/hold
@@ -409,7 +406,6 @@ tide:
     - istio/client-go
     - istio/release-builder
     labels:
-    - "cla: yes"
     - auto-merge
     missingLabels: *istio_tide_missing_labels
     author: istio-testing


### PR DESCRIPTION
Fixes https://github.com/istio/test-infra/issues/3677

I don't know if this is right

config.yaml currently has:
```
    istio:
      required_status_checks:
        contexts:
        - cla/google
```
Which I think means CLA will be checked

I removed `cla: yes` label from cherrypicker bot. Hopefully it still works