### PR TITLE
Fix the service account resource for the prow private build cluster

### DIFF
--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -15,18 +15,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: istio-prow-test-job-private@istio-testing.iam.gserviceaccount.com
-  labels:
-    app.kubernetes.io/part-of: prow-build
-  namespace: test-pods
-  # Default service account that only has permissions to access the GCS buckets
-  # for private build.
-  name: prowjob-private-sa
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
   labels:
     app.kubernetes.io/part-of: prow-build

--- a/prow/cluster/private/prowjob_service_accounts.yaml
+++ b/prow/cluster/private/prowjob_service_accounts.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: istio-prow-test-job-private@istio-testing.iam.gserviceaccount.com
+  labels:
+    app.kubernetes.io/part-of: prow-private
+  namespace: test-pods
+  # Default service account that only has permissions to access the GCS buckets
+  # for private build.
+  name: prowjob-private-sa


### PR DESCRIPTION
Not sure why these service accounts already exist in the private build cluster. @howardjohn I guess you manually applied them?