### PR TITLE
Remove the master build image specified on each 1.13 job

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -57,7 +57,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -109,7 +109,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -168,7 +168,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -312,7 +312,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -387,7 +387,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -499,7 +499,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -557,7 +557,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -24,7 +24,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -77,7 +77,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -121,7 +121,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -185,7 +185,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -251,7 +251,7 @@ postsubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -322,7 +322,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -387,7 +387,7 @@ postsubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -516,7 +516,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -578,7 +578,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -642,7 +642,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -711,7 +711,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -780,7 +780,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -851,7 +851,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -913,7 +913,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -977,7 +977,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1046,7 +1046,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1117,7 +1117,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1179,7 +1179,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1250,7 +1250,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1321,7 +1321,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1392,7 +1392,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1463,7 +1463,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1534,7 +1534,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1605,7 +1605,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1674,7 +1674,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1747,7 +1747,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1816,7 +1816,7 @@ postsubmits:
           value: -flaky
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1883,7 +1883,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1952,7 +1952,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1996,7 +1996,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2047,7 +2047,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2095,7 +2095,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2158,7 +2158,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2223,7 +2223,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2290,7 +2290,7 @@ presubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2363,7 +2363,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2429,7 +2429,7 @@ presubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2497,7 +2497,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2560,7 +2560,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2623,7 +2623,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2688,7 +2688,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2758,7 +2758,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2828,7 +2828,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2901,7 +2901,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2964,7 +2964,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3029,7 +3029,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3099,7 +3099,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3172,7 +3172,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3235,7 +3235,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3304,7 +3304,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3366,7 +3366,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3410,7 +3410,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3454,7 +3454,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -153,7 +153,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.13.gen.yaml
@@ -17,7 +17,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -55,7 +55,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -93,7 +93,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -276,7 +276,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -319,7 +319,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -154,7 +154,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -197,7 +197,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -232,7 +232,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean
           gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -175,7 +175,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.13.gen.yaml
@@ -25,7 +25,7 @@ presubmits:
         - ../test-infra/scripts/validate_schema.sh
         - --document-path=./features.yaml
         - --schema-path=./features_schema.json
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         - --git-exclude=^common/
         - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make
           clean gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -381,7 +381,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -435,7 +435,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -545,7 +545,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -608,7 +608,7 @@ presubmits:
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ periodics:
       - entrypoint
       - prow/integ-suite-kind.sh
       - test.integration-fuzz.security.fuzz.kube
-      image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+      image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
       name: ""
       resources:
         limits:
@@ -81,7 +81,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -119,7 +119,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         - make
         - benchtest
         - report-benchtest
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -263,7 +263,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -324,7 +324,7 @@ postsubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -390,7 +390,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -450,7 +450,7 @@ postsubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -512,7 +512,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -569,7 +569,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -626,7 +626,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -685,7 +685,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -749,7 +749,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -813,7 +813,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -879,7 +879,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -936,7 +936,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -995,7 +995,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1059,7 +1059,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1125,7 +1125,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1182,7 +1182,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1248,7 +1248,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1314,7 +1314,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1380,7 +1380,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1446,7 +1446,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1512,7 +1512,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1578,7 +1578,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1642,7 +1642,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1710,7 +1710,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1774,7 +1774,7 @@ postsubmits:
           value: -flaky
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1836,7 +1836,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1898,7 +1898,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1935,7 +1935,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -1979,7 +1979,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2020,7 +2020,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2076,7 +2076,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2134,7 +2134,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2194,7 +2194,7 @@ presubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2260,7 +2260,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2319,7 +2319,7 @@ presubmits:
         env:
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2380,7 +2380,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2436,7 +2436,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2492,7 +2492,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2550,7 +2550,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.pilot.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2613,7 +2613,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2676,7 +2676,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2742,7 +2742,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2798,7 +2798,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2856,7 +2856,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - test.integration.security.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2919,7 +2919,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -2985,7 +2985,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3041,7 +3041,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3103,7 +3103,7 @@ presubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3158,7 +3158,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3195,7 +3195,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3232,7 +3232,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -3278,7 +3278,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -320,7 +320,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=update_envoy_dep
       - --token-path=/etc/github-token/oauth
       - --cmd=UPDATE_BRANCH=release/v1.21 scripts/update_envoy.sh
-      image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+      image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
       name: ""
       resources:
         limits:
@@ -168,7 +168,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.13.gen.yaml
@@ -29,7 +29,7 @@ periodics:
           secretKeyRef:
             key: key
             name: cosign-key
