### PR TITLE
Minimize in_repo_config usage

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -357,7 +357,7 @@ branch-protection:
 
 in_repo_config:
   enabled:
-    istio: true
+    istio/test-infra: true
 
 tide:
   queries:


### PR DESCRIPTION
This ensures we do not accidentally use it where its not required and
should reduce some load on tide