### PR TITLE
Multi arch apply jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -22,6 +22,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: DOCKER_ARCHITECTURES
+          value: linux/amd64,linux/arm64
         - name: DOCKER_HUB
           value: gcr.io/istio-prow-build
         - name: GCS_BUCKET
@@ -110,6 +112,125 @@ postsubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: unit-tests-arm64_istio_postsubmit_pri
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - T=-v -count=1
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "15"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: integ-basic-arm64_istio_postsubmit_pri
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.kube.environment
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -2040,6 +2161,59 @@ presubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
+    name: unit-tests-arm64_istio_pri
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - T=-v -count=1
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "15"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
     name: release-test_istio_pri
     path_alias: istio.io/istio
     spec:
@@ -2050,6 +2224,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: DOCKER_ARCHITECTURES
+          value: linux/amd64,linux/arm64
         image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
@@ -2130,6 +2306,74 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/istio.git
+    cluster: private
+    decorate: true
+    labels:
+      preset-enable-netrc: "true"
+      preset-enable-ssh: "true"
+      preset-override-deps: master-istio
+      preset-override-envoy: "true"
+    name: integ-basic-arm64_istio_pri
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.kube.environment
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -82,6 +82,8 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: DOCKER_REPOSITORY
           value: istio-prow-build/envoy
@@ -93,7 +95,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -110,10 +112,6 @@ postsubmits:
           subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
-        - mountPath: /home/.netrc
-          name: netrc
-          readOnly: true
-          subPath: .netrc
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: build-pool
@@ -125,13 +123,6 @@ postsubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
-      - name: netrc
-        secret:
-          items:
-          - key: secret
-            mode: 384
-            path: .netrc
-          secretName: netrc-secret
   - annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -231,7 +222,7 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -239,13 +230,6 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: netrc
-        secret:
-          items:
-          - key: secret
-            mode: 384
-            path: .netrc
-          secretName: netrc-secret
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -265,12 +249,14 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit.sh
         env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -285,10 +271,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /home/.netrc
-          name: netrc
-          readOnly: true
-          subPath: .netrc
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: build-pool
@@ -340,7 +322,7 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -348,13 +330,6 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: netrc
-        secret:
-          items:
-          - key: secret
-            mode: 384
-            path: .netrc
-          secretName: netrc-secret
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -374,12 +349,14 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-asan.sh
         env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -394,10 +371,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /home/.netrc
-          name: netrc
-          readOnly: true
-          subPath: .netrc
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: build-pool
@@ -449,7 +422,7 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -457,13 +430,6 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: netrc
-        secret:
-          items:
-          - key: secret
-            mode: 384
-            path: .netrc
-          secretName: netrc-secret
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -483,12 +449,14 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
         env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -503,10 +471,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /home/.netrc
-          name: netrc
-          readOnly: true
-          subPath: .netrc
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: build-pool
@@ -587,12 +551,14 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: ENVOY_PREFIX
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -607,10 +573,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /home/.netrc
-          name: netrc
-          readOnly: true
-          subPath: .netrc
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: build-pool
@@ -620,13 +582,6 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: netrc
-        secret:
-          items:
-          - key: secret
-            mode: 384
-            path: .netrc
-          secretName: netrc-secret
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -72,6 +72,77 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+    name: release-arm64_proxy_postsubmit_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - ./prow/proxy-postsubmit.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: DOCKER_REPOSITORY
+          value: istio-prow-build/envoy
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        - name: GCS_ARTIFACTS_BUCKET
+          value: istio-private-artifacts
+        - name: GCS_BUILD_BUCKET
+          value: istio-private-build
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
     name: release-centos_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -160,7 +231,66 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
+    name: test-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit.sh
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -210,7 +340,66 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
+    name: test-asan-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-asan.sh
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -260,7 +449,66 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
+    name: test-tsan-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-tsan.sh
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -318,6 +566,67 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
+    name: release-test-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-release.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio/istio/istio.istio.experimental-dual-stack.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.experimental-dual-stack.gen.yaml
@@ -57,6 +57,54 @@ postsubmits:
     - experimental-dual-stack
     cluster: public
     decorate: true
+    name: unit-tests-arm64_istio_postsubmit_exp_ds
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - T=-v -count=1
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "15"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - experimental-dual-stack
+    cluster: public
+    decorate: true
     name: benchmark-report_istio_postsubmit_exp_ds
     path_alias: istio.io/istio
     spec:
@@ -95,6 +143,69 @@ postsubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - experimental-dual-stack
+    cluster: public
+    decorate: true
+    name: integ-basic-arm64_istio_postsubmit_exp_ds
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.kube.environment
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -120,6 +120,54 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: unit-tests-arm64_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - T=-v -count=1
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "15"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
     decorate: true
     name: release_istio_postsubmit
     path_alias: istio.io/istio
@@ -131,6 +179,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: DOCKER_ARCHITECTURES
+          value: linux/amd64,linux/arm64
         image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
@@ -206,6 +256,69 @@ postsubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: integ-basic-arm64_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.kube.environment
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - annotations:
       testgrid-alert-email: istio-oncall@googlegroups.com
       testgrid-dashboards: istio_istio_postsubmit
@@ -2093,6 +2206,53 @@ presubmits:
       testgrid-dashboards: istio_istio
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: unit-tests-arm64_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - T=-v -count=1
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "15"
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
     decorate: true
     name: release-test_istio
     path_alias: istio.io/istio
@@ -2104,6 +2264,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: DOCKER_ARCHITECTURES
+          value: linux/amd64,linux/arm64
         image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
