### PR TITLE
Manual update-build-tools-image_common-files_release-1.13

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.13.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -339,7 +339,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -380,7 +380,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -482,7 +482,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -542,7 +542,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -604,7 +604,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
           value: istio-private-build/dev
         - name: HELM_BUCKET
           value: istio-private-build/dev/charts
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -133,7 +133,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -413,7 +413,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -483,7 +483,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -549,7 +549,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -615,7 +615,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -683,7 +683,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -755,7 +755,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -827,7 +827,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -901,7 +901,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -967,7 +967,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1035,7 +1035,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1107,7 +1107,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1181,7 +1181,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1247,7 +1247,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1321,7 +1321,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1395,7 +1395,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1469,7 +1469,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1543,7 +1543,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1617,7 +1617,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1691,7 +1691,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1763,7 +1763,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1839,7 +1839,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1911,7 +1911,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1981,7 +1981,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2054,7 +2054,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2102,7 +2102,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2157,7 +2157,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2208,7 +2208,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2275,7 +2275,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2344,7 +2344,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2415,7 +2415,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2490,7 +2490,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2559,7 +2559,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2630,7 +2630,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2697,7 +2697,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2764,7 +2764,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2833,7 +2833,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2906,7 +2906,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2979,7 +2979,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3054,7 +3054,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3121,7 +3121,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3190,7 +3190,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3263,7 +3263,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3338,7 +3338,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3405,7 +3405,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3477,7 +3477,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3543,7 +3543,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3591,7 +3591,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3639,7 +3639,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -92,7 +92,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -144,7 +144,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -244,7 +244,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -344,7 +344,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.13.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -62,7 +62,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -104,7 +104,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -162,7 +162,7 @@ postsubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -211,7 +211,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -297,7 +297,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -216,7 +216,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -70,7 +70,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -188,7 +188,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -235,7 +235,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.13.gen.yaml
@@ -28,7 +28,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -337,7 +337,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -416,7 +416,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -532,7 +532,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -592,7 +592,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -659,7 +659,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -21,7 +21,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+      image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
       name: ""
       resources:
         limits:
@@ -88,7 +88,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -130,7 +130,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -179,7 +179,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -223,7 +223,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -286,7 +286,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -351,7 +351,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -420,7 +420,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -483,7 +483,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -548,7 +548,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -609,7 +609,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -670,7 +670,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -733,7 +733,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -800,7 +800,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -867,7 +867,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -936,7 +936,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -997,7 +997,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1060,7 +1060,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1127,7 +1127,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1196,7 +1196,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1257,7 +1257,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1326,7 +1326,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1395,7 +1395,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1464,7 +1464,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1533,7 +1533,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1602,7 +1602,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1671,7 +1671,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1738,7 +1738,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1809,7 +1809,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1876,7 +1876,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -1941,7 +1941,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2007,7 +2007,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2048,7 +2048,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2096,7 +2096,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2140,7 +2140,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2200,7 +2200,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2262,7 +2262,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2326,7 +2326,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2394,7 +2394,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2456,7 +2456,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2520,7 +2520,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2580,7 +2580,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2640,7 +2640,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2702,7 +2702,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2768,7 +2768,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2834,7 +2834,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2902,7 +2902,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -2962,7 +2962,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3024,7 +3024,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3090,7 +3090,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3158,7 +3158,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3218,7 +3218,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3283,7 +3283,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3342,7 +3342,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3383,7 +3383,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3424,7 +3424,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -3474,7 +3474,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -316,7 +316,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -32,7 +32,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+      image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
       name: ""
       resources:
         limits:
@@ -82,7 +82,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -231,7 +231,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -272,7 +272,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -354,7 +354,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.13.gen.yaml
@@ -31,7 +31,7 @@ periodics:
           secretKeyRef:
             key: key
             name: cosign-key
-      image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+      image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
       name: ""
       resources:
         limits:
@@ -84,7 +84,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -205,7 +205,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -258,7 +258,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -394,7 +394,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -473,7 +473,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -558,7 +558,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.13.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -296,7 +296,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -374,7 +374,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -413,7 +413,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+        image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.13.yaml
+++ b/prow/config/jobs/api-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.13.yaml
+++ b/prow/config/jobs/client-go-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.13.yaml
+++ b/prow/config/jobs/common-files-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/enhancements-1.13.yaml
+++ b/prow/config/jobs/enhancements-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh

--- a/prow/config/jobs/gogo-genproto-1.13.yaml
+++ b/prow/config/jobs/gogo-genproto-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/istio-1.13.yaml
+++ b/prow/config/jobs/istio-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.13.yaml
+++ b/prow/config/jobs/istio.io-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.13.yaml
+++ b/prow/config/jobs/pkg-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.13.yaml
+++ b/prow/config/jobs/proxy-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools-proxy:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -504,7 +504,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-05-12T19-56-46
+  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-06-27T20-35-06
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -884,7 +884,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-05-12T19-56-46
+  image: gcr.io/istio-testing/build-tools-centos:release-1.13-2022-06-27T20-35-06
   name: release-centos
   node_selector:
     testing: build-pool
@@ -1018,7 +1018,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+  image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1153,7 +1153,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.21 scripts/update_envoy.sh
-  image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+  image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.13.yaml
+++ b/prow/config/jobs/release-builder-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.13.yaml
+++ b/prow/config/jobs/tools-1.13.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.13
-image: gcr.io/istio-testing/build-tools:release-1.13-2022-05-12T19-56-46
+image: gcr.io/istio-testing/build-tools:release-1.13-2022-06-27T20-35-06
 jobs:
 - command:
   - make


### PR DESCRIPTION
Original job failed: https://prow.istio.io/view/gs/istio-prow/logs/update-build-tools-image_common-files_release-1.13_postsubmit/1541546683941261312

Job fixed, but still need to run manually.

@istio/release-managers-1-13 