### PR TITLE
Remove namespace from monitoring deploying command

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -42,7 +42,7 @@ deploy-velodrome: get-cluster-credentials
 deploy-monitoring: get-cluster-credentials
 	kubectl apply -f ./cluster/monitoring/prometheus-operator-crds/
 	$(MAKE) -C cluster/monitoring/mixins clean apply
-	kubectl apply -f ./cluster/monitoring/ -n prow-monitoring
+	kubectl apply -f ./cluster/monitoring/
 
 get-build-cluster-credentials: PROJECT=$(PROJECT_BUILD)
 get-build-cluster-credentials: CLUSTER=$(CLUSTER_BUILD)


### PR DESCRIPTION
Namespace is already defined on every single object under the directory, there is no need to do so. Also, newly added GMP objects are meant to be deployed in the same namespace as the resource being monitored, i.e. 'default' for prow components