### PR TITLE
Truncate long job names

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -239,7 +239,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodremote-tests_istio_postsubmit_priv
+    name: integ-telemetry-remote-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -305,7 +305,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_postsubmit_priv
+    name: integ-telemetry-less-mc-k8s-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -632,7 +632,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -696,7 +696,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-tests_istio_postsubmit_priv
+    name: integ-pilot-remote-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -765,7 +765,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-multicluster-tests_istio_postsubmit_priv
+    name: integ-pilot-remote-mc-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -834,7 +834,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit_priv
+    name: integ-pilot-less-mc-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -967,7 +967,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_postsubmit_priv
+    name: integ-security-mc-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1031,7 +1031,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodremote-tests_istio_postsubmit_priv
+    name: integ-security-remote-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1100,7 +1100,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_postsubmit_priv
+    name: integ-security-less-mc-tests_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -2278,7 +2278,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodremote-tests_istio_priv
+    name: integ-telemetry-remote-tests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2345,7 +2345,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_priv
+    name: integ-telemetry-less-mc-k8s-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2678,7 +2678,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_priv
+    name: integ-pilot-mc-tests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2743,7 +2743,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-tests_istio_priv
+    name: integ-pilot-remote-tests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2813,7 +2813,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-multicluster-tests_istio_priv
+    name: integ-pilot-remote-mc-tests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2883,7 +2883,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_priv
+    name: integ-pilot-less-mc-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -3019,7 +3019,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_priv
+    name: integ-security-mc-tests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3084,7 +3084,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodremote-tests_istio_priv
+    name: integ-security-remote-tests_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3154,7 +3154,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_priv
+    name: integ-security-less-mc-tests_istio_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -113,7 +113,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_postsubmit_priv
+    name: integ-telemetry_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -175,7 +175,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_postsubmit_priv
+    name: integ-telemetry-mc_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -239,7 +239,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-remote-tests_istio_postsubmit_priv
+    name: integ-telemetry-istiodremote_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -305,7 +305,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-less-mc-k8s-tests_istio_postsubmit_priv
+    name: integ-telemetry-istiodless-mc_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -376,7 +376,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_postsubmit_priv
+    name: integ-distroless_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -441,7 +441,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_postsubmit_priv
+    name: integ-ipv6_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -508,7 +508,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_postsubmit_priv
+    name: integ-operator-controller_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -570,7 +570,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_postsubmit_priv
+    name: integ-pilot_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -632,7 +632,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_postsubmit_priv
+    name: integ-pilot-multicluster_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -696,7 +696,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-tests_istio_postsubmit_priv
+    name: integ-pilot-istiodremote_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -765,7 +765,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-mc-tests_istio_postsubmit_priv
+    name: integ-pilot-istiodremote-mc_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -834,7 +834,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-less-mc-tests_istio_postsubmit_priv
+    name: integ-pilot-istiodless-mc_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -905,7 +905,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_postsubmit_priv
+    name: integ-security_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -967,7 +967,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_postsubmit_priv
+    name: integ-security-multicluster_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1031,7 +1031,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-remote-tests_istio_postsubmit_priv
+    name: integ-security-istiodremote_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1100,7 +1100,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-less-mc-tests_istio_postsubmit_priv
+    name: integ-security-istiodless-mc_istio_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1171,7 +1171,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_postsubmit_priv
+    name: integ-helm_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1803,7 +1803,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_postsubmit_priv
+    name: integ-cni_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1872,7 +1872,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-assertion-k8s-tests_istio_postsubmit_priv
+    name: integ-assertion_istio_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2084,7 +2084,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_priv
+    name: integ-cni_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2150,7 +2150,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_priv
+    name: integ-telemetry_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2213,7 +2213,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_priv
+    name: integ-telemetry-mc_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2278,7 +2278,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-remote-tests_istio_priv
+    name: integ-telemetry-istiodremote_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2345,7 +2345,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-less-mc-k8s-tests_istio_priv
+    name: integ-telemetry-istiodless-mc_istio_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2418,7 +2418,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_priv
+    name: integ-distroless_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2484,7 +2484,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_priv
+    name: integ-ipv6_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2552,7 +2552,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_priv
+    name: integ-operator-controller_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2615,7 +2615,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_priv
+    name: integ-pilot_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2678,7 +2678,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_priv
+    name: integ-pilot-multicluster_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2743,7 +2743,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-tests_istio_priv
+    name: integ-pilot-istiodremote_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2813,7 +2813,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-mc-tests_istio_priv
+    name: integ-pilot-istiodremote-mc_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2883,7 +2883,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-pilot-less-mc-tests_istio_priv
+    name: integ-pilot-istiodless-mc_istio_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2956,7 +2956,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_priv
+    name: integ-security_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3019,7 +3019,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_priv
+    name: integ-security-multicluster_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3084,7 +3084,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-remote-tests_istio_priv
+    name: integ-security-istiodremote_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3154,7 +3154,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-security-less-mc-tests_istio_priv
+    name: integ-security-istiodless-mc_istio_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -3227,7 +3227,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_priv
+    name: integ-helm_istio_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3292,7 +3292,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-assertion-k8s-tests_istio_priv
+    name: integ-assertion_istio_priv
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -381,7 +381,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.10_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -513,7 +513,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.10_postsubmit_priv
+    name: integ-security-mc-tests_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1536,7 +1536,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-multicluster-k8s-tests_istio_release-1.10_priv
+    name: integ-mc-k8s-tests_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1808,7 +1808,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.10_priv
+    name: integ-pilot-mc-tests_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1876,7 +1876,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.10_priv
+    name: integ-security-mc-tests_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -113,7 +113,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.10_postsubmit_priv
+    name: integ-telemetry-mc_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -180,7 +180,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.10_postsubmit_priv
+    name: integ-distroless_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -247,7 +247,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.10_postsubmit_priv
+    name: integ-ipv6_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -316,7 +316,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.10_postsubmit_priv
+    name: integ-pilot_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -381,7 +381,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.10_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -448,7 +448,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.10_postsubmit_priv
+    name: integ-security_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -513,7 +513,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.10_postsubmit_priv
+    name: integ-security-multicluster_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -580,7 +580,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.10_postsubmit_priv
+    name: integ-telemetry_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -645,7 +645,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.10_postsubmit_priv
+    name: integ-helm_istio_release-1.10_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1270,7 +1270,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.10_priv
+    name: integ-pilot_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1336,7 +1336,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.10_priv
+    name: integ-security_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1402,7 +1402,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.10_priv
+    name: integ-telemetry_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1468,7 +1468,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.10_priv
+    name: integ-telemetry-mc_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1536,7 +1536,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-mc-k8s-tests_istio_release-1.10_priv
+    name: integ-multicluster_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1604,7 +1604,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.10_priv
+    name: integ-distroless_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1672,7 +1672,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.10_priv
+    name: integ-ipv6_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1742,7 +1742,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.10_priv
+    name: integ-operator-controller_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1808,7 +1808,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.10_priv
+    name: integ-pilot-multicluster_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1876,7 +1876,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.10_priv
+    name: integ-security-multicluster_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1944,7 +1944,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.10-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.10_priv
+    name: integ-helm_istio_release-1.10_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -180,7 +180,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -454,7 +454,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.11_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -521,7 +521,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.11_postsubmit_priv
+    name: integ-pilot-less-mc-tests_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -659,7 +659,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.11_postsubmit_priv
+    name: integ-security-mc-tests_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -726,7 +726,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.11_postsubmit_priv
+    name: integ-security-less-mc-tests_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1890,7 +1890,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.11_priv
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -1965,7 +1965,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-multicluster-k8s-tests_istio_release-1.11_priv
+    name: integ-mc-k8s-tests_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2033,7 +2033,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-istiodremote-k8s-tests_istio_release-1.11_priv
+    name: integ-remote-k8s-tests_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2307,7 +2307,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.11_priv
+    name: integ-pilot-mc-tests_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2375,7 +2375,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.11_priv
+    name: integ-pilot-less-mc-tests_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2450,7 +2450,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.11_priv
+    name: integ-security-mc-tests_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2518,7 +2518,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.11_priv
+    name: integ-security-less-mc-tests_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -113,7 +113,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-telemetry-multicluster_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -180,7 +180,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-telemetry-istiodless-mc_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -253,7 +253,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-distroless_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -320,7 +320,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-ipv6_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -389,7 +389,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-pilot_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -454,7 +454,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.11_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -521,7 +521,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-less-mc-tests_istio_release-1.11_postsubmit_priv
+    name: integ-pilot-istiodless-mc_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -594,7 +594,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-security_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -659,7 +659,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.11_postsubmit_priv
+    name: integ-security-multicluster_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -726,7 +726,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-less-mc-tests_istio_release-1.11_postsubmit_priv
+    name: integ-security-istiodless-mc_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -799,7 +799,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-telemetry_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -864,7 +864,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.11_postsubmit_priv
+    name: integ-helm_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1344,7 +1344,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_release-1.11_postsubmit_priv
+    name: integ-cni_istio_release-1.11_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1556,7 +1556,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.11_priv
+    name: integ-pilot_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1622,7 +1622,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_release-1.11_priv
+    name: integ-cni_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1690,7 +1690,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.11_priv
+    name: integ-security_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1756,7 +1756,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.11_priv
+    name: integ-telemetry_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1822,7 +1822,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.11_priv
+    name: integ-telemetry-multicluster_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1890,7 +1890,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11_priv
+    name: integ-telemetry-istiodless-mc_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -1965,7 +1965,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-mc-k8s-tests_istio_release-1.11_priv
+    name: integ-multicluster_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2033,7 +2033,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-remote-k8s-tests_istio_release-1.11_priv
+    name: integ-istiodremote_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2103,7 +2103,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.11_priv
+    name: integ-distroless_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2171,7 +2171,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.11_priv
+    name: integ-ipv6_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2241,7 +2241,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.11_priv
+    name: integ-operator-controller_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2307,7 +2307,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.11_priv
+    name: integ-pilot-multicluster_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2375,7 +2375,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-pilot-less-mc-tests_istio_release-1.11_priv
+    name: integ-pilot-istiodless-mc_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2450,7 +2450,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.11_priv
+    name: integ-security-multicluster_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2518,7 +2518,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-security-less-mc-tests_istio_release-1.11_priv
+    name: integ-security-istiodless-mc_istio_release-1.11_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2593,7 +2593,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.11-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.11_priv
+    name: integ-helm_istio_release-1.11_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -113,7 +113,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-telemetry-mc_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -177,7 +177,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-remote-tests_istio_release-1.12_postsubmit_priv
+    name: integ-telemetry-istiodremote_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -243,7 +243,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-telemetry-istiodless-mc_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -314,7 +314,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-distroless_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -379,7 +379,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-ipv6_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -446,7 +446,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -508,7 +508,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -572,7 +572,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-istiodremote_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -641,7 +641,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-mc-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-istiodremote-mc_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -710,7 +710,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-less-mc-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-istiodless-mc_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -781,7 +781,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -843,7 +843,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security-multicluster_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -907,7 +907,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-remote-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security-istiodremote_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -976,7 +976,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-less-mc-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security-istiodless-mc_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1047,7 +1047,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-telemetry_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1109,7 +1109,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.12_postsubmit_priv
+    name: integ-helm_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1664,7 +1664,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-cni_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1733,7 +1733,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-assertion-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-assertion_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1945,7 +1945,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.12_priv
+    name: integ-pilot_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2011,7 +2011,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_release-1.12_priv
+    name: integ-cni_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2079,7 +2079,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.12_priv
+    name: integ-security_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2145,7 +2145,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.12_priv
+    name: integ-telemetry_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2211,7 +2211,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.12_priv
+    name: integ-telemetry-mc_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2276,7 +2276,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-remote-tests_istio_release-1.12_priv
+    name: integ-telemetry-istiodremote_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2343,7 +2343,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12_priv
+    name: integ-telemetry-istiodless-mc_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2416,7 +2416,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.12_priv
+    name: integ-distroless_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2482,7 +2482,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.12_priv
+    name: integ-ipv6_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2550,7 +2550,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.12_priv
+    name: integ-operator-controller_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2616,7 +2616,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.12_priv
+    name: integ-pilot-multicluster_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2681,7 +2681,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-tests_istio_release-1.12_priv
+    name: integ-pilot-istiodremote_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2751,7 +2751,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-remote-mc-tests_istio_release-1.12_priv
+    name: integ-pilot-istiodremote-mc_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2821,7 +2821,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-less-mc-tests_istio_release-1.12_priv
+    name: integ-pilot-istiodless-mc_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2894,7 +2894,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.12_priv
+    name: integ-security-multicluster_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2959,7 +2959,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-remote-tests_istio_release-1.12_priv
+    name: integ-security-istiodremote_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3029,7 +3029,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-less-mc-tests_istio_release-1.12_priv
+    name: integ-security-istiodless-mc_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -3102,7 +3102,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.12_priv
+    name: integ-helm_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3167,7 +3167,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-assertion-k8s-tests_istio_release-1.12_priv
+    name: integ-assertion_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -177,7 +177,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodremote-tests_istio_release-1.12_postsubmit_priv
+    name: integ-telemetry-remote-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -243,7 +243,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.12_postsubmit_priv
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -508,7 +508,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -572,7 +572,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-remote-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -641,7 +641,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-remote-mc-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -710,7 +710,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.12_postsubmit_priv
+    name: integ-pilot-less-mc-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -843,7 +843,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security-mc-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -907,7 +907,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodremote-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security-remote-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -976,7 +976,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.12_postsubmit_priv
+    name: integ-security-less-mc-tests_istio_release-1.12_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -2276,7 +2276,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodremote-tests_istio_release-1.12_priv
+    name: integ-telemetry-remote-tests_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2343,7 +2343,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.12_priv
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2616,7 +2616,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.12_priv
+    name: integ-pilot-mc-tests_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2681,7 +2681,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-tests_istio_release-1.12_priv
+    name: integ-pilot-remote-tests_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2751,7 +2751,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.12_priv
+    name: integ-pilot-remote-mc-tests_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2821,7 +2821,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.12_priv
+    name: integ-pilot-less-mc-tests_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2894,7 +2894,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.12_priv
+    name: integ-security-mc-tests_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2959,7 +2959,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodremote-tests_istio_release-1.12_priv
+    name: integ-security-remote-tests_istio_release-1.12_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3029,7 +3029,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.12-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.12_priv
+    name: integ-security-less-mc-tests_istio_release-1.12_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -113,7 +113,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-telemetry_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -175,7 +175,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-telemetry-mc_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -239,7 +239,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodremote-tests_istio_release-1.13_postsubmit_priv
+    name: integ-telemetry-istiodremote_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -305,7 +305,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-telemetry-istiodless-mc_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -376,7 +376,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-distroless_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -441,7 +441,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-ipv6_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -508,7 +508,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.13_postsubmit_priv
+    name: integ-operator-controller_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -570,7 +570,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-pilot_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -632,7 +632,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.13_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -696,7 +696,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-tests_istio_release-1.13_postsubmit_priv
+    name: integ-pilot-istiodremote_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -765,7 +765,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.13_postsubmit_priv
+    name: integ-pilot-istiodremote-mc_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -834,7 +834,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.13_postsubmit_priv
+    name: integ-pilot-istiodless-mc_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -905,7 +905,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-security_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -967,7 +967,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.13_postsubmit_priv
+    name: integ-security-multicluster_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1031,7 +1031,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodremote-tests_istio_release-1.13_postsubmit_priv
+    name: integ-security-istiodremote_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1100,7 +1100,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.13_postsubmit_priv
+    name: integ-security-istiodless-mc_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1171,7 +1171,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.13_postsubmit_priv
+    name: integ-helm_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1803,7 +1803,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-cni_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1872,7 +1872,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-assertion-k8s-tests_istio_release-1.13_postsubmit_priv
+    name: integ-assertion_istio_release-1.13_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2084,7 +2084,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-cni-k8s-tests_istio_release-1.13_priv
+    name: integ-cni_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2150,7 +2150,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.13_priv
+    name: integ-telemetry_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2213,7 +2213,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.13_priv
+    name: integ-telemetry-mc_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2278,7 +2278,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodremote-tests_istio_release-1.13_priv
+    name: integ-telemetry-istiodremote_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2345,7 +2345,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.13_priv
+    name: integ-telemetry-istiodless-mc_istio_release-1.13_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2418,7 +2418,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.13_priv
+    name: integ-distroless_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2484,7 +2484,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.13_priv
+    name: integ-ipv6_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2552,7 +2552,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.13_priv
+    name: integ-operator-controller_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2615,7 +2615,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.13_priv
+    name: integ-pilot_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2678,7 +2678,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.13_priv
+    name: integ-pilot-multicluster_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2743,7 +2743,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-tests_istio_release-1.13_priv
+    name: integ-pilot-istiodremote_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2813,7 +2813,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.13_priv
+    name: integ-pilot-istiodremote-mc_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2883,7 +2883,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.13_priv
+    name: integ-pilot-istiodless-mc_istio_release-1.13_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2956,7 +2956,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.13_priv
+    name: integ-security_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3019,7 +3019,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.13_priv
+    name: integ-security-multicluster_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3084,7 +3084,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodremote-tests_istio_release-1.13_priv
+    name: integ-security-istiodremote_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3154,7 +3154,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.13_priv
+    name: integ-security-istiodless-mc_istio_release-1.13_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -3227,7 +3227,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.13_priv
+    name: integ-helm_istio_release-1.13_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3292,7 +3292,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.13-istio
       preset-override-envoy: "true"
