### PR TITLE
Remove unused app.kubernetes.io/part-of label from all components.

### DIFF
--- a/boskos/Makefile
+++ b/boskos/Makefile
@@ -16,8 +16,8 @@ mason-image:
 mason-client:
 	go build -o cmd/mason_client/mason_client istio.io/test-infra/boskos/cmd/mason_client
 
-deploy: get-cluster-credentials get-api-resources
-	kubectl apply -Rf cluster --prune -l app.kubernetes.io/part-of=boskos $(PRUNE_WL)
+deploy: get-cluster-credentials
+	kubectl apply -Rf cluster
 
 boskos-config: get-cluster-credentials
 	kubectl create configmap boskos-config\

--- a/boskos/cluster/boskos-deployment.yaml
+++ b/boskos/cluster/boskos-deployment.yaml
@@ -2,14 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   annotations:
     iam.gke.io/gcp-service-account: boskos@istio-testing.iam.gserviceaccount.com
   name: boskos-admin
@@ -19,7 +17,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos-crd-admin
 rules:
 - apiGroups:
@@ -36,7 +33,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos-crd-admin-binding
 subjects:
 - kind: ServiceAccount
@@ -51,7 +47,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos
   namespace: boskos
 spec:

--- a/boskos/cluster/boskos-deployment.yaml
+++ b/boskos/cluster/boskos-deployment.yaml
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
   name: boskos
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  labels:
   annotations:
     iam.gke.io/gcp-service-account: boskos@istio-testing.iam.gserviceaccount.com
   name: boskos-admin
@@ -16,7 +14,6 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: boskos-crd-admin
 rules:
 - apiGroups:
@@ -32,7 +29,6 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: boskos-crd-admin-binding
 subjects:
 - kind: ServiceAccount
@@ -46,7 +42,6 @@ roleRef:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  labels:
   name: boskos
   namespace: boskos
 spec:

--- a/boskos/cluster/boskos-service.yaml
+++ b/boskos/cluster/boskos-service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: boskos
   namespace: boskos
 spec:

--- a/boskos/cluster/boskos-service.yaml
+++ b/boskos/cluster/boskos-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos
   namespace: boskos
 spec:

--- a/boskos/cluster/cleaner-deployment.yaml
+++ b/boskos/cluster/cleaner-deployment.yaml
@@ -9,7 +9,6 @@ kind: ClusterRole
 metadata:
   name: boskos-crd-reader
   labels:
-    app.kubernetes.io/part-of: boskos
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
@@ -26,7 +25,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos-crd-reader-binding
   namespace: boskos
 subjects:
@@ -43,7 +41,6 @@ kind: Deployment
 metadata:
   name: boskos-cleaner
   labels:
-    app.kubernetes.io/part-of: boskos
     app: boskos-cleaner
   namespace: boskos
 spec:

--- a/boskos/cluster/cleaner-deployment.yaml
+++ b/boskos/cluster/cleaner-deployment.yaml
@@ -24,7 +24,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
   name: boskos-crd-reader-binding
   namespace: boskos
 subjects:
@@ -68,4 +67,3 @@ spec:
         effect: NoSchedule
       nodeSelector:
         prod: boskos
-

--- a/boskos/cluster/janitor-deployment.yaml
+++ b/boskos/cluster/janitor-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: boskos-janitor
   labels:
-    app.kubernetes.io/part-of: boskos
     app: boskos-janitor
   namespace: boskos
 spec:

--- a/boskos/cluster/mason-deployment.yaml
+++ b/boskos/cluster/mason-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: boskos-mason
   labels:
-    app.kubernetes.io/part-of: boskos
     app: boskos-mason
   namespace: boskos
 spec:

--- a/boskos/cluster/metrics-deployment.yaml
+++ b/boskos/cluster/metrics-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: boskos-metrics
   labels:
-    app.kubernetes.io/part-of: boskos
     app: boskos-metrics
   namespace: boskos
 spec:

--- a/boskos/cluster/metrics-service.yaml
+++ b/boskos/cluster/metrics-service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: boskos-metrics
   namespace: boskos
 spec:

--- a/boskos/cluster/metrics-service.yaml
+++ b/boskos/cluster/metrics-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: boskos
   name: boskos-metrics
   namespace: boskos
 spec:

