### PR TITLE
Manual bump3867

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,8 +6,6 @@ presubmits:
   spec:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220223-a7c3ef700d
-      command:
-      - /checkconfig
       args:
       - --config-path=prow/config.yaml
       - --job-config-path=prow/cluster/jobs

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,6 +6,8 @@ presubmits:
   spec:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220223-a7c3ef700d
+      command:
+      - checkconfig
       args:
       - --config-path=prow/config.yaml
       - --job-config-path=prow/cluster/jobs

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
   run_if_changed: '^(\.prow|prow/(config|plugins|cluster/jobs/.*))\.yaml$'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20220221-8b6a2593f3
+    - image: gcr.io/k8s-prow/checkconfig:v20220223-a7c3ef700d
       command:
       - /checkconfig
       args:

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/cherrypicker:v20220223-a7c3ef700d
         args:
         - --create-issue-on-conflict
         - --dry-run=false

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/crier:v20220223-a7c3ef700d
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/deck:v20220223-a7c3ef700d
         ports:
         - name: http
           containerPort: 8080

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-private
-        image: gcr.io/k8s-prow/deck:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/deck:v20220223-a7c3ef700d
         ports:
         - name: http
           containerPort: 8080

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/ghproxy:v20220223-a7c3ef700d
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/hook:v20220223-a7c3ef700d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/horologium:v20220223-a7c3ef700d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator
+      - image: gcr.io/k8s-prow/configurator:v20220223-a7c3ef700d
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -10,6 +10,8 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-prow/configurator:v20220223-a7c3ef700d
+        command:
+        - configurator
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -10,8 +10,6 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-prow/configurator
-        command:
-        - /app/testgrid/cmd/configurator/app.binary
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -14,7 +14,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator
+      - image: gcr.io/k8s-prow/configurator:v20220223-a7c3ef700d
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -44,8 +44,6 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-prow/branchprotector:v20220223-a7c3ef700d
-      command:
-      - /app/prow/cmd/branchprotector/app.binary
       args:
       - --config-path=prow/config.yaml
       - --job-config-path=prow/cluster/jobs
@@ -74,8 +72,6 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220223-a7c3ef700d
-      command:
-      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=prow/istio-autobump-config.yaml
       volumeMounts:
@@ -108,8 +104,6 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220223-a7c3ef700d
-      command:
-      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=prow/istio-autobump-config.yaml
       - --labels-override=auto-merge # This label is used by tide for identifying trusted PR

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -15,6 +15,8 @@ postsubmits:
       serviceAccountName: testgrid-updater
       containers:
       - image: gcr.io/k8s-prow/configurator:v20220223-a7c3ef700d
+        command:
+        - configurator
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml
@@ -44,6 +46,8 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-prow/branchprotector:v20220223-a7c3ef700d
+      command:
+      - branchprotector
       args:
       - --config-path=prow/config.yaml
       - --job-config-path=prow/cluster/jobs
@@ -72,6 +76,8 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220223-a7c3ef700d
+      command:
+      - generic-autobumper
       args:
       - --config=prow/istio-autobump-config.yaml
       volumeMounts:
@@ -104,6 +110,8 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220223-a7c3ef700d
+      command:
+      - generic-autobumper
       args:
       - --config=prow/istio-autobump-config.yaml
       - --labels-override=auto-merge # This label is used by tide for identifying trusted PR

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -45,7 +45,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/branchprotector:v20220221-8b6a2593f3
+    - image: gcr.io/k8s-prow/branchprotector:v20220223-a7c3ef700d
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -75,7 +75,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220221-8b6a2593f3
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220223-a7c3ef700d
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -109,7 +109,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220221-8b6a2593f3
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220223-a7c3ef700d
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -15,8 +15,6 @@ postsubmits:
       serviceAccountName: testgrid-updater
       containers:
       - image: gcr.io/k8s-prow/configurator
-        command:
-        - /app/testgrid/cmd/configurator/app.binary
         args:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/needs-rebase:v20220223-a7c3ef700d
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220223-a7c3ef700d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/sinker:v20220223-a7c3ef700d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/status-reconciler:v20220223-a7c3ef700d
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220221-8b6a2593f3
+        image: gcr.io/k8s-prow/tide:v20220223-a7c3ef700d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11,10 +11,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220221-8b6a2593f3"
-        initupload: "gcr.io/k8s-prow/initupload:v20220221-8b6a2593f3"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220221-8b6a2593f3"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220221-8b6a2593f3"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220223-a7c3ef700d"
+        initupload: "gcr.io/k8s-prow/initupload:v20220223-a7c3ef700d"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220223-a7c3ef700d"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220223-a7c3ef700d"
       gcs_configuration:
         bucket: "istio-prow"
         path_strategy: "explicit"


### PR DESCRIPTION
Replaces https://github.com/istio/test-infra/pull/3867

Some changes upstream changed the path; instead just rely on the entrypoint

Since we used `:latest` tag the job is already broken so I think the only fix is to force merge. Once this is I approve I will manually merge