-    name: integ-assertion-k8s-tests_istio_release-1.13_priv
+    name: integ-assertion_istio_release-1.13_priv
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
@@ -150,7 +150,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-distroless_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -214,7 +214,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-ipv6_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -280,7 +280,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-galley-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-galley_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -342,7 +342,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-mixer-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-mixer_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -404,7 +404,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-pilot_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -466,7 +466,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.7_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -534,7 +534,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-security_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -596,7 +596,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.7_postsubmit_priv
+    name: integ-telemetry_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1043,7 +1043,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-galley-k8s-tests_istio_release-1.7_priv
+    name: integ-galley_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1106,7 +1106,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-mixer-k8s-tests_istio_release-1.7_priv
+    name: integ-mixer_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1169,7 +1169,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.7_priv
+    name: integ-pilot_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1232,7 +1232,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.7_priv
+    name: integ-security_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1295,7 +1295,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.7_priv
+    name: integ-telemetry_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1358,7 +1358,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-mc-k8s-tests_istio_release-1.7_priv
+    name: integ-multicluster_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1423,7 +1423,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.7_priv
+    name: integ-distroless_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1488,7 +1488,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.7_priv
+    name: integ-ipv6_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1555,7 +1555,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.7_priv
+    name: integ-operator-controller_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1618,7 +1618,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.7_priv
+    name: integ-pilot-multicluster_istio_release-1.7_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.7.gen.yaml
@@ -466,7 +466,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.7_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_release-1.7_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1358,7 +1358,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-multicluster-k8s-tests_istio_release-1.7_priv
+    name: integ-mc-k8s-tests_istio_release-1.7_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1618,7 +1618,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.7-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.7_priv
+    name: integ-pilot-mc-tests_istio_release-1.7_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -427,7 +427,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.8_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -494,7 +494,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmit_priv
+    name: integ-external-mc-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -632,7 +632,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.8_postsubmit_priv
+    name: integ-security-mc-tests_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1641,7 +1641,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-multicluster-k8s-tests_istio_release-1.8_priv
+    name: integ-mc-k8s-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1913,7 +1913,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.8_priv
+    name: integ-pilot-mc-tests_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1981,7 +1981,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-external-istiod-mc-tests_istio_release-1.8_priv
+    name: integ-external-mc-tests_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2056,7 +2056,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.8_priv
+    name: integ-security-mc-tests_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.8.gen.yaml
@@ -159,7 +159,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.8_postsubmit_priv
+    name: integ-telemetry-multicluster_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -226,7 +226,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.8_postsubmit_priv
+    name: integ-distroless_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -293,7 +293,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.8_postsubmit_priv
+    name: integ-ipv6_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -362,7 +362,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.8_postsubmit_priv
+    name: integ-pilot_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -427,7 +427,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.8_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -494,7 +494,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-external-mc-tests_istio_release-1.8_postsubmit_priv
+    name: integ-external-istiod-mc_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -567,7 +567,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.8_postsubmit_priv
+    name: integ-security_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -632,7 +632,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.8_postsubmit_priv
+    name: integ-security-multicluster_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -699,7 +699,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.8_postsubmit_priv
+    name: integ-telemetry_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -764,7 +764,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.8_postsubmit_priv
+    name: integ-helm_istio_release-1.8_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1374,7 +1374,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.8_priv
+    name: integ-pilot_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1440,7 +1440,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.8_priv
+    name: integ-security_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1506,7 +1506,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.8_priv
+    name: integ-telemetry_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1572,7 +1572,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.8_priv
+    name: integ-telemetry-multicluster_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1641,7 +1641,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-mc-k8s-tests_istio_release-1.8_priv
+    name: integ-multicluster_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1709,7 +1709,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.8_priv
+    name: integ-distroless_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1777,7 +1777,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.8_priv
+    name: integ-ipv6_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1847,7 +1847,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.8_priv
+    name: integ-operator-controller_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1913,7 +1913,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.8_priv
+    name: integ-pilot-multicluster_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1981,7 +1981,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-external-mc-tests_istio_release-1.8_priv
+    name: integ-external-istiod-mc_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2056,7 +2056,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.8_priv
+    name: integ-security-multicluster_istio_release-1.8_priv
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -2125,7 +2125,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.8-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.8_priv
+    name: integ-helm_istio_release-1.8_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -113,7 +113,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.9_postsubmit_priv
+    name: integ-telemetry-mc_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -180,7 +180,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.9_postsubmit_priv
+    name: integ-distroless_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -247,7 +247,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.9_postsubmit_priv
+    name: integ-ipv6_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -316,7 +316,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.9_postsubmit_priv
+    name: integ-pilot_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -381,7 +381,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.9_postsubmit_priv
+    name: integ-pilot-multicluster_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -448,7 +448,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.9_postsubmit_priv
+    name: integ-security_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -513,7 +513,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.9_postsubmit_priv
+    name: integ-security-multicluster_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -580,7 +580,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.9_postsubmit_priv
+    name: integ-telemetry_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -645,7 +645,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.9_postsubmit_priv
+    name: integ-helm_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1201,7 +1201,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-k8s-tests_istio_release-1.9_priv
+    name: integ-pilot_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1267,7 +1267,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-k8s-tests_istio_release-1.9_priv
+    name: integ-security_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1333,7 +1333,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-k8s-tests_istio_release-1.9_priv
+    name: integ-telemetry_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1399,7 +1399,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.9_priv
+    name: integ-telemetry-mc_istio_release-1.9_priv
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1468,7 +1468,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-mc-k8s-tests_istio_release-1.9_priv
+    name: integ-multicluster_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1536,7 +1536,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-distroless-k8s-tests_istio_release-1.9_priv
+    name: integ-distroless_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1604,7 +1604,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-ipv6-k8s-tests_istio_release-1.9_priv
+    name: integ-ipv6_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1674,7 +1674,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-operator-controller-tests_istio_release-1.9_priv
+    name: integ-operator-controller_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1740,7 +1740,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-mc-tests_istio_release-1.9_priv
+    name: integ-pilot-multicluster_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1808,7 +1808,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-mc-tests_istio_release-1.9_priv
+    name: integ-security-multicluster_istio_release-1.9_priv
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1877,7 +1877,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-helm-tests_istio_release-1.9_priv
+    name: integ-helm_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -381,7 +381,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.9_postsubmit_priv
+    name: integ-pilot-mc-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -513,7 +513,7 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.9_postsubmit_priv
+    name: integ-security-mc-tests_istio_release-1.9_postsubmit_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1468,7 +1468,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-multicluster-k8s-tests_istio_release-1.9_priv
+    name: integ-mc-k8s-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1740,7 +1740,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-pilot-multicluster-tests_istio_release-1.9_priv
+    name: integ-pilot-mc-tests_istio_release-1.9_priv
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1808,7 +1808,7 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.9-istio
       preset-override-envoy: "true"
