### PR TITLE
Bump to new 1.24 alpha version

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1811,7 +1811,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.0
+        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.1
         - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -1811,7 +1811,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.0
+        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.1
         - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1701,7 +1701,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.0
+        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.1
         - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -1701,7 +1701,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.0
+        - gcr.io/istio-testing/kind-node:v1.24.0-alpha.1
         - test.integration.kube
         env:
         - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio-1.13.yaml
+++ b/prow/config/jobs/istio-1.13.yaml
@@ -4576,7 +4576,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - gcr.io/istio-testing/kind-node:v1.24.0-alpha.0
+  - gcr.io/istio-testing/kind-node:v1.24.0-alpha.1
   - test.integration.kube
   env:
   - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -342,7 +342,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.24.0-alpha.0
+      - gcr.io/istio-testing/kind-node:v1.24.0-alpha.1
       - test.integration.kube
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
Current version fails 100% of the time anyways, so no risk here. The job
is hidden. I think this fixes it though.