### PR TITLE
istio-private: drop branch protection

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -340,29 +340,6 @@ branch-protection:
           branches:
             master:
               protect: true
-    istio-private:
-      required_pull_request_reviews:
-        <<: *protection_required_pull_request_reviews
-        require_code_owner_reviews: false
-      restrictions: *protection_restrictions
-      repos:
-        <<: *protection_repos
-        istio:
-          branches:
-            <<: *blocked_branches
-            release-1.1: *release11
-            release-1.2: *release12
-            release-1.3: *release13
-            release-1.4: *release14
-        proxy:
-          required_status_checks:
-          branches:
-            <<: *blocked_branches
-            endpoints-v1.1.x: *blocking_merge
-            endpoints-v1.2.x: *blocking_merge
-        istio.io:
-          required_status_checks:
-          branches: *blocked_branches
 
 in_repo_config:
   enabled:


### PR DESCRIPTION
Requires github Pro which we stopped paying for