### PR TITLE
jobs: put unit tests on dedicate node

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -84,11 +84,10 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1987,11 +1986,10 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -86,11 +86,10 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1932,11 +1931,10 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: "5"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -5,6 +5,7 @@ image: gcr.io/istio-testing/build-tools:master-2022-02-11T17-43-07
 jobs:
   - name: unit-tests
     command: [entrypoint, make, -e, "T=-v -count=1", build, racetest, binaries-test]
+    resources: dedicated
 
   - name: release-test
     service_account_name: prowjob-advanced-sa
@@ -22,13 +23,13 @@ jobs:
     types: [presubmit]
     modifiers: [presubmit_optional, presubmit_skipped]
     command: [entrypoint, make, benchtest]
-    resources: benchmark
+    resources: dedicated
 
   - name: benchmark-report
     service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     command: [entrypoint, make, benchtest, report-benchtest]
-    resources: benchmark
+    resources: dedicated
 
   - name: integ-cni
     types: [presubmit]
@@ -420,7 +421,7 @@ resources_presets:
     limits:
       memory: "24Gi"
   # Give 15 CPUs which will put us on a dedicated node, for consistency
-  benchmark:
+  dedicated:
     requests:
       memory: "8Gi"
       cpu: "15000m"


### PR DESCRIPTION
These jobs used to take like 5 minutes and now take 15, using max CPU
the entire time. I am worried they steal CPU from other jobs.

I have some ideas to optimize it, but for now see how it goes to isolate
them.