### PR TITLE
External secrets: fix RBAC

### DIFF
--- a/prow/cluster/build/kubernetes-external-secrets_rbac.yaml
+++ b/prow/cluster/build/kubernetes-external-secrets_rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update"]
+    verbs: ["create", "update", "get"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "watch", "list"]

--- a/prow/cluster/kubernetes-external-secrets_rbac.yaml
+++ b/prow/cluster/kubernetes-external-secrets_rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update"]
+    verbs: ["create", "update", "get"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "watch", "list"]

--- a/prow/cluster/private/kubernetes-external-secrets_rbac.yaml
+++ b/prow/cluster/private/kubernetes-external-secrets_rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update"]
+    verbs: ["create", "update", "get"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "watch", "list"]


### PR DESCRIPTION
Not sure why it worked before on the main cluster - on the new cluster
it doesn't. Upstream has GET here and I verified this makes things work.

Ref
https://github.com/external-secrets/kubernetes-external-secrets/blob/d83384c5d1efae9491faddb84dc231761ff54039/charts/kubernetes-external-secrets/templates/rbac.yaml#L18