### PR TITLE
Experiment with adding CPU limits to istio jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -30,6 +30,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -83,6 +84,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -127,6 +129,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -191,6 +194,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -257,6 +261,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -328,6 +333,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -393,6 +399,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -460,6 +467,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -522,6 +530,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -584,6 +593,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -648,6 +658,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -717,6 +728,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -786,6 +798,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -857,6 +870,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -919,6 +933,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -983,6 +998,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -1052,6 +1068,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -1123,6 +1140,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -1185,6 +1203,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1256,6 +1275,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1327,6 +1347,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1398,6 +1419,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1469,6 +1491,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1540,6 +1563,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1611,6 +1635,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1680,6 +1705,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1753,6 +1779,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1822,6 +1849,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1889,6 +1917,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1958,6 +1987,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2002,6 +2032,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2101,6 +2132,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2164,6 +2196,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2229,6 +2262,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2296,6 +2330,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2368,6 +2403,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2434,6 +2470,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2502,6 +2539,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2565,6 +2603,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2628,6 +2667,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2693,6 +2733,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2763,6 +2804,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2833,6 +2875,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2905,6 +2948,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2968,6 +3012,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3033,6 +3078,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -3103,6 +3149,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -3175,6 +3222,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -3238,6 +3286,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3307,6 +3356,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3369,6 +3419,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3457,6 +3508,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -22,6 +22,7 @@ periodics:
       name: ""
       resources:
         limits:
+          cpu: "5"
           memory: 24Gi
         requests:
           cpu: "5"
@@ -85,6 +86,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -123,6 +125,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -208,6 +211,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -267,6 +271,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -328,6 +333,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -394,6 +400,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -454,6 +461,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -516,6 +524,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -573,6 +582,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -630,6 +640,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -689,6 +700,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -753,6 +765,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -817,6 +830,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -883,6 +897,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -940,6 +955,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -999,6 +1015,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -1063,6 +1080,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -1129,6 +1147,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -1186,6 +1205,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1252,6 +1272,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1318,6 +1339,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1384,6 +1406,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1450,6 +1473,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1516,6 +1540,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1582,6 +1607,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1646,6 +1672,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1714,6 +1741,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1778,6 +1806,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1840,6 +1869,7 @@ postsubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1902,6 +1932,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -1939,6 +1970,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2024,6 +2056,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2080,6 +2113,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2138,6 +2172,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2198,6 +2233,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2263,6 +2299,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2322,6 +2359,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2383,6 +2421,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2439,6 +2478,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2495,6 +2535,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2553,6 +2594,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2616,6 +2658,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2679,6 +2722,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2744,6 +2788,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2800,6 +2845,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -2858,6 +2904,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2921,6 +2968,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -2986,6 +3034,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "8"
             memory: 24Gi
           requests:
             cpu: "8"
@@ -3042,6 +3091,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3104,6 +3154,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3159,6 +3210,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3233,6 +3285,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"
@@ -3279,6 +3332,7 @@ presubmits:
         name: ""
         resources:
           limits:
+            cpu: "5"
             memory: 24Gi
           requests:
             cpu: "5"

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -401,6 +401,7 @@ resources_presets:
       cpu: "5000m"
     limits:
       memory: "24Gi"
+      cpu: "5000m"
   # TODO: this was set while investigating https://github.com/istio/istio/issues/32985
   # We should consider if this is needed long term, as its expensive
   multicluster:
@@ -411,6 +412,7 @@ resources_presets:
       cpu: "8000m"
     limits:
       memory: "24Gi"
+      cpu: "8000m"
   lint:
     requests:
       memory: "16Gi"


### PR DESCRIPTION
Currently we are seeing that `echo hello world` in other pods can take
>2s. This is correlated with test flakes. it seems when a PR is
triggered, we schedule a bunch of jobs which use high CPU in the early
phase of the job (building). During this time, other tests have a
elevated chance of flaking.

This is intended to be an experiment to let us measure impact on test
time and impact on test stability