### PR TITLE
Update periodic job for grabing envoy to the 1.23 branch

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -28,7 +28,7 @@ periodics:
       - --labels=auto-merge
       - --modifier=update_envoy_dep
       - --token-path=/etc/github-token/oauth
-      - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
+      - --cmd=UPDATE_BRANCH=release/v1.23 scripts/update_envoy.sh
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -86,7 +86,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
-  - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
+  - --cmd=UPDATE_BRANCH=release/v1.23 scripts/update_envoy.sh
   requirements: [github]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-51808c10f42c7954631d0b926e134d96542eff2f


### PR DESCRIPTION
Temporary until after the 1.15 branch cut happens.

Prevent from making changes in istio/proxy main branch to change in envoy main branch and having to revert them in the 1.15 branch after the cut.