### PR TITLE
Update images for 1.11

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.11.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -57,7 +57,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -109,7 +109,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -168,7 +168,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -312,7 +312,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -387,7 +387,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -499,7 +499,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -557,7 +557,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -24,7 +24,7 @@ postsubmits:
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
           value: istio-private-build/dev
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -77,7 +77,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -266,7 +266,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -400,7 +400,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -467,7 +467,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -605,7 +605,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -672,7 +672,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -745,7 +745,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -810,7 +810,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -872,7 +872,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -941,7 +941,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1012,7 +1012,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1081,7 +1081,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1150,7 +1150,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1219,7 +1219,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1288,7 +1288,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1355,7 +1355,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1424,7 +1424,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1468,7 +1468,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1519,7 +1519,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1567,7 +1567,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1635,7 +1635,7 @@ presubmits:
           value: -postsubmit,-flaky,-multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1701,7 +1701,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1767,7 +1767,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1835,7 +1835,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1909,7 +1909,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1977,7 +1977,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2047,7 +2047,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2115,7 +2115,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2185,7 +2185,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2251,7 +2251,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2319,7 +2319,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2393,7 +2393,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2461,7 +2461,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2535,7 +2535,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2598,7 +2598,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2660,7 +2660,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2704,7 +2704,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2748,7 +2748,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
@@ -31,7 +31,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -153,7 +153,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -301,7 +301,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
@@ -17,7 +17,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -55,7 +55,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -93,7 +93,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ postsubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -276,7 +276,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -319,7 +319,7 @@ presubmits:
           value: istio-private-prerelease/prerelease
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         - --modifier=update_api_dep
         - --token-path=/etc/github-token/oauth
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -154,7 +154,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -197,7 +197,7 @@ presubmits:
       - command:
         - make
         - presubmit
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -232,7 +232,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean
           gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
         - --modifier=commonfiles
         - --token-path=/etc/github-token/oauth
         - --cmd=make update-common && make gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -175,7 +175,7 @@ postsubmits:
         - --
         - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.11.gen.yaml
@@ -25,7 +25,7 @@ presubmits:
         - ../test-infra/scripts/validate_schema.sh
         - --document-path=./features.yaml
         - --schema-path=./features_schema.json
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         - --git-exclude=^common/
         - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make
           clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ postsubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -381,7 +381,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_default
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -435,7 +435,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_demo
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - doc.test.profile_none
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -545,7 +545,7 @@ presubmits:
         - --topology
         - MULTICLUSTER
         - doc.test.multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -608,7 +608,7 @@ presubmits:
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -18,7 +18,7 @@ periodics:
       - entrypoint
       - prow/integ-suite-kind.sh
       - test.integration-fuzz.security.fuzz.kube
-      image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+      image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
       name: ""
       resources:
         limits:
@@ -81,7 +81,7 @@ postsubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -119,7 +119,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/release-commit.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         - make
         - benchtest
         - report-benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -209,7 +209,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -339,7 +339,7 @@ postsubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -403,7 +403,7 @@ postsubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -463,7 +463,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -525,7 +525,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -593,7 +593,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -653,7 +653,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -715,7 +715,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -783,7 +783,7 @@ postsubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -843,7 +843,7 @@ postsubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -900,7 +900,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -964,7 +964,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1030,7 +1030,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1094,7 +1094,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1158,7 +1158,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1222,7 +1222,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1286,7 +1286,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1348,7 +1348,7 @@ postsubmits:
         env:
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1410,7 +1410,7 @@ presubmits:
         - build
         - racetest
         - binaries-test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1447,7 +1447,7 @@ presubmits:
       - command:
         - entrypoint
         - prow/release-test.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1491,7 +1491,7 @@ presubmits:
         - entrypoint
         - make
         - benchtest
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1532,7 +1532,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1593,7 +1593,7 @@ presubmits:
           value: -postsubmit,-flaky,-multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1652,7 +1652,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1711,7 +1711,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1772,7 +1772,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1839,7 +1839,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1900,7 +1900,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -1963,7 +1963,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,+multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2024,7 +2024,7 @@ presubmits:
           value: distroless
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2087,7 +2087,7 @@ presubmits:
           value: ipv6
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2146,7 +2146,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -postsubmit,-flaky,-multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2207,7 +2207,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2274,7 +2274,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2335,7 +2335,7 @@ presubmits:
         env:
         - name: TEST_SELECT
           value: -multicluster
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2402,7 +2402,7 @@ presubmits:
           value: -multicluster
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2458,7 +2458,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2513,7 +2513,7 @@ presubmits:
       - command:
         - make
         - test.integration.analyze
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2550,7 +2550,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2587,7 +2587,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -2633,7 +2633,7 @@ presubmits:
       - command:
         - ../test-infra/tools/check_release_notes.sh
         - --token-path=/etc/github-token/oauth
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -320,7 +320,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --modifier=update_envoy_dep
       - --token-path=/etc/github-token/oauth
       - --cmd=UPDATE_BRANCH=release/v1.19 scripts/update_envoy.sh