--- a/boskos/cluster/reaper-deployment.yaml
+++ b/boskos/cluster/reaper-deployment.yaml
@@ -28,4 +28,3 @@ spec:
         effect: NoSchedule
       nodeSelector:
         prod: boskos
-

--- a/boskos/cluster/reaper-deployment.yaml
+++ b/boskos/cluster/reaper-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: boskos-reaper
   labels:
-    app.kubernetes.io/part-of: boskos
     app: boskos-reaper
   namespace: boskos
 spec:

--- a/prow/cluster/build/buildcache.yaml
+++ b/prow/cluster/build/buildcache.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-build
   name: fileserver
   namespace: test-pods
 spec:
@@ -18,7 +17,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-build
   name: build-cache-claim
   namespace: test-pods
 spec:

--- a/prow/cluster/build/buildcache.yaml
+++ b/prow/cluster/build/buildcache.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  labels:
   name: fileserver
   namespace: test-pods
 spec:
@@ -16,7 +15,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  labels:
   name: build-cache-claim
   namespace: test-pods
 spec:

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -4,7 +4,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job-default@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: test-pods
   # Default service account that only has permissions to access the GCS bucket
   # for logging.
@@ -15,7 +14,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: test-pods
   # Service account that has more permissions on the shared GCP projects, check
   # with a Googler on what permissions it has.

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job-default@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow-build
   namespace: test-pods
   # Default service account that only has permissions to access the GCS bucket
   # for logging.
@@ -17,7 +16,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow-build
   namespace: test-pods
   # Service account that has more permissions on the shared GCP projects, check
   # with a Googler on what permissions it has.

--- a/prow/cluster/build/test_pod_namespace.yaml
+++ b/prow/cluster/build/test_pod_namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-build
   name: test-pods

--- a/prow/cluster/build/test_pod_namespace.yaml
+++ b/prow/cluster/build/test_pod_namespace.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
   name: test-pods

--- a/prow/cluster/build/tune-sysctls_daemonset.yaml
+++ b/prow/cluster/build/tune-sysctls_daemonset.yaml
@@ -4,7 +4,6 @@ metadata:
   name: tune-sysctls
   namespace: kube-system
   labels:
-    app.kubernetes.io/part-of: prow-build
     app: tune-sysctls
 spec:
   selector:

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   namespace: default
   name: cherrypicker
   labels:
-    app.kubernetes.io/part-of: prow
     app: cherrypicker
 spec:
   replicas: 1

--- a/prow/cluster/cherrypicker_service.yaml
+++ b/prow/cluster/cherrypicker_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
     app: cherrypicker
   namespace: default
   name: cherrypicker

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: crier
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: crier
 spec:
   replicas: 1

--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   name: "crier"
   namespace: default
 ---
@@ -13,7 +12,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: crier
   namespace: default
 rules:
@@ -31,7 +29,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: crier
 rules:
@@ -54,7 +51,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: crier-namespaced
   namespace: default
 roleRef:
@@ -70,7 +66,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: crier-namespaced
   namespace: test-pods
 roleRef:

--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -4,14 +4,12 @@ apiVersion: v1
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
-  labels:
   name: "crier"
   namespace: default
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: crier
   namespace: default
 rules:
@@ -28,7 +26,6 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: crier
 rules:
@@ -50,7 +47,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: crier-namespaced
   namespace: default
 roleRef:
@@ -65,7 +61,6 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: crier-namespaced
   namespace: test-pods
 roleRef:

--- a/prow/cluster/crier_service.yaml
+++ b/prow/cluster/crier_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: crier
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: crier
 spec:

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: deck
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: deck
 spec:
   replicas: 3

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: deck-private
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: deck-private
 spec:
   replicas: 1

--- a/prow/cluster/deck_private_rbac.yaml
+++ b/prow/cluster/deck_private_rbac.yaml
@@ -2,7 +2,6 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: deck-private
 ---
@@ -10,7 +9,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: deck-private
 rules:
@@ -26,7 +24,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: deck-private
 rules:
@@ -41,7 +38,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: deck-private
 roleRef:
@@ -56,7 +52,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: deck-private
 roleRef:

--- a/prow/cluster/deck_private_rbac.yaml
+++ b/prow/cluster/deck_private_rbac.yaml
@@ -1,14 +1,12 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  labels:
   namespace: default
   name: deck-private
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: deck-private
 rules:
