### PR TITLE
fix centos image

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-20T23-08-19
         name: ""
         resources:
           limits:
@@ -419,7 +419,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-20T23-08-19
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -117,7 +117,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-20T23-08-19
         name: ""
         resources:
           limits:
@@ -360,7 +360,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-20T23-08-19
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/proxy-1.13.yaml
+++ b/prow/config/jobs/proxy-1.13.yaml
@@ -504,7 +504,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
+  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-20T23-08-19
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -884,7 +884,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-19T18-35-09
+  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-01-20T23-08-19
   name: release-centos
   node_selector:
     testing: build-pool


### PR DESCRIPTION
Not sure how this ended up with the invalid tag, but it's breaking istio/proxy: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_proxy/3670/release-centos-test_proxy_release-1.13/1485692994966261760