### PR TITLE
Fix the ghproxy cache size

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
         image: gcr.io/k8s-prow/ghproxy:v20220418-5b1d25764f
         args:
         - --cache-dir=/cache
-        - --cache-sizeGB=99
+        - --cache-sizeGB=15
         - --serve-metrics=true
         ports:
         - name: main


### PR DESCRIPTION
The volume claim is only 15GB.