### PR TITLE
Remove dedicated ipv6 pool

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -480,7 +480,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2522,7 +2522,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.10.gen.yaml
@@ -288,7 +288,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1713,7 +1713,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -361,7 +361,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2211,7 +2211,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -418,7 +418,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2520,7 +2520,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -480,7 +480,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2522,7 +2522,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.9.gen.yaml
@@ -288,7 +288,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1645,7 +1645,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -538,7 +538,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2405,7 +2405,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.10.gen.yaml
@@ -300,7 +300,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1595,7 +1595,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -429,7 +429,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2113,7 +2113,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -481,7 +481,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2399,7 +2399,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -538,7 +538,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -2405,7 +2405,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.9.gen.yaml
@@ -300,7 +300,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -1532,7 +1532,7 @@ presubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
-        testing: ipv6-pool
+        testing: test-pool
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/config/jobs/istio-1.10.yaml
+++ b/prow/config/jobs/istio-1.10.yaml
@@ -182,9 +182,6 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
-  node_selector:
-    # COS does not currently support IPv6
-    testing: ipv6-pool
   name: integ-ipv6
   requirements:
   - cache

--- a/prow/config/jobs/istio-1.11.yaml
+++ b/prow/config/jobs/istio-1.11.yaml
@@ -262,8 +262,6 @@ jobs:
     value: -multicluster
   image: gcr.io/istio-testing/build-tools:release-1.11-2022-01-26T20-01-20
   name: integ-ipv6
-  node_selector:
-    testing: ipv6-pool
   requirements:
   - cache
   - kind

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -214,8 +214,6 @@ jobs:
   - name: IP_FAMILY
     value: ipv6
   name: integ-ipv6
-  node_selector:
-    testing: ipv6-pool
   requirements:
   - cache
   - kind

--- a/prow/config/jobs/istio-1.13.yaml
+++ b/prow/config/jobs/istio-1.13.yaml
@@ -1616,8 +1616,6 @@ jobs:
   - name: IP_FAMILY
     value: ipv6
   name: integ-ipv6
-  node_selector:
-    testing: ipv6-pool
   requirement_presets:
     cache:
       annotations: null

--- a/prow/config/jobs/istio-1.9.yaml
+++ b/prow/config/jobs/istio-1.9.yaml
@@ -137,9 +137,6 @@ jobs:
     value: ipv6
   - name: TEST_SELECT
     value: -multicluster
-  node_selector:
-    # COS does not currently support IPv6
-    testing: ipv6-pool
   name: integ-ipv6
   requirements:
   - kind

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -91,9 +91,6 @@ jobs:
   - name: integ-ipv6
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]
     requirements: [kind]
-    node_selector:
-      # COS does not currently support IPv6
-      testing: ipv6-pool
     env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"


### PR DESCRIPTION
GKE COS 1.21+, which we are on, can support the ipv6 tests now. No need
for dedicated pool. I manually verified this so I am fairly confident it
will work.