### PR TITLE
Normalize config names

### DIFF
--- a/tools/prowtrans/cmd/prowtrans/main.go
+++ b/tools/prowtrans/cmd/prowtrans/main.go
@@ -907,7 +907,7 @@ func getOutPath(o options, p string, in string, branches, branchesOut []string) 
 		if newOrg, ok := o.OrgMap[org]; ok {
 			filename := util.RenameFile(`^`+util.NormalizeOrg(org, filenameSeparator)+`\b`, file, util.NormalizeOrg(newOrg, filenameSeparator))
 			if len(branchesOut) > 0 {
-				filename = strings.ReplaceAll(filename, branches[0], branchesOut[0])
+				filename = util.NormalizeConfigName(strings.ReplaceAll(filename, branches[0], branchesOut[0]))
 			}
 			return filepath.Join(o.Output, util.GetTopLevelOrg(newOrg), repo, filename)
 		}

--- a/tools/prowtrans/pkg/util/strings.go
+++ b/tools/prowtrans/pkg/util/strings.go
@@ -58,6 +58,12 @@ func NormalizeOrg(s, sep string) string {
 	return s
 }
 
+// NormalizeConfigName keeps only alphanumeric characters, '-', '_' or '.' in
+// prow config name.
+func NormalizeConfigName(s string) string {
+	return regexp.MustCompile(`[._-]([^\w]|[_])|([^\w\-_.])`).ReplaceAllString(s, "")
+}
+
 // SortedKeys returns a sorted list of keys for a given map.
 func SortedKeys(m map[string]string) []string {
 	keys := make([]string, 0, len(m))


### PR DESCRIPTION
Prow allows only alphanumeric characters, '-', '_' or '.' in config filename. Since wildcards can be used in `branches-out` the resulting filenames become invalid.
Normalization drops invalid characters and sequences of 2 special characters to keep names sane.