### PR TITLE
Do not validate missing releasenotes (removed in PR)

### DIFF
--- a/tools/check_release_notes.sh
+++ b/tools/check_release_notes.sh
@@ -185,12 +185,14 @@ function validateNotes() {
     {
     set +e
     while read -r line; do
-    if ! validateNote "./${line}"; then
-        errorOccurred=1
-    fi
+      if test -f "./${line}"; then # Do not validate if the file doesn't exist (was removed in the PR)
+        if ! validateNote "./${line}"; then
+          errorOccurred=1
+        fi
+      fi
+    done
     popd
 
-    done
     set -e
     if [ "${errorOccurred}" != 0 ]; then
         echo ""


### PR DESCRIPTION
If a PR removes a release notes file, it fails the release notes test. See https://github.com/istio/istio/pull/38826 and https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/38826/release-notes_istio/1524008660739559424.

The reason is that the `gh pr` returns all files changed in a PR. The release note logic assumes that it was a file add or modify, and tries to validate its schema. This change is to not validate the file schema is the file doesn't exist, ie it was removed.

There is a matching change in the the tools go code as well.