### PR TITLE
Support cluster-per-arch

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -20,6 +20,7 @@ fmt: format-go tidy-go
 
 test:
 	@go test -race ./...
+	@(cd tools/prowgen; go test -race ./...)
 
 gen: generate-config fmt mirror-licenses
 

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -6,6 +6,9 @@ path_aliases:
 node_selector:
   testing: test-pool
 
+cluster_overrides:
+  arm64: istio-prow-build-arm64
+
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"

--- a/tools/prowgen/pkg/generate.go
+++ b/tools/prowgen/pkg/generate.go
@@ -224,7 +224,8 @@ func (cli *Client) ConvertJobConfig(fileName string, jobsConfig spec.JobsConfig,
 		if len(parentJob.Architectures) == 0 {
 			parentJob.Architectures = []string{ArchAMD64}
 		}
-		expandedJobs := decorator.ApplyVariables(parentJob, parentJob.Architectures, jobsConfig.Params, jobsConfig.Matrix)
+
+		expandedJobs := decorator.ApplyVariables(parentJob, parentJob.Architectures, jobsConfig.Params, jobsConfig.Matrix, cli.BaseConfig.ClusterOverrides)
 		for _, job := range expandedJobs {
 			brancher := config.Brancher{
 				Branches: []string{fmt.Sprintf("^%s$", branch)},

--- a/tools/prowgen/pkg/spec/spec.go
+++ b/tools/prowgen/pkg/spec/spec.go
@@ -31,6 +31,8 @@ type BaseConfig struct {
 
 	PathAliases map[string]string `json:"path_aliases,omitempty"`
 
+	ClusterOverrides map[string]string `json:"cluster_overrides,omitempty"`
+
 	TestgridConfig TestgridConfig `json:"testgrid_config,omitempty"`
 }
 

--- a/tools/prowgen/pkg/testdata/.base.yaml
+++ b/tools/prowgen/pkg/testdata/.base.yaml
@@ -6,6 +6,9 @@ path_aliases:
 node_selector:
   testing: test-pool
 
+cluster_overrides:
+  arm64: arm64-cluster
+
 testgrid_config:
   enabled: true
   alert_email: istio-oncall@googlegroups.com

--- a/tools/prowgen/pkg/testdata/simple.gen.yaml
+++ b/tools/prowgen/pkg/testdata/simple.gen.yaml
@@ -348,6 +348,9 @@ presubmits:
       containers:
       - command:
         - prow/command.sh
+        env:
+        - name: key
+          value: value
         image: test
         name: ""
         resources:
@@ -382,6 +385,9 @@ presubmits:
       containers:
       - command:
         - prow/command.sh
+        env:
+        - name: key
+          value: value
         image: test
         name: ""
         resources:
@@ -417,6 +423,9 @@ presubmits:
       - command:
         - prow/command.sh
         - amd64
+        env:
+        - name: key
+          value: value
         image: test
         name: ""
         resources:
@@ -452,6 +461,9 @@ presubmits:
       - command:
         - prow/command.sh
         - arm64
+        env:
+        - name: key
+          value: value
         image: test
         name: ""
         resources:

--- a/tools/prowgen/pkg/testdata/simple.gen.yaml
+++ b/tools/prowgen/pkg/testdata/simple.gen.yaml
@@ -379,6 +379,7 @@ presubmits:
       testgrid-dashboards: gerrit.istio_istio
     branches:
     - ^master$
+    cluster: arm64-cluster
     decorate: true
     name: multi-arch-arm64_istio
     spec:
@@ -454,6 +455,7 @@ presubmits:
       testgrid-dashboards: gerrit.istio_istio
     branches:
     - ^master$
+    cluster: arm64-cluster
     decorate: true
     name: multi-arch-param-arm64_istio
     spec:


### PR DESCRIPTION
Its not always feasible to have multi-arch clusters. Instead, we may need to split them across clusters. This adds that functionality.

Also maake sure prowgen actually runs tests.