-      image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+      image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
       name: ""
       resources:
         limits:
@@ -78,7 +78,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -114,7 +114,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -150,7 +150,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -187,7 +187,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -293,7 +293,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -334,7 +334,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -369,7 +369,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -404,7 +404,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -440,7 +440,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -481,7 +481,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -517,7 +517,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.13.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ postsubmits:
         - --modifier=update_image_version
         - --token-path=/etc/github-token/oauth
         - --script-path=../common-files/bin/create-buildtools-and-update.sh
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -227,7 +227,7 @@ postsubmits:
         - -C
         - perf_dashboard
         - deploy
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -269,7 +269,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -339,7 +339,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -374,7 +374,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -411,7 +411,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.13.yaml
+++ b/prow/config/jobs/api-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - presubmit
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build
   node_selector:
     testing: test-pool
@@ -128,7 +127,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -257,7 +255,6 @@ jobs:
   - --modifier=update_api_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update_api_dep_client_go
   node_selector:
     testing: test-pool
@@ -392,7 +389,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update_api_dep_istio
   node_selector:
     testing: test-pool
@@ -520,7 +516,6 @@ jobs:
 - command:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/config/jobs/client-go-1.13.yaml
+++ b/prow/config/jobs/client-go-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build
   node_selector:
     testing: test-pool
@@ -128,7 +127,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -251,7 +249,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -382,7 +379,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update_client-go_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/common-files-1.13.yaml
+++ b/prow/config/jobs/common-files-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -135,7 +134,6 @@ jobs:
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common && make gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update-common
   node_selector:
     testing: test-pool
@@ -270,7 +268,6 @@ jobs:
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common && make gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -409,7 +406,6 @@ jobs:
   - --
   - --post=make gen
   - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements-1.13.yaml
+++ b/prow/config/jobs/enhancements-1.13.yaml
@@ -6,7 +6,6 @@ jobs:
   - ../test-infra/scripts/validate_schema.sh
   - --document-path=./features.yaml
   - --schema-path=./features_schema.json
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/config/jobs/gogo-genproto-1.13.yaml
+++ b/prow/config/jobs/gogo-genproto-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build
   node_selector:
     testing: test-pool
@@ -128,7 +127,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -251,7 +249,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -383,7 +380,6 @@ jobs:
   - --git-exclude=^common/
   - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make clean
     gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update_gogo-genproto_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.13.yaml
+++ b/prow/config/jobs/istio-1.13.yaml
@@ -10,7 +10,6 @@ jobs:
   - build
   - racetest
   - binaries-test
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -151,7 +150,6 @@ jobs:
 - command:
   - entrypoint
   - prow/release-test.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: release-test
   node_selector:
     testing: test-pool
@@ -296,7 +294,6 @@ jobs:
 - command:
   - entrypoint
   - prow/release-commit.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: release
   node_selector:
     testing: test-pool
@@ -442,7 +439,6 @@ jobs:
   - entrypoint
   - make
   - benchtest
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -591,7 +587,6 @@ jobs:
   - make
   - benchtest
   - report-benchtest
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: benchmark-report
   node_selector:
     testing: test-pool
@@ -740,7 +735,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -885,7 +879,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.telemetry.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -1030,7 +1023,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.telemetry.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-telemetry-mc
   node_selector:
     testing: test-pool
@@ -1178,7 +1170,6 @@ jobs:
   - --topology-config
   - prow/config/topology/external-istiod.json
   - test.integration.telemetry.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
@@ -1327,7 +1318,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.istio.istiodlessRemotes
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -1478,7 +1468,6 @@ jobs:
   env:
   - name: VARIANT
     value: distroless
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -1626,7 +1615,6 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-ipv6
   node_selector:
     testing: ipv6-pool
@@ -1769,7 +1757,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.operator.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-operator-controller
   node_selector:
     testing: test-pool
@@ -1912,7 +1899,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.pilot.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -2057,7 +2043,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.pilot.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -2208,7 +2193,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
@@ -2359,7 +2343,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
@@ -2508,7 +2491,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.istio.istiodlessRemotes
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -2656,7 +2638,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.security.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-security
   node_selector:
     testing: test-pool
@@ -2800,7 +2781,6 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration-fuzz.security.fuzz.kube
   cron: 0 7 * * *
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -2947,7 +2927,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.security.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -3098,7 +3077,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-security-istiodremote
   node_selector:
     testing: test-pool
@@ -3247,7 +3225,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.istio.istiodlessRemotes
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -3395,7 +3372,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -3545,7 +3521,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-116
   node_selector:
     testing: test-pool
