### PR TITLE
Move Authentikos' ClusterRoleBinding to v1

### DIFF
--- a/authentikos/examples/authentikos-deployment.yaml
+++ b/authentikos/examples/authentikos-deployment.yaml
@@ -32,7 +32,7 @@ rules:
   - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: authentikos
 roleRef:

--- a/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
+++ b/authentikos/examples/authentikos-grandmatriarch-deployment.yaml
@@ -32,7 +32,7 @@ rules:
   - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: authentikos
 roleRef:

--- a/authentikos/test/testdata/authentikos-simple.yaml
+++ b/authentikos/test/testdata/authentikos-simple.yaml
@@ -32,7 +32,7 @@ rules:
   - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: authentikos
 roleRef:


### PR DESCRIPTION
Safe migration for v1.22 per https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22
/assign @cjwagner @chaodaiG 