### PR TITLE
Set VERSION in image scan jobs for base of generated image name

### DIFF
--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -22,6 +22,8 @@ periodics:
       env:
       - name: BUILD_BASE_IMAGES
         value: "true"
+      - name: VERSION
+        value: master
       - name: COSIGN_KEY
         valueFrom:
           secretKeyRef:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
@@ -22,6 +22,8 @@ periodics:
       env:
       - name: BUILD_BASE_IMAGES
         value: "true"
+      - name: VERSION
+        value: "1.12"
       - name: COSIGN_KEY
         valueFrom:
           secretKeyRef:

--- a/prow/config/jobs/release-builder-1.12.yaml
+++ b/prow/config/jobs/release-builder-1.12.yaml
@@ -98,6 +98,8 @@ jobs:
   env:
   - name: BUILD_BASE_IMAGES
     value: "true"
+  - name: VERSION
+    value: "1.12"
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -52,6 +52,8 @@ jobs:
     env:
     - name: BUILD_BASE_IMAGES
       value: "true"
+    - name: VERSION
+      value: "master"
     command: [entrypoint, release/build.sh]
     requirements: [release, docker, github-optional]
     resources: build


### PR DESCRIPTION
With https://github.com/istio/release-builder/pull/887 and it's cherry-pick: https://github.com/istio/release-builder/pull/888 the VERSION can be specified to override the base name of the newly built images.