-      image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+      image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
       name: ""
       resources:
         limits:
@@ -75,7 +75,7 @@ postsubmits:
       - command:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -168,7 +168,7 @@ postsubmits:
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -212,7 +212,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -249,7 +249,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -286,7 +286,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -360,7 +360,7 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
-        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-centos:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -398,7 +398,7 @@ presubmits:
       - command:
         - entrypoint
         - ./prow/proxy-presubmit-wasm.sh
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -174,7 +174,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -230,7 +230,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -306,7 +306,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -341,7 +341,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -377,7 +377,7 @@ presubmits:
       - command:
         - entrypoint
         - test/publish.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -418,7 +418,7 @@ presubmits:
       containers:
       - command:
         - release/build-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ presubmits:
       containers:
       - command:
         - release/publish-warning.sh
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
@@ -15,7 +15,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -51,7 +51,7 @@ postsubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -123,7 +123,7 @@ postsubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -161,7 +161,7 @@ postsubmits:
         - entrypoint
         - make
         - containers
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -206,7 +206,7 @@ postsubmits:
         - -C
         - perf_dashboard
         - deploy
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -248,7 +248,7 @@ presubmits:
       - command:
         - make
         - build
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -283,7 +283,7 @@ presubmits:
       - command:
         - make
         - lint
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -318,7 +318,7 @@ presubmits:
       - command:
         - make
         - test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -353,7 +353,7 @@ presubmits:
       - command:
         - make
         - gen-check
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:
@@ -390,7 +390,7 @@ presubmits:
         - entrypoint
         - make
         - containers-test
-        image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+        image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.11.yaml
+++ b/prow/config/jobs/api-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - presubmit
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: build
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -29,7 +29,7 @@ jobs:
   - --modifier=update_api_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update_api_dep_client_go
   node_selector:
     testing: test-pool
@@ -50,7 +50,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update_api_dep_istio
   node_selector:
     testing: test-pool
@@ -64,7 +64,7 @@ jobs:
 - command:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/config/jobs/client-go-1.11.yaml
+++ b/prow/config/jobs/client-go-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: build
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -23,7 +23,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -40,7 +40,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update_client-go_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/common-files-1.11.yaml
+++ b/prow/config/jobs/common-files-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -21,7 +21,7 @@ jobs:
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common && make gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update-common
   node_selector:
     testing: test-pool
@@ -42,7 +42,7 @@ jobs:
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common && make gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -67,7 +67,7 @@ jobs:
   - --
   - --post=make gen
   - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements-1.11.yaml
+++ b/prow/config/jobs/enhancements-1.11.yaml
@@ -1,12 +1,12 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh
   - --document-path=./features.yaml
   - --schema-path=./features_schema.json
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/config/jobs/gogo-genproto-1.11.yaml
+++ b/prow/config/jobs/gogo-genproto-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: build
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -23,7 +23,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -41,7 +41,7 @@ jobs:
   - --git-exclude=^common/
   - --cmd=go get istio.io/gogo-genproto@$AUTOMATOR_SHA && go mod tidy && make clean
     gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update_gogo-genproto_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - entrypoint
@@ -10,7 +10,7 @@ jobs:
   - build
   - racetest
   - binaries-test
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -20,7 +20,7 @@ jobs:
 - command:
   - entrypoint
   - prow/release-test.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: release-test
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -34,7 +34,7 @@ jobs:
 - command:
   - entrypoint
   - prow/release-commit.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: release
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -49,7 +49,7 @@ jobs:
   - entrypoint
   - make
   - benchtest
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -67,7 +67,7 @@ jobs:
   - make
   - benchtest
   - report-benchtest
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: benchmark-report
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -85,7 +85,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -104,7 +104,7 @@ jobs:
     value: -postsubmit,-flaky,-multicluster
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -121,7 +121,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-security
   node_selector:
     testing: test-pool
@@ -138,7 +138,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -157,7 +157,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-telemetry-multicluster
   node_selector:
     testing: test-pool
@@ -177,7 +177,7 @@ jobs:
     value: -multicluster
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.istio.istiodlessRemotes
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -199,7 +199,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-multicluster
   node_selector:
     testing: test-pool
@@ -221,7 +221,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,+multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-istiodremote
   node_selector:
     testing: test-pool
@@ -241,7 +241,7 @@ jobs:
     value: distroless
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -260,7 +260,7 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-ipv6
   node_selector:
     testing: ipv6-pool
@@ -275,7 +275,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -postsubmit,-flaky,-multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-operator-controller
   node_selector:
     testing: test-pool
@@ -292,7 +292,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -311,7 +311,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -331,7 +331,7 @@ jobs:
     value: -multicluster
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.istio.istiodlessRemotes
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -351,7 +351,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-security
   node_selector:
     testing: test-pool
@@ -366,7 +366,7 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration-fuzz.security.fuzz.kube
   cron: 0 7 * * *
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -385,7 +385,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -405,7 +405,7 @@ jobs:
     value: -multicluster
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.istio.istiodlessRemotes
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -425,7 +425,7 @@ jobs:
   env:
   - name: TEST_SELECT
     value: -multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -439,7 +439,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -456,7 +456,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-k8s-116
   node_selector:
     testing: test-pool
