### PR TITLE
istiodless: always skip VMs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -255,6 +255,9 @@ postsubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
         image: gcr.io/istio-testing/build-tools:master-2022-05-19T17-27-24
         name: ""
         resources:
@@ -2104,6 +2107,9 @@ presubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
         image: gcr.io/istio-testing/build-tools:master-2022-05-19T17-27-24
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -327,6 +327,9 @@ postsubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
         image: gcr.io/istio-testing/build-tools:master-2022-05-19T17-27-24
         name: ""
         resources:
@@ -2092,6 +2095,9 @@ presubmits:
         - --topology-config
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
+        env:
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.skipVM
         image: gcr.io/istio-testing/build-tools:master-2022-05-19T17-27-24
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -66,6 +66,9 @@ jobs:
       - test.integration.telemetry.kube
     requirements: [kind]
     resources: multicluster
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: --istio.test.skipVM
 
   - name: integ-distroless
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]


### PR DESCRIPTION
currently security and pilot test skip VM for istiodless, but not
telemtry. This was an oversight due to telemetry not testing VMs at all (until now)