### PR TITLE
Remove authentikos from ExternalSecrets

### DIFF
--- a/prow/cluster/private/kubernetes_external_secrets.yaml
+++ b/prow/cluster/private/kubernetes_external_secrets.yaml
@@ -1,17 +1,6 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: "authentikos-token"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow-private__test-pods__authentikos-token" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: "cosign-key"
   namespace: "test-pods"
 spec:


### PR DESCRIPTION
This is generated dynamically; by using ExternalSecrets we are pinning
it to some old expired version and racing with the authentikos dynamic
updater.