@@ -3698,7 +3673,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-117
   node_selector:
     testing: test-pool
@@ -3851,7 +3825,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-118
   node_selector:
     testing: test-pool
@@ -4004,7 +3977,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-119
   node_selector:
     testing: test-pool
@@ -4157,7 +4129,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-120
   node_selector:
     testing: test-pool
@@ -4310,7 +4281,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-122
   node_selector:
     testing: test-pool
@@ -4461,7 +4431,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-k8s-123
   node_selector:
     testing: test-pool
@@ -4612,7 +4581,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - hidden
   name: integ-k8s-124
@@ -4765,7 +4733,6 @@ jobs:
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -4914,7 +4881,6 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -5060,7 +5026,6 @@ jobs:
 - command:
   - make
   - test.integration.analyze
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: analyze-tests
   node_selector:
     testing: test-pool
@@ -5203,7 +5168,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -5347,7 +5311,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -5490,7 +5453,6 @@ jobs:
 - command:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: release-notes
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.io-1.13.yaml
+++ b/prow/config/jobs/istio.io-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -135,7 +134,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -266,7 +264,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_default
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: doc.test.profile_default
   node_selector:
     testing: test-pool
@@ -398,7 +395,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_demo
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: doc.test.profile_demo
   node_selector:
     testing: test-pool
@@ -530,7 +526,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_none
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: doc.test.profile_none
   node_selector:
     testing: test-pool
@@ -664,7 +659,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - doc.test.multicluster
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -799,7 +793,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=make update_ref_docs
   - --dry-run
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/config/jobs/pkg-1.13.yaml
+++ b/prow/config/jobs/pkg-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build
   node_selector:
     testing: test-pool
@@ -128,7 +127,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -251,7 +249,6 @@ jobs:
 - command:
   - make
   - test
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: test
   node_selector:
     testing: test-pool
@@ -374,7 +371,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -504,7 +500,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update_pkg_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/proxy-1.13.yaml
+++ b/prow/config/jobs/proxy-1.13.yaml
@@ -1024,7 +1024,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1159,7 +1158,6 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.21 scripts/update_envoy.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.13.yaml
+++ b/prow/config/jobs/release-builder-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -135,7 +134,6 @@ jobs:
 - command:
   - make
   - test
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: test
   node_selector:
     testing: test-pool
@@ -265,7 +263,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -395,7 +392,6 @@ jobs:
 - command:
   - entrypoint
   - test/publish.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: dry-run
   node_selector:
     testing: test-pool
@@ -528,7 +524,6 @@ jobs:
   service_account_name: prowjob-advanced-sa
 - command:
   - release/build-warning.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -662,7 +657,6 @@ jobs:
   - presubmit
 - command:
   - release/publish-warning.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -797,7 +791,6 @@ jobs:
 - command:
   - entrypoint
   - release/build.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build-release
   node_selector:
     testing: test-pool
@@ -934,7 +927,6 @@ jobs:
 - command:
   - entrypoint
   - release/publish.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: publish-release
   node_selector:
     testing: test-pool
@@ -1076,7 +1068,6 @@ jobs:
     value: "true"
   - name: VERSION
     value: master
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/tools-1.13.yaml
+++ b/prow/config/jobs/tools-1.13.yaml
@@ -5,7 +5,6 @@ jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: build
   node_selector:
     testing: test-pool
@@ -135,7 +134,6 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: lint
   node_selector:
     testing: test-pool
@@ -265,7 +263,6 @@ jobs:
 - command:
   - make
   - test
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: test
   node_selector:
     testing: test-pool
@@ -395,7 +392,6 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: gencheck
   node_selector:
     testing: test-pool
@@ -532,7 +528,6 @@ jobs:
   - --modifier=update_image_version
   - --token-path=/etc/github-token/oauth
   - --script-path=../common-files/bin/create-buildtools-and-update.sh
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: containers
   node_selector:
     testing: test-pool
@@ -673,7 +668,6 @@ jobs:
   - entrypoint
   - make
   - containers-test
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: containers-test
   node_selector:
     testing: test-pool
@@ -812,7 +806,6 @@ jobs:
   - -C
   - perf_dashboard
   - deploy
-  image: gcr.io/istio-testing/build-tools:master-2022-01-19T18-35-09
   name: deploy-perf-dashboard
   node_selector:
     testing: test-pool


### PR DESCRIPTION
It looks like the generate added a image onto each job pointing to the master image which overrides the 1.13 image at the top of the yaml. This removes the image specified on the jobs (matches how they look for 1.12 yamls).