@@ -478,7 +478,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-k8s-117
   node_selector:
     testing: test-pool
@@ -498,7 +498,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-k8s-118
   node_selector:
     testing: test-pool
@@ -518,7 +518,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-k8s-119
   node_selector:
     testing: test-pool
@@ -538,7 +538,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-k8s-120
   node_selector:
     testing: test-pool
@@ -558,7 +558,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-k8s-122
   node_selector:
     testing: test-pool
@@ -576,7 +576,7 @@ jobs:
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -590,7 +590,7 @@ jobs:
 - command:
   - make
   - test.integration.analyze
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: analyze-tests
   node_selector:
     testing: test-pool
@@ -602,7 +602,7 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -615,7 +615,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -627,7 +627,7 @@ jobs:
 - command:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: release-notes
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.io-1.11.yaml
+++ b/prow/config/jobs/istio.io-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -24,7 +24,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_default
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: doc.test.profile_default
   node_selector:
     testing: test-pool
@@ -35,7 +35,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_demo
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: doc.test.profile_demo
   node_selector:
     testing: test-pool
@@ -46,7 +46,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_none
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: doc.test.profile_none
   node_selector:
     testing: test-pool
@@ -59,7 +59,7 @@ jobs:
   - --topology
   - MULTICLUSTER
   - doc.test.multicluster
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -73,7 +73,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=make update_ref_docs
   - --dry-run
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/config/jobs/pkg-1.11.yaml
+++ b/prow/config/jobs/pkg-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: build
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -23,7 +23,7 @@ jobs:
 - command:
   - make
   - test
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: test
   node_selector:
     testing: test-pool
@@ -32,7 +32,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -48,7 +48,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update_pkg_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/proxy-1.11.yaml
+++ b/prow/config/jobs/proxy-1.11.yaml
@@ -1,10 +1,10 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
   name: test
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -16,7 +16,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-asan.sh
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
   name: test-asan
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -28,7 +28,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-tsan.sh
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
   name: test-tsan
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -40,7 +40,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-release.sh
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
   name: release-test
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -52,7 +52,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-centos:release-1.11-2022-01-26T20-01-20
   name: release-centos-test
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -65,7 +65,7 @@ jobs:
 - command:
   - entrypoint
   - ./prow/proxy-presubmit-wasm.sh
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
   name: check-wasm
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -79,7 +79,7 @@ jobs:
 - command:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.11-2022-01-26T20-01-20
   name: release
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -92,7 +92,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools-centos:release-1.11-2022-01-26T20-01-20
   name: release-centos
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -112,7 +112,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update-istio
   node_selector:
     testing: build-pool
@@ -133,7 +133,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.19 scripts/update_envoy.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: update-proxy
   interval: 24h
   repos:

--- a/prow/config/jobs/release-builder-1.11.yaml
+++ b/prow/config/jobs/release-builder-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - test
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: test
   node_selector:
     testing: test-pool
@@ -23,7 +23,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -32,7 +32,7 @@ jobs:
 - command:
   - entrypoint
   - test/publish.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: dry-run
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -44,7 +44,7 @@ jobs:
   resources: build
 - command:
   - release/build-warning.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -57,7 +57,7 @@ jobs:
   - presubmit
 - command:
   - release/publish-warning.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -71,7 +71,7 @@ jobs:
 - command:
   - entrypoint
   - release/build.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: build-release
   node_selector:
     testing: test-pool
@@ -87,7 +87,7 @@ jobs:
 - command:
   - entrypoint
   - release/publish.sh
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: publish-release
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/tools-1.11.yaml
+++ b/prow/config/jobs/tools-1.11.yaml
@@ -1,11 +1,11 @@
 branches:
 - release-1.11
-image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
 jobs:
 - command:
   - make
   - build
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: build
   node_selector:
     testing: test-pool
@@ -14,7 +14,7 @@ jobs:
 - command:
   - make
   - lint
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: lint
   node_selector:
     testing: test-pool
@@ -23,7 +23,7 @@ jobs:
 - command:
   - make
   - test
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: test
   node_selector:
     testing: test-pool
@@ -32,7 +32,7 @@ jobs:
 - command:
   - make
   - gen-check
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: gencheck
   node_selector:
     testing: test-pool
@@ -42,7 +42,7 @@ jobs:
   - entrypoint
   - make
   - containers
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: containers
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -58,7 +58,7 @@ jobs:
   - entrypoint
   - make
   - containers-test
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: containers-test
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -76,7 +76,7 @@ jobs:
   - -C
   - perf_dashboard
   - deploy
-  image: gcr.io/istio-testing/build-tools:release-1.11-2021-11-15T12-29-57
+  image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: deploy-perf-dashboard
   service_account_name: prowjob-advanced-sa
   node_selector:


### PR DESCRIPTION
Automated task failed with:
```
 go mod tidy: go.mod file indicates go 1.17, but maximum supported version is 1.16
make: *** [common/Makefile.common.mk:72: tidy-go] Error 1
```