-    name: integ-security-multicluster-tests_istio_release-1.9_priv
+    name: integ-security-mc-tests_istio_release-1.9_priv
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -312,7 +312,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-istiodremote-tests_istio_postsubmit
+    name: integ-telemetry-remote-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -373,7 +373,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_postsubmit
+    name: integ-telemetry-less-mc-k8s-tests_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -675,7 +675,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_postsubmit
+    name: integ-pilot-mc-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -734,7 +734,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-istiodremote-tests_istio_postsubmit
+    name: integ-pilot-remote-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -798,7 +798,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-istiodremote-multicluster-tests_istio_postsubmit
+    name: integ-pilot-remote-mc-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -862,7 +862,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_postsubmit
+    name: integ-pilot-less-mc-tests_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -985,7 +985,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-multicluster-tests_istio_postsubmit
+    name: integ-security-mc-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1044,7 +1044,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-istiodremote-tests_istio_postsubmit
+    name: integ-security-remote-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1108,7 +1108,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_postsubmit
+    name: integ-security-less-mc-tests_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -2182,7 +2182,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-istiodremote-tests_istio
+    name: integ-telemetry-remote-tests_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2242,7 +2242,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio
+    name: integ-telemetry-less-mc-k8s-tests_istio
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2540,7 +2540,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio
+    name: integ-pilot-mc-tests_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2598,7 +2598,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-istiodremote-tests_istio
+    name: integ-pilot-remote-tests_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2661,7 +2661,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-istiodremote-multicluster-tests_istio
+    name: integ-pilot-remote-mc-tests_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2724,7 +2724,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio
+    name: integ-pilot-less-mc-tests_istio
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2846,7 +2846,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-multicluster-tests_istio
+    name: integ-security-mc-tests_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2904,7 +2904,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-istiodremote-tests_istio
+    name: integ-security-remote-tests_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2967,7 +2967,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio
+    name: integ-security-less-mc-tests_istio
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -11,7 +11,7 @@ periodics:
     org: istio
     path_alias: istio.io/istio
     repo: istio
-  name: integ-security-fuzz-k8s-tests_istio_periodic
+  name: integ-security-fuzz_istio_periodic
   spec:
     containers:
     - command:
@@ -196,7 +196,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_postsubmit
+    name: integ-telemetry_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -253,7 +253,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_postsubmit
+    name: integ-telemetry-mc_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -312,7 +312,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-remote-tests_istio_postsubmit
+    name: integ-telemetry-istiodremote_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -373,7 +373,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-less-mc-k8s-tests_istio_postsubmit
+    name: integ-telemetry-istiodless-mc_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -439,7 +439,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_postsubmit
+    name: integ-distroless_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -499,7 +499,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_postsubmit
+    name: integ-ipv6_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -561,7 +561,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-operator-controller-tests_istio_postsubmit
+    name: integ-operator-controller_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -618,7 +618,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_postsubmit
+    name: integ-pilot_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -675,7 +675,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-mc-tests_istio_postsubmit
+    name: integ-pilot-multicluster_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -734,7 +734,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-remote-tests_istio_postsubmit
+    name: integ-pilot-istiodremote_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -798,7 +798,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-remote-mc-tests_istio_postsubmit
+    name: integ-pilot-istiodremote-mc_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -862,7 +862,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-less-mc-tests_istio_postsubmit
+    name: integ-pilot-istiodless-mc_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -928,7 +928,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-k8s-tests_istio_postsubmit
+    name: integ-security_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -985,7 +985,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-mc-tests_istio_postsubmit
+    name: integ-security-multicluster_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1044,7 +1044,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-remote-tests_istio_postsubmit
+    name: integ-security-istiodremote_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1108,7 +1108,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-less-mc-tests_istio_postsubmit
+    name: integ-security-istiodless-mc_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1174,7 +1174,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-helm-tests_istio_postsubmit
+    name: integ-helm_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1761,7 +1761,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-cni-k8s-tests_istio_postsubmit
+    name: integ-cni_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1825,7 +1825,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion-k8s-tests_istio_postsubmit
+    name: integ-assertion_istio_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2009,7 +2009,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-cni-k8s-tests_istio
+    name: integ-cni_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2068,7 +2068,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio
+    name: integ-telemetry_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2124,7 +2124,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio
+    name: integ-telemetry-mc_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2182,7 +2182,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-remote-tests_istio
+    name: integ-telemetry-istiodremote_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2242,7 +2242,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-telemetry-less-mc-k8s-tests_istio
+    name: integ-telemetry-istiodless-mc_istio
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2308,7 +2308,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-distroless-k8s-tests_istio
+    name: integ-distroless_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2367,7 +2367,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio
+    name: integ-ipv6_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2428,7 +2428,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-operator-controller-tests_istio
+    name: integ-operator-controller_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2484,7 +2484,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-k8s-tests_istio
+    name: integ-pilot_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2540,7 +2540,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-mc-tests_istio
+    name: integ-pilot-multicluster_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2598,7 +2598,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-remote-tests_istio
+    name: integ-pilot-istiodremote_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2661,7 +2661,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-remote-mc-tests_istio
+    name: integ-pilot-istiodremote-mc_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2724,7 +2724,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-pilot-less-mc-tests_istio
+    name: integ-pilot-istiodless-mc_istio
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2790,7 +2790,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-k8s-tests_istio
+    name: integ-security_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2846,7 +2846,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-mc-tests_istio
+    name: integ-security-multicluster_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2904,7 +2904,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-remote-tests_istio
+    name: integ-security-istiodremote_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2967,7 +2967,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-security-less-mc-tests_istio
+    name: integ-security-istiodless-mc_istio
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -3033,7 +3033,7 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: integ-helm-tests_istio
+    name: integ-helm_istio
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3091,7 +3091,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion-k8s-tests_istio
+    name: integ-assertion_istio
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -383,7 +383,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.10_postsubmit
+    name: integ-pilot-mc-tests_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -505,7 +505,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.10_postsubmit
+    name: integ-security-mc-tests_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1432,7 +1432,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-multicluster-k8s-tests_istio_release-1.10
+    name: integ-mc-k8s-tests_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1676,7 +1676,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.10
+    name: integ-pilot-mc-tests_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1737,7 +1737,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.10
+    name: integ-security-mc-tests_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -135,7 +135,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.10_postsubmit
+    name: integ-telemetry-mc_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -197,7 +197,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.10_postsubmit
+    name: integ-distroless_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -259,7 +259,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.10_postsubmit
+    name: integ-ipv6_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -323,7 +323,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.10_postsubmit
+    name: integ-pilot_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -383,7 +383,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.10_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -445,7 +445,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.10_postsubmit
+    name: integ-security_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -505,7 +505,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.10_postsubmit
+    name: integ-security-multicluster_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -567,7 +567,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.10_postsubmit
+    name: integ-telemetry_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -627,7 +627,7 @@ postsubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-helm-tests_istio_release-1.10_postsubmit
+    name: integ-helm_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1194,7 +1194,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.10
+    name: integ-pilot_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1253,7 +1253,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.10
+    name: integ-security_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1312,7 +1312,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.10
+    name: integ-telemetry_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1371,7 +1371,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.10
+    name: integ-telemetry-mc_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1432,7 +1432,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-mc-k8s-tests_istio_release-1.10
+    name: integ-multicluster_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1493,7 +1493,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.10
+    name: integ-distroless_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1554,7 +1554,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.10
+    name: integ-ipv6_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1617,7 +1617,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.10
+    name: integ-operator-controller_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1676,7 +1676,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.10
+    name: integ-pilot-multicluster_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1737,7 +1737,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.10
+    name: integ-security-multicluster_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1798,7 +1798,7 @@ presubmits:
     branches:
     - ^release-1.10$
     decorate: true
