### PR TITLE
Add external secrets for build cluster

### DIFF
--- a/prow/cluster/build/kubernetes_external_secrets.yaml
+++ b/prow/cluster/build/kubernetes_external_secrets.yaml
@@ -1,0 +1,77 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "cosign-key"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__cosign-key" # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "grafana-token"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__grafana-token" # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "oauth-token"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__oauth-token" # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "policybot"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__policybot" # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "rel-pipeline-docker-config"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__rel-pipeline-docker-config" # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "rel-pipeline-github"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__rel-pipeline-github" # Secret name in GSM
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: "rel-pipeline-service-account"
+  namespace: "test-pods"
+spec:
+  backendType: gcpSecretsManager
+  projectId: "istio-prow-build"
+  dataFrom:
+  - "gke_istio-prow-build_us-west1-a_prow__test-pods__rel-pipeline-service-account" # Secret name in GSM
+---


### PR DESCRIPTION
This matches what exists in the cluster today, synced with https://github.com/kubernetes/test-infra/tree/master/experiment/clustersecretbackup. Unless we messed up this should be a NOP