@@ -23,7 +21,6 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: deck-private
 rules:
@@ -37,7 +34,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: deck-private
 roleRef:
@@ -51,7 +47,6 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: deck-private
 roleRef:

--- a/prow/cluster/deck_private_service.yaml
+++ b/prow/cluster/deck_private_service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: deck-private
   namespace: default
 spec:

--- a/prow/cluster/deck_private_service.yaml
+++ b/prow/cluster/deck_private_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: deck-private
   namespace: default
 spec:

--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "deck"
 ---
@@ -12,7 +11,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: deck
 rules:
@@ -31,7 +29,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: deck
 rules:
@@ -46,7 +43,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: deck
 roleRef:
@@ -61,7 +57,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: deck
 roleRef:

--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -3,14 +3,12 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: default
   name: "deck"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: deck
 rules:
@@ -28,7 +26,6 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: deck
 rules:
@@ -42,7 +39,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: deck
 roleRef:
@@ -56,7 +52,6 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: deck
 roleRef:
@@ -67,4 +62,3 @@ subjects:
 - kind: ServiceAccount
   name: deck
   namespace: default
-

--- a/prow/cluster/deck_service.yaml
+++ b/prow/cluster/deck_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: deck
-    app.kubernetes.io/part-of: prow
   name: deck
   namespace: default
 spec:

--- a/prow/cluster/gcsweb/gcsweb-istio-io_managedcertificate.yaml
+++ b/prow/cluster/gcsweb/gcsweb-istio-io_managedcertificate.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  labels:
   name: gcs-istio-io
   namespace: gcs
 spec:

--- a/prow/cluster/gcsweb/gcsweb-istio-io_managedcertificate.yaml
+++ b/prow/cluster/gcsweb/gcsweb-istio-io_managedcertificate.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
   labels:
-    app.kubernetes.io/part-of: gcsweb
   name: gcs-istio-io
   namespace: gcs
 spec:

--- a/prow/cluster/gcsweb/gcsweb_configmap-nginx.yaml
+++ b/prow/cluster/gcsweb/gcsweb_configmap-nginx.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nginx
   namespace: gcs
   labels:
-    app.kubernetes.io/part-of: gcsweb
 data:
   nginx.conf: |
     server {

--- a/prow/cluster/gcsweb/gcsweb_configmap-nginx.yaml
+++ b/prow/cluster/gcsweb/gcsweb_configmap-nginx.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: nginx
   namespace: gcs
-  labels:
 data:
   nginx.conf: |
     server {

--- a/prow/cluster/gcsweb/gcsweb_deployment.yaml
+++ b/prow/cluster/gcsweb/gcsweb_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: gcsweb
   namespace: gcs
   labels:
-    app.kubernetes.io/part-of: gcsweb
     app: gcsweb
 spec:
   replicas: 2

--- a/prow/cluster/gcsweb/gcsweb_ing.yaml
+++ b/prow/cluster/gcsweb/gcsweb_ing.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  labels:
   name: gcsweb-ing
   namespace: gcs
   annotations:

--- a/prow/cluster/gcsweb/gcsweb_ing.yaml
+++ b/prow/cluster/gcsweb/gcsweb_ing.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app.kubernetes.io/part-of: gcsweb
   name: gcsweb-ing
   namespace: gcs
   annotations:

--- a/prow/cluster/gcsweb/gcsweb_namespace.yaml
+++ b/prow/cluster/gcsweb/gcsweb_namespace.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
   name: gcs

--- a/prow/cluster/gcsweb/gcsweb_namespace.yaml
+++ b/prow/cluster/gcsweb/gcsweb_namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/part-of: gcsweb
   name: gcs

--- a/prow/cluster/gcsweb/gcsweb_service.yaml
+++ b/prow/cluster/gcsweb/gcsweb_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: gcsweb
   name: gcsweb
   namespace: gcs
 spec:

--- a/prow/cluster/gcsweb/gcsweb_service.yaml
+++ b/prow/cluster/gcsweb/gcsweb_service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: gcsweb
   namespace: gcs
 spec:

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -2,7 +2,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
     app: ghproxy
   name: ghproxy
   namespace: default
@@ -19,7 +18,6 @@ metadata:
   namespace: default
   name: ghproxy
   labels:
-    app.kubernetes.io/part-of: prow
     app: ghproxy
 spec:
   replicas: 1
@@ -29,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/part-of: prow
         app: ghproxy
     spec:
       containers:
@@ -56,7 +53,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
     app: ghproxy
   namespace: default
   name: ghproxy

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: hook
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: hook
 spec:
   replicas: 4

--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "hook"
 ---
@@ -12,7 +11,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "hook"
 rules:
@@ -38,7 +36,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "hook"
 roleRef:

--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -3,14 +3,12 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: default
   name: "hook"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: "hook"
 rules:
@@ -35,7 +33,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: "hook"
 roleRef:

--- a/prow/cluster/hook_service.yaml
+++ b/prow/cluster/hook_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: hook
-    app.kubernetes.io/part-of: prow
   name: hook
   namespace: default
 spec:

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: horologium
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: horologium
 spec:
   replicas: 1

--- a/prow/cluster/horologium_rbac.yaml
+++ b/prow/cluster/horologium_rbac.yaml
@@ -4,13 +4,11 @@ metadata:
   namespace: default
   name: "horologium"
   labels:
-    app.kubernetes.io/part-of: prow
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "horologium"
 rules:
@@ -27,7 +25,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "horologium"
 roleRef:

--- a/prow/cluster/horologium_rbac.yaml
+++ b/prow/cluster/horologium_rbac.yaml
@@ -3,12 +3,10 @@ kind: ServiceAccount
 metadata:
   namespace: default
   name: "horologium"
-  labels:
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: "horologium"
 rules:
@@ -24,7 +22,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: "horologium"
 roleRef:

--- a/prow/cluster/horologium_service.yaml
+++ b/prow/cluster/horologium_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: horologium
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: horologium
 spec:

--- a/prow/cluster/kubernetes-external-secrets_crd.yaml
+++ b/prow/cluster/kubernetes-external-secrets_crd.yaml
@@ -4,8 +4,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalsecrets.kubernetes-client.io
-  labels:
-    # to avoid pruning by the deploy process
   annotations:
     # for helm v2 backwards compatibility
     helm.sh/hook: crd-install

--- a/prow/cluster/kubernetes-external-secrets_crd.yaml
+++ b/prow/cluster/kubernetes-external-secrets_crd.yaml
@@ -6,7 +6,6 @@ metadata:
   name: externalsecrets.kubernetes-client.io
   labels:
     # to avoid pruning by the deploy process
-    app.kubernetes.io/part-of: prow
   annotations:
     # for helm v2 backwards compatibility
     helm.sh/hook: crd-install

--- a/prow/cluster/kubernetes-external-secrets_deployment.yaml
+++ b/prow/cluster/kubernetes-external-secrets_deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: kubernetes-external-secrets
   namespace: "default"
   labels:
-    app.kubernetes.io/part-of: prow
     app.kubernetes.io/name: kubernetes-external-secrets
 spec:
   replicas: 1

--- a/prow/cluster/kubernetes-external-secrets_rbac.yaml
+++ b/prow/cluster/kubernetes-external-secrets_rbac.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: kubernetes-external-secrets-sa@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: default
   name: "kubernetes-external-secrets-sa"
 ---

--- a/prow/cluster/kubernetes-external-secrets_rbac.yaml
+++ b/prow/cluster/kubernetes-external-secrets_rbac.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: kubernetes-external-secrets-sa@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "kubernetes-external-secrets-sa"
 ---
@@ -14,7 +13,6 @@ kind: ClusterRole
 metadata:
   name: kubernetes-external-secrets
   labels:
-    app.kubernetes.io/part-of: prow
     app.kubernetes.io/name: kubernetes-external-secrets
 rules:
   - apiGroups: [""]
@@ -43,7 +41,6 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-external-secrets
   labels:
-    app.kubernetes.io/part-of: prow
     app.kubernetes.io/name: kubernetes-external-secrets
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -60,7 +57,6 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-external-secrets-auth
   labels:
-    app.kubernetes.io/part-of: prow
     app.kubernetes.io/name: kubernetes-external-secrets
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/kubernetes-external-secrets_service.yaml
+++ b/prow/cluster/kubernetes-external-secrets_service.yaml
@@ -6,7 +6,6 @@ metadata:
   name: kubernetes-external-secrets
   namespace: "default"
   labels:
-    app.kubernetes.io/part-of: prow
     app.kubernetes.io/name: kubernetes-external-secrets
 spec:
   selector:

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -5,7 +5,6 @@ metadata:
   name: prow-grafana
   namespace: prow-monitoring
   labels:
-    app.kubernetes.io/part-of: prow
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing
@@ -20,7 +19,6 @@ metadata:
   name: oauth-token
   namespace: test-pods
   labels:
-    app.kubernetes.io/part-of: prow
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing
@@ -33,7 +31,6 @@ metadata:
   name: istio-testing-robot-ssh-key
   namespace: test-pods
   labels:
-    app.kubernetes.io/part-of: prow
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -4,7 +4,6 @@ kind: ExternalSecret
 metadata:
   name: prow-grafana
   namespace: prow-monitoring
-  labels:
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing
@@ -18,7 +17,6 @@ kind: ExternalSecret
 metadata:
   name: oauth-token
   namespace: test-pods
-  labels:
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing
@@ -30,7 +28,6 @@ kind: ExternalSecret
 metadata:
   name: istio-testing-robot-ssh-key
   namespace: test-pods
-  labels:
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing

--- a/prow/cluster/monitoring/grafana_expose.yaml
+++ b/prow/cluster/monitoring/grafana_expose.yaml
@@ -23,7 +23,6 @@ apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: monitoring-prow-istio-io
   namespace: prow-monitoring
 spec:

--- a/prow/cluster/monitoring/grafana_expose.yaml
+++ b/prow/cluster/monitoring/grafana_expose.yaml
@@ -22,7 +22,6 @@ spec:
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  labels:
   name: monitoring-prow-istio-io
   namespace: prow-monitoring
 spec:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -18,7 +18,6 @@ metadata:
   name: needs-rebase
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: needs-rebase
 spec:
   replicas: 1

--- a/prow/cluster/needs-rebase_service.yaml
+++ b/prow/cluster/needs-rebase_service.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: needs-rebase
   namespace: default
 spec:

--- a/prow/cluster/needs-rebase_service.yaml
+++ b/prow/cluster/needs-rebase_service.yaml
@@ -15,7 +15,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: needs-rebase
   namespace: default
 spec:

--- a/prow/cluster/private/authentikos_deployment.yaml
+++ b/prow/cluster/private/authentikos_deployment.yaml
@@ -19,14 +19,12 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow-private
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: authentikos
   labels:
-    app.kubernetes.io/part-of: prow-private
     app: authentikos
 spec:
   replicas: 1
@@ -36,7 +34,6 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/part-of: prow-private
         app: authentikos
     spec:
       serviceAccountName: authentikos

--- a/prow/cluster/private/authentikos_deployment.yaml
+++ b/prow/cluster/private/authentikos_deployment.yaml
@@ -18,7 +18,6 @@ metadata:
   name: "authentikos"
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
-  labels:
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/prow/cluster/private/authentikos_rbac.yaml
+++ b/prow/cluster/private/authentikos_rbac.yaml
@@ -16,7 +16,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-private
   name: authentikos
 rules:
 - apiGroups:
@@ -31,7 +30,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-private
   name: authentikos
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/private/authentikos_rbac.yaml
+++ b/prow/cluster/private/authentikos_rbac.yaml
@@ -15,7 +15,6 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: authentikos
 rules:
 - apiGroups:
@@ -29,7 +28,6 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   name: authentikos
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/private/prow-private-istio-io_managedcertificate.yaml
+++ b/prow/cluster/private/prow-private-istio-io_managedcertificate.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  labels:
   name: prow-private-istio-io
 spec:
   domains:

--- a/prow/cluster/private/prow-private-istio-io_managedcertificate.yaml
+++ b/prow/cluster/private/prow-private-istio-io_managedcertificate.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-private
   name: prow-private-istio-io
 spec:
   domains:

--- a/prow/cluster/private/test_pod_namespace.yaml
+++ b/prow/cluster/private/test_pod_namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow-private
   name: test-pods

--- a/prow/cluster/private/test_pod_namespace.yaml
+++ b/prow/cluster/private/test_pod_namespace.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
   name: test-pods

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -4,7 +4,6 @@ metadata:
   namespace: default
   name: prow-controller-manager
   labels:
-    app.kubernetes.io/part-of: prow
     app: prow-controller-manager
 spec:
   replicas: 1 # TODO(fejta) - delete plank
@@ -60,7 +59,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,7 +66,6 @@ metadata:
   namespace: default
   name: "prow-controller-manager"
   labels:
-    app.kubernetes.io/part-of: prow
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -119,7 +116,6 @@ metadata:
   namespace: test-pods
   name: "prow-controller-manager"
   labels:
-    app.kubernetes.io/part-of: prow
 rules:
 - apiGroups:
    - ""
@@ -139,7 +135,6 @@ metadata:
   namespace: default
   name: "prow-controller-manager"
   labels:
-    app.kubernetes.io/part-of: prow
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -154,7 +149,6 @@ metadata:
   namespace: test-pods
   name: "prow-controller-manager"
   labels:
-    app.kubernetes.io/part-of: prow
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -169,7 +163,6 @@ kind: Service
 metadata:
   labels:
     app: prow-controller-manager
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: prow-controller-manager
 spec:

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -58,14 +58,12 @@ metadata:
   name: "prow-controller-manager"
   annotations:
     iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
-  labels:
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "prow-controller-manager"
-  labels:
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -115,7 +113,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"
-  labels:
 rules:
 - apiGroups:
    - ""
@@ -134,7 +131,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "prow-controller-manager"
-  labels:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -148,7 +144,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"
-  labels:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/prow/cluster/prow-istio-io_managedcertificate.yaml
+++ b/prow/cluster/prow-istio-io_managedcertificate.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: prow-istio-io
   namespace: default
 spec:

--- a/prow/cluster/prow-istio-io_managedcertificate.yaml
+++ b/prow/cluster/prow-istio-io_managedcertificate.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  labels:
   name: prow-istio-io
   namespace: default
 spec:

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -4,7 +4,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job-default@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: test-pods
   # Default service account that only has permissions to access the GCS bucket
   # for logging.
@@ -15,7 +14,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: test-pods
   # Service account that has more permissions on the shared GCP projects, check
   # with a Googler on what permissions it has.
@@ -27,7 +25,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-deployer@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: test-pods
   name: prow-deployer
 ---
@@ -36,6 +33,5 @@ kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: testgrid-updater@istio-testing.iam.gserviceaccount.com
-  labels:
   namespace: test-pods
   name: testgrid-updater

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job-default@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   # Default service account that only has permissions to access the GCS bucket
   # for logging.
@@ -17,7 +16,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   # Service account that has more permissions on the shared GCP projects, check
   # with a Googler on what permissions it has.
@@ -30,7 +28,6 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prow-deployer@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: prow-deployer
 ---
@@ -40,6 +37,5 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: testgrid-updater@istio-testing.iam.gserviceaccount.com
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: testgrid-updater

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: sinker
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: sinker
 spec:
   replicas: 1

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "sinker"
 ---
@@ -10,7 +9,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "sinker"
 rules:
@@ -59,7 +57,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: "sinker"
 rules:
@@ -78,7 +75,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: "sinker"
 roleRef:
@@ -93,7 +89,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: test-pods
   name: "sinker"
 roleRef:

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -1,14 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
   namespace: default
   name: "sinker"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: "sinker"
 rules:
@@ -56,7 +54,6 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: "sinker"
 rules:
@@ -74,7 +71,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: "sinker"
 roleRef:
@@ -88,7 +84,6 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: test-pods
   name: "sinker"
 roleRef:

--- a/prow/cluster/sinker_service.yaml
+++ b/prow/cluster/sinker_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: sinker
-    app.kubernetes.io/part-of: prow
   name: sinker
   namespace: default
 spec:

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   namespace: default
   name: statusreconciler
   labels:
-    app.kubernetes.io/part-of: prow
     app: statusreconciler
 spec:
   replicas: 1

--- a/prow/cluster/test_pod_namespace.yaml
+++ b/prow/cluster/test_pod_namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   name: test-pods

--- a/prow/cluster/test_pod_namespace.yaml
+++ b/prow/cluster/test_pod_namespace.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
   name: test-pods

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: tide
   namespace: default
   labels:
-    app.kubernetes.io/part-of: prow
     app: tide
 spec:
   replicas: 1 # Do not scale up.

--- a/prow/cluster/tide_rbac.yaml
+++ b/prow/cluster/tide_rbac.yaml
@@ -10,7 +10,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: tide
 rules:
@@ -28,7 +27,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: tide
 roleRef:

--- a/prow/cluster/tide_rbac.yaml
+++ b/prow/cluster/tide_rbac.yaml
@@ -9,7 +9,6 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: tide
 rules:
@@ -26,7 +25,6 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
   namespace: default
   name: tide
 roleRef:

--- a/prow/cluster/tide_service.yaml
+++ b/prow/cluster/tide_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app: deck
-    app.kubernetes.io/part-of: prow
   name: tide
   namespace: default
 spec:

--- a/prow/cluster/tls-ing.yaml
+++ b/prow/cluster/tls-ing.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app.kubernetes.io/part-of: prow
   namespace: default
   name: tls-ing
   annotations:

--- a/prow/cluster/tls-ing.yaml
+++ b/prow/cluster/tls-ing.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  labels:
   namespace: default
   name: tls-ing
   annotations:

--- a/prow/cluster/velodrome/velodrome-istio-io_managedcertificate.yaml
+++ b/prow/cluster/velodrome/velodrome-istio-io_managedcertificate.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
   labels:
-    app.kubernetes.io/part-of: velodrome
   name: velodrome-istio-io
   namespace: velodrome
 spec:

--- a/prow/cluster/velodrome/velodrome-istio-io_managedcertificate.yaml
+++ b/prow/cluster/velodrome/velodrome-istio-io_managedcertificate.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  labels:
   name: velodrome-istio-io
   namespace: velodrome
 spec:

--- a/prow/cluster/velodrome/velodrome_configmap-nginx.yaml
+++ b/prow/cluster/velodrome/velodrome_configmap-nginx.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: nginx
   namespace: velodrome
-  labels:
 data:
   nginx.conf: |
     server {

--- a/prow/cluster/velodrome/velodrome_configmap-nginx.yaml
+++ b/prow/cluster/velodrome/velodrome_configmap-nginx.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nginx
   namespace: velodrome
   labels:
-    app.kubernetes.io/part-of: velodrome
 data:
   nginx.conf: |
     server {

--- a/prow/cluster/velodrome/velodrome_deployment.yaml
+++ b/prow/cluster/velodrome/velodrome_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: velodrome
   namespace: velodrome
   labels:
-    app.kubernetes.io/part-of: velodrome
     app: velodrome
 spec:
   replicas: 2

--- a/prow/cluster/velodrome/velodrome_ing.yaml
+++ b/prow/cluster/velodrome/velodrome_ing.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app.kubernetes.io/part-of: velodrome
   name: velodrome-ing
   namespace: velodrome
   annotations:

--- a/prow/cluster/velodrome/velodrome_ing.yaml
+++ b/prow/cluster/velodrome/velodrome_ing.yaml
@@ -1,7 +1,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  labels:
   name: velodrome-ing
   namespace: velodrome
   annotations:

--- a/prow/cluster/velodrome/velodrome_namespace.yaml
+++ b/prow/cluster/velodrome/velodrome_namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/part-of: velodrome
   name: velodrome

--- a/prow/cluster/velodrome/velodrome_namespace.yaml
+++ b/prow/cluster/velodrome/velodrome_namespace.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
   name: velodrome

--- a/prow/cluster/velodrome/velodrome_service.yaml
+++ b/prow/cluster/velodrome/velodrome_service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: velodrome
   name: velodrome
   namespace: velodrome
 spec:
@@ -16,7 +15,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/part-of: velodrome
   name: velodrome-external
   namespace: velodrome
 spec:
@@ -28,7 +26,6 @@ kind: Endpoints
 apiVersion: v1
 metadata:
   labels:
-    app.kubernetes.io/part-of: velodrome
   name: velodrome-external
   namespace: velodrome
 subsets:

--- a/prow/cluster/velodrome/velodrome_service.yaml
+++ b/prow/cluster/velodrome/velodrome_service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: velodrome
   namespace: velodrome
 spec:
@@ -14,7 +13,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
   name: velodrome-external
   namespace: velodrome
 spec:
@@ -25,7 +23,6 @@ spec:
 kind: Endpoints
 apiVersion: v1
 metadata:
-  labels:
   name: velodrome-external
   namespace: velodrome
 subsets:


### PR DESCRIPTION
Depends on #3764, only the latest two commits are unique to this PR and should be reviewed here.
/hold

This also cleans up the use of `--prune` in the boskos Makefile where it was also used (missed that before).
/assign @chaodaiG @listx