-    name: integ-helm-tests_istio_release-1.10
+    name: integ-helm_istio_release-1.10
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -11,7 +11,7 @@ periodics:
     org: istio
     path_alias: istio.io/istio
     repo: istio
-  name: integ-security-fuzz-k8s-tests_istio_release-1.11_periodic
+  name: integ-security-fuzz_istio_release-1.11_periodic
   spec:
     containers:
     - command:
@@ -196,7 +196,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-telemetry-multicluster_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -258,7 +258,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-telemetry-istiodless-mc_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -326,7 +326,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-distroless_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -388,7 +388,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-ipv6_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -452,7 +452,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-pilot_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -512,7 +512,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.11_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -574,7 +574,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-less-mc-tests_istio_release-1.11_postsubmit
+    name: integ-pilot-istiodless-mc_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -642,7 +642,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-security_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -702,7 +702,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.11_postsubmit
+    name: integ-security-multicluster_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -764,7 +764,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-less-mc-tests_istio_release-1.11_postsubmit
+    name: integ-security-istiodless-mc_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -832,7 +832,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-telemetry_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -892,7 +892,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-helm-tests_istio_release-1.11_postsubmit
+    name: integ-helm_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1337,7 +1337,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-cni-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-cni_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1521,7 +1521,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.11
+    name: integ-pilot_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1580,7 +1580,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-cni-k8s-tests_istio_release-1.11
+    name: integ-cni_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1641,7 +1641,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.11
+    name: integ-security_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1700,7 +1700,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.11
+    name: integ-telemetry_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1759,7 +1759,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.11
+    name: integ-telemetry-multicluster_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1820,7 +1820,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11
+    name: integ-telemetry-istiodless-mc_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -1888,7 +1888,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-mc-k8s-tests_istio_release-1.11
+    name: integ-multicluster_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1949,7 +1949,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-remote-k8s-tests_istio_release-1.11
+    name: integ-istiodremote_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2012,7 +2012,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.11
+    name: integ-distroless_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2073,7 +2073,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.11
+    name: integ-ipv6_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2136,7 +2136,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.11
+    name: integ-operator-controller_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2195,7 +2195,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.11
+    name: integ-pilot-multicluster_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2256,7 +2256,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-less-mc-tests_istio_release-1.11
+    name: integ-pilot-istiodless-mc_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2324,7 +2324,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.11
+    name: integ-security-multicluster_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2385,7 +2385,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-less-mc-tests_istio_release-1.11
+    name: integ-security-istiodless-mc_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2453,7 +2453,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-helm-tests_istio_release-1.11
+    name: integ-helm_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -258,7 +258,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.11_postsubmit
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -512,7 +512,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.11_postsubmit
+    name: integ-pilot-mc-tests_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -574,7 +574,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.11_postsubmit
+    name: integ-pilot-less-mc-tests_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -702,7 +702,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.11_postsubmit
+    name: integ-security-mc-tests_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -764,7 +764,7 @@ postsubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.11_postsubmit
+    name: integ-security-less-mc-tests_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1820,7 +1820,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.11
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -1888,7 +1888,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-multicluster-k8s-tests_istio_release-1.11
+    name: integ-mc-k8s-tests_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1949,7 +1949,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-istiodremote-k8s-tests_istio_release-1.11
+    name: integ-remote-k8s-tests_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2195,7 +2195,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.11
+    name: integ-pilot-mc-tests_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2256,7 +2256,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.11
+    name: integ-pilot-less-mc-tests_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2324,7 +2324,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.11
+    name: integ-security-mc-tests_istio_release-1.11
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2385,7 +2385,7 @@ presubmits:
     branches:
     - ^release-1.11$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.11
+    name: integ-security-less-mc-tests_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -255,7 +255,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-istiodremote-tests_istio_release-1.12_postsubmit
+    name: integ-telemetry-remote-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -316,7 +316,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -561,7 +561,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-mc-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -620,7 +620,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-istiodremote-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-remote-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -684,7 +684,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-remote-mc-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -748,7 +748,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-less-mc-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -871,7 +871,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.12_postsubmit
+    name: integ-security-mc-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -930,7 +930,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-istiodremote-tests_istio_release-1.12_postsubmit
+    name: integ-security-remote-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -994,7 +994,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.12_postsubmit
+    name: integ-security-less-mc-tests_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -2176,7 +2176,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-istiodremote-tests_istio_release-1.12
+    name: integ-telemetry-remote-tests_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2236,7 +2236,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.12
+    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2481,7 +2481,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.12
+    name: integ-pilot-mc-tests_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2539,7 +2539,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-istiodremote-tests_istio_release-1.12
+    name: integ-pilot-remote-tests_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2602,7 +2602,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.12
+    name: integ-pilot-remote-mc-tests_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2665,7 +2665,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.12
+    name: integ-pilot-less-mc-tests_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2731,7 +2731,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.12
+    name: integ-security-mc-tests_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2789,7 +2789,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-istiodremote-tests_istio_release-1.12
+    name: integ-security-remote-tests_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2852,7 +2852,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.12
+    name: integ-security-less-mc-tests_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -11,7 +11,7 @@ periodics:
     org: istio
     path_alias: istio.io/istio
     repo: istio
-  name: integ-security-fuzz-k8s-tests_istio_release-1.12_periodic
+  name: integ-security-fuzz_istio_release-1.12_periodic
   spec:
     containers:
     - command:
@@ -196,7 +196,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-telemetry-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -255,7 +255,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-remote-tests_istio_release-1.12_postsubmit
+    name: integ-telemetry-istiodremote_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -316,7 +316,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-telemetry-istiodless-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -382,7 +382,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-distroless_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -442,7 +442,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-ipv6_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -504,7 +504,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-pilot_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -561,7 +561,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -620,7 +620,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-remote-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-istiodremote_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -684,7 +684,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-remote-mc-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-istiodremote-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -748,7 +748,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-less-mc-tests_istio_release-1.12_postsubmit
+    name: integ-pilot-istiodless-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -814,7 +814,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-security_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -871,7 +871,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.12_postsubmit
+    name: integ-security-multicluster_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -930,7 +930,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-remote-tests_istio_release-1.12_postsubmit
+    name: integ-security-istiodremote_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -994,7 +994,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-less-mc-tests_istio_release-1.12_postsubmit
+    name: integ-security-istiodless-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1060,7 +1060,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-telemetry_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1117,7 +1117,7 @@ postsubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-helm-tests_istio_release-1.12_postsubmit
+    name: integ-helm_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1632,7 +1632,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-cni-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-cni_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1696,7 +1696,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion-k8s-tests_istio_release-1.12_postsubmit
+    name: integ-assertion_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1880,7 +1880,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.12
+    name: integ-pilot_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1939,7 +1939,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-cni-k8s-tests_istio_release-1.12
+    name: integ-cni_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2000,7 +2000,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.12
+    name: integ-security_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2059,7 +2059,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.12
+    name: integ-telemetry_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2118,7 +2118,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.12
+    name: integ-telemetry-mc_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2176,7 +2176,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-remote-tests_istio_release-1.12
+    name: integ-telemetry-istiodremote_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2236,7 +2236,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-telemetry-less-mc-k8s-tests_istio_release-1.12
+    name: integ-telemetry-istiodless-mc_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2302,7 +2302,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.12
+    name: integ-distroless_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2361,7 +2361,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.12
+    name: integ-ipv6_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2422,7 +2422,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.12
+    name: integ-operator-controller_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2481,7 +2481,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.12
+    name: integ-pilot-multicluster_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2539,7 +2539,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-remote-tests_istio_release-1.12
+    name: integ-pilot-istiodremote_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2602,7 +2602,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-remote-mc-tests_istio_release-1.12
+    name: integ-pilot-istiodremote-mc_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2665,7 +2665,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-pilot-less-mc-tests_istio_release-1.12
+    name: integ-pilot-istiodless-mc_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2731,7 +2731,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.12
+    name: integ-security-multicluster_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2789,7 +2789,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-remote-tests_istio_release-1.12
+    name: integ-security-istiodremote_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2852,7 +2852,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-security-less-mc-tests_istio_release-1.12
+    name: integ-security-istiodless-mc_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2918,7 +2918,7 @@ presubmits:
     branches:
     - ^release-1.12$
     decorate: true
-    name: integ-helm-tests_istio_release-1.12
+    name: integ-helm_istio_release-1.12
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2976,7 +2976,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion-k8s-tests_istio_release-1.12
+    name: integ-assertion_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -11,7 +11,7 @@ periodics:
     org: istio
     path_alias: istio.io/istio
     repo: istio
-  name: integ-security-fuzz-k8s-tests_istio_release-1.13_periodic
+  name: integ-security-fuzz_istio_release-1.13_periodic
   spec:
     containers:
     - command:
