### PR TITLE
Add back inadvertently removed proxy to common-files update job

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -110,7 +110,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=istio,api,tools,release-builder,pkg,client-go
+        - --repo=istio,api,tools,release-builder,pkg,client-go,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
         - --strict

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -28,7 +28,7 @@ jobs:
     command:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
-    - --repo=istio,api,tools,release-builder,pkg,client-go
+    - --repo=istio,api,tools,release-builder,pkg,client-go,proxy
     - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
     - --strict


### PR DESCRIPTION
https://github.com/istio/test-infra/pull/3949 inadvertently removed `proxy` from the common-files update job.

Add it back in.