@@ -2177,6 +2339,68 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: integ-basic-arm64_istio
+    path_alias: istio.io/istio
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.kube.environment
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -116,6 +116,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -129,7 +130,9 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -294,7 +297,7 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -307,6 +310,7 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -316,7 +320,10 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -373,7 +380,7 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -386,6 +393,7 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -395,7 +403,10 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -452,7 +463,7 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -465,6 +476,7 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -474,7 +486,10 @@ presubmits:
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:
@@ -544,6 +559,7 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -556,7 +572,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
-        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -119,6 +119,53 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
+    name: release-arm64_proxy_postsubmit
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - ./prow/proxy-postsubmit.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_proxy_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
     name: release-centos_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
@@ -247,7 +294,45 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: test-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit.sh
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -288,7 +373,45 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: test-asan-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-asan.sh
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -329,7 +452,45 @@ presubmits:
           name: build-cache
           subPath: gomod
       nodeSelector:
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: test-tsan-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-tsan.sh
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -371,6 +532,47 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: amd64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: release-test-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-release.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        image: gcr.io/istio-testing/build-tools-proxy:master-2022-06-13T19-37-37
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -167,6 +167,61 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: containers-arm64_tools_postsubmit
+    path_alias: istio.io/tools
+    run_if_changed: docker/.+|cmd/.+
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - containers
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: MANIFEST_ARCH
+        image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 4Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root
+      - name: github
+        secret:
+          secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_tools_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
     decorate: true
     extra_refs:
     - base_ref: master
@@ -195,6 +250,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: MANIFEST_ARCH
+          value: arm64 amd64
         image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
         name: ""
         resources:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -4,6 +4,7 @@ support_release_branching: true
 image: gcr.io/istio-testing/build-tools:master-7cb17d17e2e98087622580837b2cd61400011c84
 jobs:
   - name: unit-tests
+    architectures: [amd64, arm64]
     command: [entrypoint, make, -e, "T=-v -count=1", build, racetest, binaries-test]
     resources: dedicated
 
@@ -13,6 +14,9 @@ jobs:
     command: [entrypoint, prow/release-test.sh]
     requirements: [docker]
     resources: dedicated
+    env:
+    - name: DOCKER_ARCHITECTURES
+      value: "linux/amd64,linux/arm64"
 
   - name: release
     service_account_name: prowjob-advanced-sa
@@ -20,6 +24,9 @@ jobs:
     command: [entrypoint, prow/release-commit.sh]
     requirements: [docker]
     resources: dedicated
+    env:
+    - name: DOCKER_ARCHITECTURES
+      value: "linux/amd64,linux/arm64"
 
   - name: benchmark
     types: [presubmit]
@@ -32,6 +39,11 @@ jobs:
     types: [postsubmit]
     command: [entrypoint, make, benchtest, report-benchtest]
     resources: dedicated
+
+  - name: integ-basic
+    architectures: [arm64]
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]
+    requirements: [kind]
 
   - name: integ-cni
     types: [presubmit]

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -7,24 +7,36 @@ node_selector:
 
 jobs:
 - name: test
+  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 4h
 
 - name: test-asan
+  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
   timeout: 4h
 
 - name: test-tsan
+  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-tsan.sh]
   timeout: 4h
 
 - name: release-test
+  service_account_name: prowjob-advanced-sa
+  types: [presubmit]
+  command: [./prow/proxy-presubmit-release.sh]
+  timeout: 4h
+- name: release-test
+  architectures: [arm64]
+  env:
+  - name: ARCH_SUFFIX
+    value: $(params.arch)
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
@@ -45,6 +57,16 @@ jobs:
   timeout: 4h
 
 - name: release
+  service_account_name: prowjob-advanced-sa
+  types: [postsubmit]
+  command: [entrypoint, ./prow/proxy-postsubmit.sh]
+  requirements: [docker]
+  timeout: 4h
+- name: release
+  architectures: [arm64]
+  env:
+  - name: ARCH_SUFFIX
+    value: $(params.arch)
   service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -29,6 +29,22 @@ jobs:
 
   - name: containers
     service_account_name: prowjob-advanced-sa
+    architectures: [arm64]
+    types: [postsubmit]
+    command:
+    - entrypoint
+    - make
+    - containers
+    env:
+    # For arm64, we do not generate the manifest; the amd job will handle it
+    - name: MANIFEST_ARCH
+      value: ""
+    resources: build
+    regex: 'docker/.+|cmd/.+'
+    requirements: [docker, github]
+  - name: containers
+    service_account_name: prowjob-advanced-sa
+    architectures: [amd64]
     types: [postsubmit]
     command:
     - entrypoint
@@ -41,6 +57,10 @@ jobs:
     - --token-path=/etc/github-token/oauth
     - --script-path=../common-files/bin/create-buildtools-and-update.sh
     resources: build
+    env:
+    # For amd64, publish the manifest for arm64+amd64
+    - name: MANIFEST_ARCH
+      value: "arm64 amd64"
     regex: 'docker/.+|cmd/.+'
     requirements: [docker, github]
     repos: [istio/test-infra@master,istio/common-files@master]


### PR DESCRIPTION
For https://github.com/istio/istio/issues/26652#issuecomment-1155682106

This introduces new jobs for arm64

tools: new pre/postsubmit for container publishing
proxy: new presubmit jobs for all tests and release test; postsubmit job for release
istio: new integ test for arm, run unit tests on arm, change release to multi-arch (cross compiles)

These cannot merge until we have arm nodes... and we also should split them into three phases (since each depends on the former)