@@ -196,7 +196,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-telemetry_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -253,7 +253,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-telemetry-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -312,7 +312,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-istiodremote-tests_istio_release-1.13_postsubmit
+    name: integ-telemetry-istiodremote_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -373,7 +373,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-telemetry-istiodless-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -439,7 +439,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-distroless_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -499,7 +499,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-ipv6_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -561,7 +561,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.13_postsubmit
+    name: integ-operator-controller_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -618,7 +618,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-pilot_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -675,7 +675,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.13_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -734,7 +734,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-istiodremote-tests_istio_release-1.13_postsubmit
+    name: integ-pilot-istiodremote_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -798,7 +798,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.13_postsubmit
+    name: integ-pilot-istiodremote-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -862,7 +862,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.13_postsubmit
+    name: integ-pilot-istiodless-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -928,7 +928,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-security_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -985,7 +985,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.13_postsubmit
+    name: integ-security-multicluster_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1044,7 +1044,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-istiodremote-tests_istio_release-1.13_postsubmit
+    name: integ-security-istiodremote_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1108,7 +1108,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.13_postsubmit
+    name: integ-security-istiodless-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1174,7 +1174,7 @@ postsubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-helm-tests_istio_release-1.13_postsubmit
+    name: integ-helm_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1761,7 +1761,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-cni-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-cni_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1825,7 +1825,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion-k8s-tests_istio_release-1.13_postsubmit
+    name: integ-assertion_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2009,7 +2009,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-cni-k8s-tests_istio_release-1.13
+    name: integ-cni_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2068,7 +2068,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.13
+    name: integ-telemetry_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2124,7 +2124,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.13
+    name: integ-telemetry-mc_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2182,7 +2182,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-istiodremote-tests_istio_release-1.13
+    name: integ-telemetry-istiodremote_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2242,7 +2242,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-telemetry-istiodless-mc-k8s-tests_istio_release-1.13
+    name: integ-telemetry-istiodless-mc_istio_release-1.13
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2308,7 +2308,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.13
+    name: integ-distroless_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2367,7 +2367,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.13
+    name: integ-ipv6_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2428,7 +2428,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.13
+    name: integ-operator-controller_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2484,7 +2484,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.13
+    name: integ-pilot_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2540,7 +2540,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.13
+    name: integ-pilot-multicluster_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2598,7 +2598,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-istiodremote-tests_istio_release-1.13
+    name: integ-pilot-istiodremote_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2661,7 +2661,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-istiodremote-multicluster-tests_istio_release-1.13
+    name: integ-pilot-istiodremote-mc_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2724,7 +2724,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-pilot-istiodless-multicluster-tests_istio_release-1.13
+    name: integ-pilot-istiodless-mc_istio_release-1.13
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -2790,7 +2790,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.13
+    name: integ-security_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2846,7 +2846,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.13
+    name: integ-security-multicluster_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2904,7 +2904,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-istiodremote-tests_istio_release-1.13
+    name: integ-security-istiodremote_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -2967,7 +2967,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-security-istiodless-multicluster-tests_istio_release-1.13
+    name: integ-security-istiodless-mc_istio_release-1.13
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -3033,7 +3033,7 @@ presubmits:
     branches:
     - ^release-1.13$
     decorate: true
-    name: integ-helm-tests_istio_release-1.13
+    name: integ-helm_istio_release-1.13
     path_alias: istio.io/istio
     spec:
       containers:
@@ -3091,7 +3091,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion-k8s-tests_istio_release-1.13
+    name: integ-assertion_istio_release-1.13
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -126,7 +126,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-distroless_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -185,7 +185,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-ipv6_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -246,7 +246,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-galley-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-galley_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -303,7 +303,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-mixer-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-mixer_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -360,7 +360,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-pilot_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -417,7 +417,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.7_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -480,7 +480,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-security_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -537,7 +537,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.7_postsubmit
+    name: integ-telemetry_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -936,7 +936,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-galley-k8s-tests_istio_release-1.7
+    name: integ-galley_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -992,7 +992,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-mixer-k8s-tests_istio_release-1.7
+    name: integ-mixer_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1048,7 +1048,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.7
+    name: integ-pilot_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1104,7 +1104,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.7
+    name: integ-security_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1160,7 +1160,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.7
+    name: integ-telemetry_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1216,7 +1216,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-mc-k8s-tests_istio_release-1.7
+    name: integ-multicluster_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1274,7 +1274,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.7
+    name: integ-distroless_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1332,7 +1332,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.7
+    name: integ-ipv6_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1392,7 +1392,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.7
+    name: integ-operator-controller_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1448,7 +1448,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.7
+    name: integ-pilot-multicluster_istio_release-1.7
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.7.gen.yaml
@@ -417,7 +417,7 @@ postsubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.7_postsubmit
+    name: integ-pilot-mc-tests_istio_release-1.7_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -1216,7 +1216,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-multicluster-k8s-tests_istio_release-1.7
+    name: integ-mc-k8s-tests_istio_release-1.7
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1448,7 +1448,7 @@ presubmits:
     branches:
     - ^release-1.7$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.7
+    name: integ-pilot-mc-tests_istio_release-1.7
     optional: true
     path_alias: istio.io/istio
     reporter_config:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -383,7 +383,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.8_postsubmit
+    name: integ-pilot-mc-tests_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -445,7 +445,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-external-istiod-mc-tests_istio_release-1.8_postsubmit
+    name: integ-external-mc-tests_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -573,7 +573,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.8_postsubmit
+    name: integ-security-mc-tests_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1486,7 +1486,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-multicluster-k8s-tests_istio_release-1.8
+    name: integ-mc-k8s-tests_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1730,7 +1730,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.8
+    name: integ-pilot-mc-tests_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1791,7 +1791,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-external-istiod-mc-tests_istio_release-1.8
+    name: integ-external-mc-tests_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -1859,7 +1859,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.8
+    name: integ-security-mc-tests_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.8.gen.yaml
@@ -135,7 +135,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.8_postsubmit
+    name: integ-telemetry-multicluster_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -197,7 +197,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.8_postsubmit
+    name: integ-distroless_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -259,7 +259,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.8_postsubmit
+    name: integ-ipv6_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -323,7 +323,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.8_postsubmit
+    name: integ-pilot_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -383,7 +383,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.8_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -445,7 +445,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-external-mc-tests_istio_release-1.8_postsubmit
+    name: integ-external-istiod-mc_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     reporter_config:
       slack:
@@ -513,7 +513,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.8_postsubmit
+    name: integ-security_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -573,7 +573,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.8_postsubmit
+    name: integ-security-multicluster_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -635,7 +635,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.8_postsubmit
+    name: integ-telemetry_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -695,7 +695,7 @@ postsubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-helm-tests_istio_release-1.8_postsubmit
+    name: integ-helm_istio_release-1.8_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1247,7 +1247,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.8
+    name: integ-pilot_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1306,7 +1306,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.8
+    name: integ-security_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1365,7 +1365,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.8
+    name: integ-telemetry_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1424,7 +1424,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.8
+    name: integ-telemetry-multicluster_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1486,7 +1486,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-mc-k8s-tests_istio_release-1.8
+    name: integ-multicluster_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1547,7 +1547,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.8
+    name: integ-distroless_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1608,7 +1608,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.8
+    name: integ-ipv6_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1671,7 +1671,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.8
+    name: integ-operator-controller_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1730,7 +1730,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.8
+    name: integ-pilot-multicluster_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1791,7 +1791,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-external-mc-tests_istio_release-1.8
+    name: integ-external-istiod-mc_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -1859,7 +1859,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.8
+    name: integ-security-multicluster_istio_release-1.8
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1921,7 +1921,7 @@ presubmits:
     branches:
     - ^release-1.8$
     decorate: true
-    name: integ-helm-tests_istio_release-1.8
+    name: integ-helm_istio_release-1.8
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -135,7 +135,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.9_postsubmit
+    name: integ-telemetry-mc_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -197,7 +197,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.9_postsubmit
+    name: integ-distroless_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -259,7 +259,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.9_postsubmit
+    name: integ-ipv6_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -323,7 +323,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.9_postsubmit
+    name: integ-pilot_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -383,7 +383,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.9_postsubmit
+    name: integ-pilot-multicluster_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -445,7 +445,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.9_postsubmit
+    name: integ-security_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -505,7 +505,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.9_postsubmit
+    name: integ-security-multicluster_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -567,7 +567,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.9_postsubmit
+    name: integ-telemetry_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -627,7 +627,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-helm-tests_istio_release-1.9_postsubmit
+    name: integ-helm_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1130,7 +1130,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-pilot-k8s-tests_istio_release-1.9
+    name: integ-pilot_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1189,7 +1189,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-security-k8s-tests_istio_release-1.9
+    name: integ-security_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1248,7 +1248,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-telemetry-k8s-tests_istio_release-1.9
+    name: integ-telemetry_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1307,7 +1307,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-telemetry-mc-k8s-tests_istio_release-1.9
+    name: integ-telemetry-mc_istio_release-1.9
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1369,7 +1369,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-mc-k8s-tests_istio_release-1.9
+    name: integ-multicluster_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1430,7 +1430,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-distroless-k8s-tests_istio_release-1.9
+    name: integ-distroless_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1491,7 +1491,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-ipv6-k8s-tests_istio_release-1.9
+    name: integ-ipv6_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1554,7 +1554,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-operator-controller-tests_istio_release-1.9
+    name: integ-operator-controller_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1613,7 +1613,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-pilot-mc-tests_istio_release-1.9
+    name: integ-pilot-multicluster_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1674,7 +1674,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-security-mc-tests_istio_release-1.9
+    name: integ-security-multicluster_istio_release-1.9
     optional: true
     path_alias: istio.io/istio
     spec:
@@ -1736,7 +1736,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-helm-tests_istio_release-1.9
+    name: integ-helm_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -383,7 +383,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.9_postsubmit
+    name: integ-pilot-mc-tests_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -505,7 +505,7 @@ postsubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.9_postsubmit
+    name: integ-security-mc-tests_istio_release-1.9_postsubmit
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1369,7 +1369,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-multicluster-k8s-tests_istio_release-1.9
+    name: integ-mc-k8s-tests_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1613,7 +1613,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-pilot-multicluster-tests_istio_release-1.9
+    name: integ-pilot-mc-tests_istio_release-1.9
     path_alias: istio.io/istio
     spec:
       containers:
@@ -1674,7 +1674,7 @@ presubmits:
     branches:
     - ^release-1.9$
     decorate: true
-    name: integ-security-multicluster-tests_istio_release-1.9
+    name: integ-security-mc-tests_istio_release-1.9
     optional: true
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -80,7 +80,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirements:
@@ -96,7 +96,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirements:
@@ -112,7 +112,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirements:
@@ -130,7 +130,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-telemetry-mc-k8s-tests
+  name: integ-telemetry-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -146,7 +146,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-mc-k8s-tests
+  name: integ-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -164,7 +164,7 @@ jobs:
     value: distroless
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   node_selector:
     testing: test-pool
   requirements:
@@ -185,7 +185,7 @@ jobs:
   node_selector:
     # COS does not currently support IPv6
     testing: ipv6-pool
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   requirements:
   - cache
   - kind
@@ -197,7 +197,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   node_selector:
     testing: test-pool
   requirements:
