### PR TITLE
Add ExternalSecret for test-pods secrets.

### DIFF
--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -13,3 +13,29 @@ spec:
   - key: istio-prow__prow-monitoring__grafana
     name: password
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: oauth-token
+  namespace: test-pods
+  labels:
+    app.kubernetes.io/part-of: prow
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  dataFrom:
+  - gke_istio-testing_us-west1-a_prow__test-pods__oauth-token # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: istio-testing-robot-ssh-key
+  namespace: test-pods
+  labels:
+    app.kubernetes.io/part-of: prow
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  dataFrom:
+  - gke_istio-testing_us-west1-a_prow__test-pods__istio-testing-robot-ssh-key # Secret name in GSM


### PR DESCRIPTION
Replacing deleted secrets from backups. I think this `dataFrom` field will do what we want: https://github.com/external-secrets/kubernetes-external-secrets#readme
/assign @chaodaiG 