### PR TITLE
Move tide_update_period back to 10s

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -76,7 +76,7 @@ deck:
   hidden_repos:
   - istio-private
 
-  tide_update_period: 1s
+  tide_update_period: 10s
   rerun_auth_configs:
     '*':
       github_users:


### PR DESCRIPTION
Currently this causes both tide and deck to regularly use high CPU.
Since this only impacts a page rarely viewed, seems reasonable to
lower it. Being 10s outdated is not an issue.

Our value of 1s was driven from
https://github.com/kubernetes/test-infra/pull/7089, where it was
apparently important. However, I do not think the same applies for our
use cases.