@@ -213,7 +213,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirements:
@@ -231,7 +231,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-mc-tests
+  name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -245,7 +245,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirements:
@@ -263,7 +263,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-security-mc-tests
+  name: integ-security-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -277,7 +277,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirements:
@@ -290,7 +290,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  name: integ-helm-tests
+  name: integ-helm
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -146,7 +146,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-multicluster-k8s-tests
+  name: integ-mc-k8s-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -231,7 +231,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -263,7 +263,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-security-multicluster-tests
+  name: integ-security-mc-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -86,7 +86,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirements:
@@ -105,7 +105,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-cni-k8s-tests
+  name: integ-cni
   node_selector:
     testing: test-pool
   requirements:
@@ -122,7 +122,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirements:
@@ -139,7 +139,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirements:
@@ -158,7 +158,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-telemetry-mc-k8s-tests
+  name: integ-telemetry-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -182,7 +182,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-telemetry-less-mc-k8s-tests
+  name: integ-telemetry-istiodless-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -200,7 +200,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-mc-k8s-tests
+  name: integ-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -222,7 +222,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-remote-k8s-tests
+  name: integ-istiodremote
   node_selector:
     testing: test-pool
   requirements:
@@ -242,7 +242,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   node_selector:
     testing: test-pool
   requirements:
@@ -261,7 +261,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   node_selector:
     testing: ipv6-pool
   requirements:
@@ -276,7 +276,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   node_selector:
     testing: test-pool
   requirements:
@@ -293,7 +293,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirements:
@@ -312,7 +312,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-pilot-mc-tests
+  name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -336,7 +336,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-less-mc-tests
+  name: integ-pilot-istiodless-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -352,7 +352,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirements:
@@ -367,7 +367,7 @@ jobs:
   - test.integration-fuzz.security.fuzz.kube
   cron: 0 7 * * *
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-security-fuzz-k8s-tests
+  name: integ-security-fuzz
   node_selector:
     testing: test-pool
   requirements:
@@ -386,7 +386,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-security-mc-tests
+  name: integ-security-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -410,7 +410,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-security-less-mc-tests
+  name: integ-security-istiodless-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -426,7 +426,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirements:
@@ -440,7 +440,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-helm-tests
+  name: integ-helm
   node_selector:
     testing: test-pool
   requirements:
@@ -577,7 +577,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-cni-k8s-tests
+  name: integ-cni
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -200,7 +200,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-multicluster-k8s-tests
+  name: integ-mc-k8s-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -182,7 +182,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-telemetry-istiodless-mc-k8s-tests
+  name: integ-telemetry-less-mc-k8s-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -222,7 +222,7 @@ jobs:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-istiodremote-k8s-tests
+  name: integ-remote-k8s-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -312,7 +312,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -336,7 +336,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-istiodless-multicluster-tests
+  name: integ-pilot-less-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -386,7 +386,7 @@ jobs:
   - name: TEST_SELECT
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
-  name: integ-security-multicluster-tests
+  name: integ-security-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -410,7 +410,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-security-istiodless-multicluster-tests
+  name: integ-security-less-mc-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -80,7 +80,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirements:
@@ -98,7 +98,7 @@ jobs:
     value: -postsubmit,-flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  name: integ-cni-k8s-tests
+  name: integ-cni
   node_selector:
     testing: test-pool
   requirements:
@@ -114,7 +114,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirements:
@@ -130,7 +130,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirements:
@@ -145,7 +145,7 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.telemetry.kube
-  name: integ-telemetry-mc-k8s-tests
+  name: integ-telemetry-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -161,7 +161,7 @@ jobs:
   - --topology-config
   - prow/config/topology/external-istiod.json
   - test.integration.telemetry.kube
-  name: integ-telemetry-remote-tests
+  name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
   requirements:
@@ -182,7 +182,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-telemetry-less-mc-k8s-tests
+  name: integ-telemetry-istiodless-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -197,7 +197,7 @@ jobs:
   env:
   - name: VARIANT
     value: distroless
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   node_selector:
     testing: test-pool
   requirements:
@@ -213,7 +213,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   node_selector:
     testing: ipv6-pool
   requirements:
@@ -227,7 +227,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   node_selector:
     testing: test-pool
   requirements:
@@ -240,7 +240,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.pilot.kube
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirements:
@@ -255,7 +255,7 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.pilot.kube
-  name: integ-pilot-mc-tests
+  name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -274,7 +274,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  name: integ-pilot-remote-tests
+  name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
   requirements:
@@ -293,7 +293,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  name: integ-pilot-remote-mc-tests
+  name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -314,7 +314,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-less-mc-tests
+  name: integ-pilot-istiodless-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -326,7 +326,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.security.kube
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirements:
@@ -340,7 +340,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration-fuzz.security.fuzz.kube
   cron: 0 7 * * *
-  name: integ-security-fuzz-k8s-tests
+  name: integ-security-fuzz
   node_selector:
     testing: test-pool
   requirements:
@@ -355,7 +355,7 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.security.kube
-  name: integ-security-mc-tests
+  name: integ-security-multicluster
   node_selector:
     testing: test-pool
   requirements:
@@ -374,7 +374,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  name: integ-security-remote-tests
+  name: integ-security-istiodremote
   node_selector:
     testing: test-pool
   requirements:
@@ -395,7 +395,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-security-less-mc-tests
+  name: integ-security-istiodless-mc
   node_selector:
     testing: test-pool
   requirements:
@@ -407,7 +407,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.telemetry.kube
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirements:
@@ -420,7 +420,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  name: integ-helm-tests
+  name: integ-helm
   node_selector:
     testing: test-pool
   requirements:
@@ -577,7 +577,7 @@ jobs:
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  name: integ-cni-k8s-tests
+  name: integ-cni
   node_selector:
     testing: test-pool
   requirements:
@@ -597,7 +597,7 @@ jobs:
   modifiers:
   - presubmit_optional
   - presubmit_skipped
-  name: integ-assertion-k8s-tests
+  name: integ-assertion
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -255,7 +255,7 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.pilot.kube
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -314,7 +314,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-istiodless-multicluster-tests
+  name: integ-pilot-istiodless-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -355,7 +355,7 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.security.kube
-  name: integ-security-multicluster-tests
+  name: integ-security-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -395,7 +395,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-security-istiodless-multicluster-tests
+  name: integ-security-istiodless-mc-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -182,7 +182,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-telemetry-istiodless-mc-k8s-tests
+  name: integ-telemetry-less-mc-k8s-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -314,7 +314,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-istiodless-mc-tests
+  name: integ-pilot-less-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -395,7 +395,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-security-istiodless-mc-tests
+  name: integ-security-less-mc-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -161,7 +161,7 @@ jobs:
   - --topology-config
   - prow/config/topology/external-istiod.json
   - test.integration.telemetry.kube
-  name: integ-telemetry-istiodremote-tests
+  name: integ-telemetry-remote-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -274,7 +274,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  name: integ-pilot-istiodremote-tests
+  name: integ-pilot-remote-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -293,7 +293,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  name: integ-pilot-istiodremote-multicluster-tests
+  name: integ-pilot-remote-mc-tests
   node_selector:
     testing: test-pool
   requirements:
@@ -374,7 +374,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  name: integ-security-istiodremote-tests
+  name: integ-security-remote-tests
   node_selector:
     testing: test-pool
   requirements:

--- a/prow/config/jobs/istio-1.13.yaml
+++ b/prow/config/jobs/istio-1.13.yaml
@@ -741,7 +741,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-cni-k8s-tests
+  name: integ-cni
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -886,7 +886,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.telemetry.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -1031,7 +1031,7 @@ jobs:
   - MULTICLUSTER
   - test.integration.telemetry.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-telemetry-mc-k8s-tests
+  name: integ-telemetry-mc
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -1179,7 +1179,7 @@ jobs:
   - prow/config/topology/external-istiod.json
   - test.integration.telemetry.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-telemetry-istiodremote-tests
+  name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -1332,7 +1332,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-telemetry-istiodless-mc-k8s-tests
+  name: integ-telemetry-istiodless-mc
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -1479,7 +1479,7 @@ jobs:
   - name: VARIANT
     value: distroless
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -1627,7 +1627,7 @@ jobs:
   - name: IP_FAMILY
     value: ipv6
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   node_selector:
     testing: ipv6-pool
   requirement_presets:
@@ -1770,7 +1770,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.operator.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -1913,7 +1913,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.pilot.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2058,7 +2058,7 @@ jobs:
   - MULTICLUSTER
   - test.integration.pilot.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2209,7 +2209,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-pilot-istiodremote-tests
+  name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2360,7 +2360,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-pilot-istiodremote-multicluster-tests
+  name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2513,7 +2513,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-istiodless-multicluster-tests
+  name: integ-pilot-istiodless-mc
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2657,7 +2657,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.security.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-security-k8s-tests
+  name: integ-security
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2801,7 +2801,7 @@ jobs:
   - test.integration-fuzz.security.fuzz.kube
   cron: 0 7 * * *
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-security-fuzz-k8s-tests
+  name: integ-security-fuzz
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -2948,7 +2948,7 @@ jobs:
   - MULTICLUSTER
   - test.integration.security.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-security-multicluster-tests
+  name: integ-security-multicluster
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -3099,7 +3099,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-security-istiodremote-tests
+  name: integ-security-istiodremote
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -3252,7 +3252,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-security-istiodless-multicluster-tests
+  name: integ-security-istiodless-mc
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -3396,7 +3396,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-helm-tests
+  name: integ-helm
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -4766,7 +4766,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
   image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
-  name: integ-cni-k8s-tests
+  name: integ-cni
   node_selector:
     testing: test-pool
   requirement_presets:
@@ -4918,7 +4918,7 @@ jobs:
   modifiers:
   - presubmit_optional
   - presubmit_skipped
-  name: integ-assertion-k8s-tests
+  name: integ-assertion
   node_selector:
     testing: test-pool
   requirement_presets:

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -53,7 +53,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-galley-k8s-tests
+  name: integ-galley
   requirements:
   - kind
   types: [presubmit]
@@ -64,7 +64,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-mixer-k8s-tests
+  name: integ-mixer
   requirements:
   - kind
   types: [presubmit]
@@ -75,7 +75,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   requirements:
   - kind
   types: [presubmit]
@@ -86,7 +86,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   requirements:
   - kind
   types: [presubmit]
@@ -97,7 +97,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   requirements:
   - kind
   types: [presubmit]
@@ -110,7 +110,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-mc-k8s-tests
+  name: integ-multicluster
   requirements:
   - kind
   types: [presubmit]
@@ -123,7 +123,7 @@ jobs:
     value: distroless
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   requirements:
   - kind
 - command:
