### PR TITLE
private: add proper helm env var

### DIFF
--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -144,6 +144,8 @@ postsubmits:
               name: cosign-key
         - name: GCS_BUCKET
           value: istio-private-prerelease/prerelease
+        - name: HELM_BUCKET
+          value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
         image: gcr.io/istio-testing/build-tools:master-2022-05-23T15-41-52

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.14.gen.yaml
@@ -144,6 +144,8 @@ postsubmits:
               name: cosign-key
         - name: GCS_BUCKET
           value: istio-private-prerelease/prerelease
+        - name: HELM_BUCKET
+          value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
         image: gcr.io/istio-testing/build-tools:release-1.14-2022-05-12T14-42-16

--- a/prow/config/istio-private_jobs/release-builder-1.14.yaml
+++ b/prow/config/istio-private_jobs/release-builder-1.14.yaml
@@ -32,6 +32,7 @@ transforms:
   - release-builder
 - env:
     GCS_BUCKET: istio-private-prerelease/prerelease
+    HELM_BUCKET: istio-private-build/dev/charts
     PRERELEASE_DOCKER_HUB: gcr.io/istio-prow-build
   job-allowlist:
   - build-release_release-builder_release-1.14_postsubmit

--- a/prow/config/istio-private_jobs/release-builder.yaml
+++ b/prow/config/istio-private_jobs/release-builder.yaml
@@ -29,6 +29,7 @@ transforms:
   # istio/release-builder master build jobs(s) - postsubmit(s)
 - env:
     PRERELEASE_DOCKER_HUB: gcr.io/istio-prow-build
+    HELM_BUCKET: istio-private-build/dev/charts
     GCS_BUCKET: istio-private-prerelease/prerelease
   labels:
     preset-enable-ssh: "true"


### PR DESCRIPTION
This was on 1.13, but not master, so 1.14 ended up missing it