### PR TITLE
1.14: bump images

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1777,7 +1777,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
@@ -1856,7 +1856,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.24.0-beta.0
+        - gcr.io/istio-testing/kind-node:v1.24.0-0.13.0
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER
@@ -1933,7 +1933,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.experimental-dual-stack.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.experimental-dual-stack.gen.yaml
@@ -1666,7 +1666,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1753,7 +1753,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
@@ -1827,7 +1827,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.24.0-beta.0
+        - gcr.io/istio-testing/kind-node:v1.24.0-0.13.0
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER
@@ -1899,7 +1899,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+        - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio-1.14.yaml
+++ b/prow/config/jobs/istio-1.14.yaml
@@ -3773,7 +3773,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - gcr.io/istio-testing/kind-node:v1.24.0-beta.0
+  - gcr.io/istio-testing/kind-node:v1.24.0-0.13.0
   - test.integration.kube
   env:
   - name: INTEGRATION_TEST_FLAGS
@@ -3899,7 +3899,7 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+  - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
   - test.integration.kube
   env:
   - name: INTEGRATION_TEST_FLAGS

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -318,7 +318,7 @@ jobs:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.25.0-alpha.1
+      - gcr.io/istio-testing/kind-node:v1.25.0-alpha.2
       - test.integration.kube
     requirements: [kind]
     modifiers: [hidden] # Hidden until job is stable


### PR DESCRIPTION
This is to mirror master, which is required to update kind, which is
required to test recent versions.