@@ -137,7 +137,7 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   requirements:
   - kind
 - command:
@@ -147,7 +147,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   requirements:
   - kind
   types: [presubmit]
@@ -158,7 +158,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-galley-k8s-tests
+  name: integ-galley
   requirements:
   - kind
   types: [postsubmit]
@@ -169,7 +169,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-mixer-k8s-tests
+  name: integ-mixer
   requirements:
   - kind
   types: [postsubmit]
@@ -180,7 +180,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   requirements:
   - kind
   types: [postsubmit]
@@ -197,7 +197,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-mc-tests
+  name: integ-pilot-multicluster
   requirements:
   - kind
 - command:
@@ -207,7 +207,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   requirements:
   - kind
   types: [postsubmit]
@@ -218,7 +218,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   requirements:
   - kind
   types: [postsubmit]

--- a/prow/config/jobs/istio-1.7.yaml
+++ b/prow/config/jobs/istio-1.7.yaml
@@ -110,7 +110,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-multicluster-k8s-tests
+  name: integ-mc-k8s-tests
   requirements:
   - kind
   types: [presubmit]
@@ -197,7 +197,7 @@ jobs:
   - presubmit_optional
   - presubmit_skipped
   - hidden
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-mc-tests
   requirements:
   - kind
 - command:

--- a/prow/config/jobs/istio-1.8.yaml
+++ b/prow/config/jobs/istio-1.8.yaml
@@ -102,7 +102,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-multicluster-k8s-tests
+  name: integ-mc-k8s-tests
   requirements:
   - kind
   types: [presubmit]
@@ -163,7 +163,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-mc-tests
   requirements:
   - kind
 - command:
@@ -180,7 +180,7 @@ jobs:
   modifiers:
   - presubmit_optional
   - hidden
-  name: integ-external-istiod-mc-tests
+  name: integ-external-mc-tests
   requirements:
   - kind
 - command:
@@ -205,7 +205,7 @@ jobs:
     value: -multicluster
   modifiers:
   - presubmit_optional
-  name: integ-security-multicluster-tests
+  name: integ-security-mc-tests
   requirements:
   - kind
 - command:

--- a/prow/config/jobs/istio-1.8.yaml
+++ b/prow/config/jobs/istio-1.8.yaml
@@ -53,7 +53,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   requirements:
   - kind
   types: [presubmit]
@@ -64,7 +64,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   requirements:
   - kind
   types: [presubmit]
@@ -75,7 +75,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   requirements:
   - kind
   types: [presubmit]
@@ -90,7 +90,7 @@ jobs:
     value: -multicluster
   modifiers:
   - presubmit_optional
-  name: integ-telemetry-mc-k8s-tests
+  name: integ-telemetry-multicluster
   requirements:
   - kind
 - command:
@@ -102,7 +102,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-mc-k8s-tests
+  name: integ-multicluster
   requirements:
   - kind
   types: [presubmit]
@@ -115,7 +115,7 @@ jobs:
     value: distroless
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   requirements:
   - kind
 - command:
@@ -129,7 +129,7 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   requirements:
   - kind
 - command:
@@ -139,7 +139,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   requirements:
   - kind
   types: [presubmit]
@@ -150,7 +150,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   requirements:
   - kind
   types: [postsubmit]
@@ -163,7 +163,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-mc-tests
+  name: integ-pilot-multicluster
   requirements:
   - kind
 - command:
@@ -180,7 +180,7 @@ jobs:
   modifiers:
   - presubmit_optional
   - hidden
-  name: integ-external-mc-tests
+  name: integ-external-istiod-mc
   requirements:
   - kind
 - command:
@@ -190,7 +190,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   requirements:
   - kind
   types: [postsubmit]
@@ -205,7 +205,7 @@ jobs:
     value: -multicluster
   modifiers:
   - presubmit_optional
-  name: integ-security-mc-tests
+  name: integ-security-multicluster
   requirements:
   - kind
 - command:
@@ -215,7 +215,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   requirements:
   - kind
   types: [postsubmit]
@@ -223,7 +223,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  name: integ-helm-tests
+  name: integ-helm
   requirements:
   - kind
 - command:

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -109,7 +109,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-multicluster-k8s-tests
+  name: integ-mc-k8s-tests
   requirements:
   - kind
   types:
@@ -176,7 +176,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-multicluster-tests
+  name: integ-pilot-mc-tests
   requirements:
   - kind
 - command:
@@ -202,7 +202,7 @@ jobs:
     value: -multicluster
   modifiers:
   - presubmit_optional
-  name: integ-security-multicluster-tests
+  name: integ-security-mc-tests
   requirements:
   - kind
 - command:

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -57,7 +57,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   requirements:
   - kind
   types:
@@ -69,7 +69,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   requirements:
   - kind
   types:
@@ -81,7 +81,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   requirements:
   - kind
   types:
@@ -97,7 +97,7 @@ jobs:
     value: -multicluster
   modifiers:
   - presubmit_optional
-  name: integ-telemetry-mc-k8s-tests
+  name: integ-telemetry-mc
   requirements:
   - kind
 - command:
@@ -109,7 +109,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  name: integ-mc-k8s-tests
+  name: integ-multicluster
   requirements:
   - kind
   types:
@@ -123,7 +123,7 @@ jobs:
     value: distroless
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-distroless-k8s-tests
+  name: integ-distroless
   requirements:
   - kind
 - command:
@@ -140,7 +140,7 @@ jobs:
   node_selector:
     # COS does not currently support IPv6
     testing: ipv6-pool
-  name: integ-ipv6-k8s-tests
+  name: integ-ipv6
   requirements:
   - kind
 - command:
@@ -150,7 +150,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  name: integ-operator-controller-tests
+  name: integ-operator-controller
   requirements:
   - kind
   types:
@@ -162,7 +162,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-k8s-tests
+  name: integ-pilot
   requirements:
   - kind
   types:
@@ -176,7 +176,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-pilot-mc-tests
+  name: integ-pilot-multicluster
   requirements:
   - kind
 - command:
@@ -186,7 +186,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-security-k8s-tests
+  name: integ-security
   requirements:
   - kind
   types:
@@ -202,7 +202,7 @@ jobs:
     value: -multicluster
   modifiers:
   - presubmit_optional
-  name: integ-security-mc-tests
+  name: integ-security-multicluster
   requirements:
   - kind
 - command:
@@ -212,7 +212,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  name: integ-telemetry-k8s-tests
+  name: integ-telemetry
   requirements:
   - kind
   types:
@@ -221,7 +221,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  name: integ-helm-tests
+  name: integ-helm
   requirements:
   - kind
 - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -109,7 +109,7 @@ jobs:
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
 
-  - name: integ-pilot-multicluster-tests
+  - name: integ-pilot-mc-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -134,7 +134,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-pilot-remote-multicluster-tests
+  - name: integ-pilot-remote-mc-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -149,7 +149,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-pilot-istiodless-multicluster-tests
+  - name: integ-pilot-istiodless-mc-tests
     modifiers:
       - presubmit_optional
       - presubmit_skipped
@@ -176,7 +176,7 @@ jobs:
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration-fuzz.security.fuzz.kube]
     requirements: [kind]
 
-  - name: integ-security-multicluster-tests
+  - name: integ-security-mc-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -30,7 +30,7 @@ jobs:
     command: [entrypoint, make, benchtest, report-benchtest]
     resources: benchmark
 
-  - name: integ-cni-k8s-tests
+  - name: integ-cni
     types: [presubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube.presubmit]
     requirements: [kind]
@@ -38,11 +38,11 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.istio.enableCNI=true "
 
-  - name: integ-telemetry-k8s-tests
+  - name: integ-telemetry
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.telemetry.kube]
     requirements: [kind]
 
-  - name: integ-telemetry-mc-k8s-tests
+  - name: integ-telemetry-mc
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -52,7 +52,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-telemetry-remote-tests
+  - name: integ-telemetry-istiodremote
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -64,7 +64,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-telemetry-less-mc-k8s-tests
+  - name: integ-telemetry-istiodless-mc
     modifiers:
       - presubmit_optional
       - presubmit_skipped
@@ -81,14 +81,14 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.istio.istiodlessRemotes
 
-  - name: integ-distroless-k8s-tests
+  - name: integ-distroless
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]
     requirements: [kind]
     env:
       - name: VARIANT
         value: "distroless"
 
-  - name: integ-ipv6-k8s-tests
+  - name: integ-ipv6
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]
     requirements: [kind]
     node_selector:
@@ -100,16 +100,16 @@ jobs:
       - name: IP_FAMILY
         value: "ipv6"
 
-  - name: integ-operator-controller-tests
+  - name: integ-operator-controller
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.operator.kube]
     requirements: [kind]
 
 
-  - name: integ-pilot-k8s-tests
+  - name: integ-pilot
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
 
-  - name: integ-pilot-mc-tests
+  - name: integ-pilot-multicluster
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -119,7 +119,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-pilot-remote-tests
+  - name: integ-pilot-istiodremote
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -134,7 +134,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-pilot-remote-mc-tests
+  - name: integ-pilot-istiodremote-mc
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -149,7 +149,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-pilot-less-mc-tests
+  - name: integ-pilot-istiodless-mc
     modifiers:
       - presubmit_optional
       - presubmit_skipped
@@ -166,17 +166,17 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.istio.istiodlessRemotes
 
-  - name: integ-security-k8s-tests
+  - name: integ-security
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.security.kube]
     requirements: [kind]
 
-  - name: integ-security-fuzz-k8s-tests
+  - name: integ-security-fuzz
     types: [periodic]
     cron: "0 7 * * *" # starts every day at 07:00AM UTC
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration-fuzz.security.fuzz.kube]
     requirements: [kind]
 
-  - name: integ-security-mc-tests
+  - name: integ-security-multicluster
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -186,7 +186,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-security-remote-tests
+  - name: integ-security-istiodremote
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -201,7 +201,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-security-less-mc-tests
+  - name: integ-security-istiodless-mc
     modifiers:
       - presubmit_optional
       - presubmit_skipped
@@ -218,7 +218,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.istio.istiodlessRemotes
 
-  - name: integ-helm-tests
+  - name: integ-helm
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.helm.kube]
     requirements: [kind]
 
@@ -350,7 +350,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
-  - name: integ-cni-k8s-tests
+  - name: integ-cni
     types: [postsubmit]
     command:
       - entrypoint
@@ -365,7 +365,7 @@ jobs:
         value: " --istio.test.retries=1 --istio.test.istio.enableCNI=true "
 
   # Test with assertions enabled.
