### PR TITLE
Manual update-build-tools-image_common-files_release-1.12

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.12.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -339,7 +339,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -380,7 +380,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -482,7 +482,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -542,7 +542,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -604,7 +604,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
           value: istio-private-build/dev
         - name: HELM_BUCKET
           value: istio-private-build/dev/charts
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -135,7 +135,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -205,7 +205,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -279,7 +279,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -347,7 +347,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -417,7 +417,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -483,7 +483,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -551,7 +551,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -623,7 +623,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -695,7 +695,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -769,7 +769,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -835,7 +835,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -903,7 +903,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -975,7 +975,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1049,7 +1049,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1115,7 +1115,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1181,7 +1181,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1255,7 +1255,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1329,7 +1329,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1403,7 +1403,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1477,7 +1477,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1549,7 +1549,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1621,7 +1621,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1693,7 +1693,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1765,7 +1765,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1835,7 +1835,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1908,7 +1908,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1956,7 +1956,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2011,7 +2011,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2062,7 +2062,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2133,7 +2133,7 @@ presubmits:
           value: ' --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2202,7 +2202,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2271,7 +2271,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2340,7 +2340,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2411,7 +2411,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2486,7 +2486,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2555,7 +2555,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2626,7 +2626,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2695,7 +2695,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2764,7 +2764,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2837,7 +2837,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2910,7 +2910,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2985,7 +2985,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3054,7 +3054,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3127,7 +3127,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3202,7 +3202,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3269,7 +3269,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3341,7 +3341,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3407,7 +3407,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3455,7 +3455,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3503,7 +3503,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -92,7 +92,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -144,7 +144,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -244,7 +244,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -344,7 +344,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.12.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -62,7 +62,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -104,7 +104,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -162,7 +162,7 @@ postsubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -211,7 +211,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -297,7 +297,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -216,7 +216,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -70,7 +70,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -188,7 +188,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -235,7 +235,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.12.gen.yaml
@@ -28,7 +28,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -337,7 +337,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -416,7 +416,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -532,7 +532,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -592,7 +592,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -659,7 +659,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -21,7 +21,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+      image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
       name: ""
       resources:
         limits:
@@ -88,7 +88,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -130,7 +130,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -179,7 +179,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -290,7 +290,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -359,7 +359,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -487,7 +487,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -548,7 +548,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -611,7 +611,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -678,7 +678,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -745,7 +745,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -814,7 +814,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -875,7 +875,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -938,7 +938,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1005,7 +1005,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1074,7 +1074,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1135,7 +1135,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1196,7 +1196,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1265,7 +1265,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1334,7 +1334,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1403,7 +1403,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1472,7 +1472,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1539,7 +1539,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1606,7 +1606,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1673,7 +1673,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1740,7 +1740,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1805,7 +1805,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1871,7 +1871,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1912,7 +1912,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -1960,7 +1960,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2004,7 +2004,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2068,7 +2068,7 @@ presubmits:
           value: ' --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2130,7 +2130,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2192,7 +2192,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2254,7 +2254,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2318,7 +2318,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2386,7 +2386,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2448,7 +2448,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2512,7 +2512,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2574,7 +2574,7 @@ presubmits:
           value: "0"
         - name: TEST_SELECT
           value: -postsubmit,-flaky
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2636,7 +2636,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2702,7 +2702,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2768,7 +2768,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2836,7 +2836,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2898,7 +2898,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -2964,7 +2964,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3032,7 +3032,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3092,7 +3092,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3157,7 +3157,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3216,7 +3216,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3257,7 +3257,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3298,7 +3298,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -3348,7 +3348,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -316,7 +316,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
@@ -32,7 +32,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+      image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
       name: ""
       resources:
         limits:
@@ -82,7 +82,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -231,7 +231,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -272,7 +272,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -354,7 +354,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
@@ -31,7 +31,7 @@ periodics:
           secretKeyRef:
             key: key
             name: cosign-key
-      image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+      image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
       name: ""
       resources:
         limits:
@@ -84,7 +84,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -205,7 +205,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -258,7 +258,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -394,7 +394,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -473,7 +473,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -558,7 +558,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.12.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -296,7 +296,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -374,7 +374,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -413,7 +413,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+        image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.12.yaml
+++ b/prow/config/jobs/api-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.12.yaml
+++ b/prow/config/jobs/client-go-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.12.yaml
+++ b/prow/config/jobs/common-files-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/enhancements-1.12.yaml
+++ b/prow/config/jobs/enhancements-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh

--- a/prow/config/jobs/gogo-genproto-1.12.yaml
+++ b/prow/config/jobs/gogo-genproto-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.12.yaml
+++ b/prow/config/jobs/istio-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.12.yaml
+++ b/prow/config/jobs/istio.io-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.12.yaml
+++ b/prow/config/jobs/pkg-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.12.yaml
+++ b/prow/config/jobs/proxy-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools-proxy:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -48,7 +48,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-05-23T15-37-29
+  image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-06-28T09-02-11
   name: release-centos-test
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -86,7 +86,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-05-23T15-37-29
+  image: gcr.io/istio-testing/build-tools-centos:release-1.12-2022-06-28T09-02-11
   name: release-centos
   service_account_name: prowjob-advanced-sa
   node_selector:
@@ -106,7 +106,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+  image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
   name: update-istio
   node_selector:
     testing: build-pool
@@ -127,7 +127,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.20 scripts/update_envoy.sh
-  image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+  image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.12.yaml
+++ b/prow/config/jobs/release-builder-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.12.yaml
+++ b/prow/config/jobs/tools-1.12.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.12
-image: gcr.io/istio-testing/build-tools:release-1.12-2022-05-23T15-37-29
+image: gcr.io/istio-testing/build-tools:release-1.12-2022-06-28T09-02-11
 jobs:
 - command:
   - make


### PR DESCRIPTION
Original job failed: https://prow.istio.io/view/gs/istio-prow/logs/update-build-tools-image_common-files_release-1.12_postsubmit/1541771544378740736

Job fixed, but still need to run manually.

@istio/release-managers-1-12 