### PR TITLE
Use clone_uri when defined

### DIFF
--- a/prow/config/README.md
+++ b/prow/config/README.md
@@ -109,6 +109,9 @@ org: istio
 # REQUIRED. Defines what repo these jobs should run for
 repo: istio
 
+# The URI for cloning git repository.
+clone_uri: https://github.com/istio/istio.git
+
 # Defines what branches to run these jobs for. Multiple can be provided
 # The branch name will be appended to the job name (e.g tests -> tests-master)
 # If this is not supplied, it defaults to master

--- a/prow/config/generate.go
+++ b/prow/config/generate.go
@@ -428,6 +428,13 @@ func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) confi
 					Cron:     job.Cron,
 					Tags:     job.Tags,
 				}
+
+				for i, ref := range periodic.JobBase.ExtraRefs {
+					if ref.Org == jobsConfig.Org && ref.Repo == jobsConfig.Repo {
+						periodic.JobBase.ExtraRefs[i].CloneURI = jobsConfig.CloneURI
+					}
+				}
+
 				if testgridConfig.Enabled {
 					periodic.JobBase.Annotations = mergeMaps(periodic.JobBase.Annotations, map[string]string{
 						TestGridDashboard:   testgridJobPrefix + "_periodic",

--- a/prow/config/testdata/simple.gen.yaml
+++ b/prow/config/testdata/simple.gen.yaml
@@ -10,6 +10,7 @@ periodics:
   decorate: true
   extra_refs:
   - base_ref: master
+    clone_uri: https://github.com/istio/istio
     org: istio
     path_alias: istio.io/istio
     repo: istio
@@ -54,10 +55,12 @@ periodics:
   decorate: true
   extra_refs:
   - base_ref: master
+    clone_uri: https://github.com/istio/istio
     org: istio
     path_alias: istio.io/istio
     repo: istio
   - base_ref: master
+    clone_uri: https://github.com/istio/istio
     org: istio
     path_alias: istio.io/istio
     repo: istio

--- a/prow/config/testdata/simple.yaml
+++ b/prow/config/testdata/simple.yaml
@@ -1,5 +1,6 @@
 org: istio
 repo: istio
+clone_uri: https://github.com/istio/istio
 image: fooimage
 branches:
   - master


### PR DESCRIPTION
This was unused before despite `CloneURI` field being present in the `JobsConfig` struct.

The current implementation finds `prowjob.Refs` that matches `JobsConfig.Org` and `JobsConfig.Repo` and sets the `CloneURI` field to the given value. It's not perfect but given how `ExtraRefs` are processed this change adds the lowest number of LOC.

I've considered appending a `prowjob.Refs` to the `periodic.JobBase.ExtraRefs` instead of what happens in line 424 but this unfortunately causes more problems than it solves.