### PR TITLE
Move Role and RoleBinding to v1

### DIFF
--- a/boskos/cluster/boskos-crds.yaml
+++ b/boskos/cluster/boskos-crds.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dynamicresourcelifecycles.boskos.k8s.io
@@ -16,7 +16,7 @@ spec:
       served: true
       storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: resources.boskos.k8s.io

--- a/prow/cluster/deck_private_rbac.yaml
+++ b/prow/cluster/deck_private_rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deck-private
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/part-of: prow
@@ -23,7 +23,7 @@ rules:
   - list
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/part-of: prow
@@ -38,7 +38,7 @@ rules:
   - get
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/part-of: prow
@@ -53,7 +53,7 @@ subjects:
   name: deck-private
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/part-of: prow

--- a/prow/cluster/kubernetes-external-secrets_crd.yaml
+++ b/prow/cluster/kubernetes-external-secrets_crd.yaml
@@ -1,6 +1,6 @@
 ---
 # From https://github.com/external-secrets/kubernetes-external-secrets/tree/f866e34e0319d9c54ea17d07f5d5818a28d9d0f6
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalsecrets.kubernetes-client.io

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/part-of: prow
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "prow-controller-manager"
@@ -114,7 +114,7 @@ rules:
   - patch
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"
@@ -134,7 +134,7 @@ rules:
   - patch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "prow-controller-manager"
@@ -149,7 +149,7 @@ subjects:
   name: "prow-controller-manager"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"

--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:


### PR DESCRIPTION
Related to #3735, but probably not the root cause.

Removes deprecation warnings from deploy script