-  - name: integ-assertion-k8s-tests
+  - name: integ-assertion
     modifiers: [presubmit_optional, presubmit_skipped] #  We run this in postsubmit always, but let developers explicitly run in presubmit
     command:
       - entrypoint

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -52,7 +52,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-telemetry-istiodremote-tests
+  - name: integ-telemetry-remote-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -119,7 +119,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-pilot-istiodremote-tests
+  - name: integ-pilot-remote-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -134,7 +134,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-pilot-istiodremote-multicluster-tests
+  - name: integ-pilot-remote-multicluster-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -186,7 +186,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-security-istiodremote-tests
+  - name: integ-security-remote-tests
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
@@ -201,7 +201,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-security-istiodless-multicluster-tests
+  - name: integ-security-istiodless-mc-tests
     modifiers:
       - presubmit_optional
       - presubmit_skipped

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -64,7 +64,7 @@ jobs:
     requirements: [kind]
     resources: multicluster
 
-  - name: integ-telemetry-istiodless-mc-k8s-tests
+  - name: integ-telemetry-less-mc-k8s-tests
     modifiers:
       - presubmit_optional
       - presubmit_skipped
@@ -149,7 +149,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-pilot-istiodless-mc-tests
+  - name: integ-pilot-less-mc-tests
     modifiers:
       - presubmit_optional
       - presubmit_skipped
@@ -201,7 +201,7 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: --istio.test.skipVM
 
-  - name: integ-security-istiodless-mc-tests
+  - name: integ-security-less-mc-tests
     modifiers:
       - presubmit_optional
       - presubmit_skipped

--- a/tools/prowgen/cmd/prowgen/main.go
+++ b/tools/prowgen/cmd/prowgen/main.go
@@ -182,7 +182,10 @@ func main() {
 				jobs := cli.ReadJobsConfig(src)
 				for _, branch := range jobs.Branches {
 					cli.ValidateJobConfig(file.Name(), &jobs)
-					output := cli.ConvertJobConfig(&jobs, branch)
+					output, err := cli.ConvertJobConfig(&jobs, branch)
+					if err != nil {
+						exit(err, "job name is too long")
+					}
 					rf := ref{jobs.Org, jobs.Repo, branch}
 					if _, ok := cachedOutput[rf]; !ok {
 						cachedOutput[rf] = output

--- a/tools/prowgen/pkg/generate.go
+++ b/tools/prowgen/pkg/generate.go
@@ -65,9 +65,8 @@ const (
 
 	variableSubstitutionFormat = `\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*\)`
 
-	// prow currently has a limit for jobs being 63 characters due to
-	// kubernetes label length restriction
-	jobCharLimit = 63
+	// Kubernetes has a label limit of 63 characters
+	maxJobNameLength = 63
 )
 
 var variableSubstitutionRegex = regexp.MustCompile(variableSubstitutionFormat)
@@ -274,9 +273,6 @@ func (cli *Client) ValidateJobConfig(fileName string, jobsConfig *JobsConfig) {
 	}
 
 	for _, job := range jobsConfig.Jobs {
-		if len(job.Name) > jobCharLimit {
-			err = multierror.Append(err, fmt.Errorf("%s: name for job exceeds %v character limit '%v'", fileName, jobCharLimit, job.Name))
-		}
 		if job.Image == "" {
 			err = multierror.Append(err, fmt.Errorf("%s: image must be set for job %v", fileName, job.Name))
 		}
@@ -321,7 +317,7 @@ func (cli *Client) ValidateJobConfig(fileName string, jobsConfig *JobsConfig) {
 	}
 }
 
-func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) config.JobConfig {
+func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) (config.JobConfig, error) {
 	baseConfig := cli.BaseConfig
 	testgridConfig := baseConfig.TestgridConfig
 
@@ -353,8 +349,13 @@ func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) confi
 					name += "_" + branch
 				}
 
+				base, err := createJobBase(baseConfig, jobsConfig, job, name, branch, jobsConfig.ResourcePresets)
+				if err != nil {
+					return config.JobConfig{}, err
+				}
+
 				presubmit := config.Presubmit{
-					JobBase:   createJobBase(baseConfig, jobsConfig, job, name, branch, jobsConfig.ResourcePresets),
+					JobBase:   base,
 					AlwaysRun: true,
 					Brancher:  brancher,
 				}
@@ -392,8 +393,13 @@ func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) confi
 				}
 				name += "_postsubmit"
 
+				base, err := createJobBase(baseConfig, jobsConfig, job, name, branch, jobsConfig.ResourcePresets)
+				if err != nil {
+					return config.JobConfig{}, err
+				}
+
 				postsubmit := config.Postsubmit{
-					JobBase:  createJobBase(baseConfig, jobsConfig, job, name, branch, jobsConfig.ResourcePresets),
+					JobBase:  base,
 					Brancher: brancher,
 				}
 				if job.GerritPostsubmitLabel != "" {
@@ -429,8 +435,13 @@ func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) confi
 				// For periodic jobs, the repo needs to be added to the clonerefs and its root directory
 				// should be set as the working directory, so add itself to the repo list here.
 				job.Repos = append([]string{jobsConfig.Org + "/" + jobsConfig.Repo}, job.Repos...)
+
+				base, err := createJobBase(baseConfig, jobsConfig, job, name, branch, jobsConfig.ResourcePresets)
+				if err != nil {
+					return config.JobConfig{}, err
+				}
 				periodic := config.Periodic{
-					JobBase:  createJobBase(baseConfig, jobsConfig, job, name, branch, jobsConfig.ResourcePresets),
+					JobBase:  base,
 					Interval: job.Interval,
 					Cron:     job.Cron,
 					Tags:     job.Tags,
@@ -457,7 +468,7 @@ func (cli *Client) ConvertJobConfig(jobsConfig *JobsConfig, branch string) confi
 			output.Periodics = periodics
 		}
 	}
-	return output
+	return output, nil
 }
 
 func (cli *Client) CheckConfig(jobs config.JobConfig, currentConfigFile string, header string) error {
@@ -652,8 +663,12 @@ func createContainer(jobConfig *JobsConfig, job *Job, resources map[string]v1.Re
 }
 
 func createJobBase(baseConfig BaseConfig, jobConfig *JobsConfig, job *Job,
-	name string, branch string, resources map[string]v1.ResourceRequirements) config.JobBase {
+	name string, branch string, resources map[string]v1.ResourceRequirements) (config.JobBase, error) {
 	yes := true
+
+	if len(name) > maxJobNameLength {
+		return config.JobBase{}, fmt.Errorf("job name exceeds %v character limit '%v'", maxJobNameLength, name)
+	}
 	jb := config.JobBase{
 		Name:           name,
 		MaxConcurrency: job.MaxConcurrency,
@@ -708,7 +723,7 @@ func createJobBase(baseConfig BaseConfig, jobConfig *JobsConfig, job *Job,
 		}
 	}
 
-	return jb
+	return jb, nil
 }
 
 func createExtraRefs(extraRepos []string, defaultBranch string, pathAliases map[string]string) []prowjob.Refs {

--- a/tools/prowgen/pkg/generate.go
+++ b/tools/prowgen/pkg/generate.go
@@ -64,6 +64,10 @@ const (
 	TypePeriodic   = "periodic"
 
 	variableSubstitutionFormat = `\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*\)`
+
+	// prow currently has a limit for jobs being 63 characters due to
+	// kubernetes label length restriction
+	jobCharLimit = 63
 )
 
 var variableSubstitutionRegex = regexp.MustCompile(variableSubstitutionFormat)
@@ -270,6 +274,9 @@ func (cli *Client) ValidateJobConfig(fileName string, jobsConfig *JobsConfig) {
 	}
 
 	for _, job := range jobsConfig.Jobs {
+		if len(job.Name) > jobCharLimit {
+			err = multierror.Append(err, fmt.Errorf("%s: name for job exceeds %v character limit '%v'", fileName, jobCharLimit, job.Name))
+		}
 		if job.Image == "" {
 			err = multierror.Append(err, fmt.Errorf("%s: image must be set for job %v", fileName, job.Name))
 		}

--- a/tools/prowgen/pkg/testdata/long-job-name.yaml
+++ b/tools/prowgen/pkg/testdata/long-job-name.yaml
@@ -1,0 +1,63 @@
+org: gerrit.istio
+repo: istio
+image: fooimage
+branches:
+  - release-1.12
+cron: 0 2 * * *
+
+jobs:
+  - name: test-this-is-a-very-long-name-that-is-expected-to-fail
+    types: [presubmit, postsubmit]
+    command: [prow/command.sh]
+    image: barimage
+    regex: "foo.*"
+    trigger: "/test basic"
+
+  - name: presubmit-kind
+    types: [presubmit]
+    resources: custom
+    requirements: [kind]
+    excluded_requirements: [cache]
+    command: [prow/istio-lint.sh]
+    env:
+    - name: var
+      value: val
+    repos: [istio/istio]
+
+  - name: custom-node-selector
+    types: [presubmit]
+    command: [prow/command.sh]
+    requirements: [gcp, commonargs]
+    node_selector:
+      foo: baz
+
+  - name: periodic-job
+    types: [periodic]
+    command: [run/nightly.sh]
+    annotations:
+      whatever-annotation-name: whatever-annotation-value
+    requirements: [desc, commonargs]
+    tags: [ "prowDashPrefix: periodic-job" ]
+
+  - name: presubmit-skipped
+    types: [presubmit, periodic]
+    resources: custom
+    command: [prow/command.sh]
+    repos: [istio/istio]
+    modifier: [presubmit_skipped]
+    trigger: "/test basic"
+
+requirements: [gocache]
+
+resources_presets:
+  default:
+    requests:
+      memory: "1Gi"
+      cpu: "1000m"
+  custom:
+    requests:
+      memory: "3Gi"
+      cpu: "3000m"
+    limits:
+      memory: "5Gi"
+      cpu: "5000m"


### PR DESCRIPTION
There is a limit to job names (being 63 characters). This is preventing us from getting CI/CD done for the istio-private organization.

See https://github.com/istio/test-infra/pull/3739/ for the PR that is failing and the test grid job is here https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_test-infra/3739/pull-test-infra-check-testgrid-config/1483874476742414336/build-log.txt


Changes
* remove k8s-tests suffix from integration test names
* remove tests suffix from integration test names
* for long names that include "multicluster" change them to mc (e.g. integ-pilot-istiodremote-multicluster to integ-pilot-istiodremote-mc)