### PR TITLE
Remove `make gen` from build image automation (1.12 & 1.13)

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.12.gen.yaml
@@ -184,8 +184,6 @@ postsubmits:
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh
         - --labels=release-notes-none
         - --verbose
-        - --
-        - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
@@ -184,8 +184,6 @@ postsubmits:
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh
         - --labels=release-notes-none
         - --verbose
-        - --
-        - --post=make gen
         - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/common-files-1.12.yaml
+++ b/prow/config/jobs/common-files-1.12.yaml
@@ -61,8 +61,6 @@ jobs:
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh
   - --labels=release-notes-none
   - --verbose
-  - --
-  - --post=make gen
   - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
   name: update-build-tools-image
   node_selector:

--- a/prow/config/jobs/common-files-1.13.yaml
+++ b/prow/config/jobs/common-files-1.13.yaml
@@ -403,8 +403,6 @@ jobs:
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh
   - --labels=release-notes-none
   - --verbose
-  - --
-  - --post=make gen
   - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
   name: update-build-tools-image
   node_selector:


### PR DESCRIPTION
`make gen` uses `prowrtans` which now needs Go 1.18 which these releases don't use (sill using Go 1.17).

I did try and create a go.mod and go.sum for `prowtrans` similar to `prowgen` specifying an older k8s/test-infra but ran into issues with preset file error messages. I did try to pass in --presets with the file, but couldn't get rid of the errors. 

Finally, for simplicity I removed the `make gen` from the automation. The `make gen` didn't seen to actually change anything and if the automation for the few remaining build image updates fails, running them manually might be OK.