### PR TITLE
Fix more master image references in 1.13 files

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -153,7 +153,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -87,7 +87,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -87,7 +87,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -117,7 +117,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -360,7 +360,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -117,7 +117,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:
@@ -360,7 +360,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:master-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=update_envoy_dep
       - --token-path=/etc/github-token/oauth
       - --cmd=UPDATE_BRANCH=release/v1.21 scripts/update_envoy.sh
-      image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+      image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
       name: ""
       resources:
         limits:
@@ -168,7 +168,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/proxy-1.13.yaml
+++ b/prow/config/jobs/proxy-1.13.yaml
@@ -1018,6 +1018,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
+  image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1152,6 +1153,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.21 scripts/update_envoy.sh
+  image: gcr.io/istio-testing/build-tools:release-1.13-2022-01-19T18-35-09
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/proxy-1.13.yaml
+++ b/prow/config/jobs/proxy-1.13.yaml
@@ -504,6 +504,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
+  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -883,6 +884,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
+  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
   name: release-centos
   node_selector:
     testing: build-pool

--- a/prow/config/jobs/proxy-1.13.yaml
+++ b/prow/config/jobs/proxy-1.13.yaml
@@ -504,7 +504,6 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:master-2022-01-19T18-35-09
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -884,7 +883,6 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:master-2022-01-19T18-35-09
   name: release-centos
   node_selector:
     testing: build-pool


### PR DESCRIPTION
Update `build-tools-centos` from master to release-1.13.