### PR TITLE
GMP monitors KES from default namespace

### DIFF
--- a/prow/cluster/monitoring/prow_podmonitors_for_gmp.yaml
+++ b/prow/cluster/monitoring/prow_podmonitors_for_gmp.yaml
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/name: kubernetes-external-secrets
     app: kubernetes-external-secrets
   name: kubernetes-external-secrets
-  namespace: prow-monitoring
+  namespace: default
 spec:
   endpoints:
   - interval: 30s


### PR DESCRIPTION
It was overlooked in previous PR