### PR TITLE
Fix configurator command

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -10,8 +10,6 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-prow/configurator
-        command:
-        - /app/testgrid/cmd/configurator/app.binary
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -15,8 +15,6 @@ postsubmits:
       serviceAccountName: testgrid-updater
       containers:
       - image: gcr.io/k8s-prow/configurator
-        command:
-        - /app/testgrid/cmd/configurator/app.binary
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml


### PR DESCRIPTION
"Broken" in 701ef54495. We should probably not use `:latest` and get it
bumped by the bump script