### PR TITLE
arm64: add initial build-tools job with bootstap image

### DIFF
--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -237,7 +237,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
-    cluster: istio-prow-build-arm64
+    cluster: prow-arm
     decorate: true
     name: containers-arm64_tools_postsubmit
     path_alias: istio.io/tools
@@ -588,7 +588,7 @@ presubmits:
       testgrid-dashboards: istio_tools
     branches:
     - ^master$
-    cluster: istio-prow-build-arm64
+    cluster: prow-arm
     decorate: true
     name: containers-test-arm64_tools
     path_alias: istio.io/tools

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -195,6 +195,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: MANIFEST_ARCH
+          value: arm64 amd64
         image: gcr.io/istio-testing/build-tools:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
         name: ""
         resources:
@@ -217,6 +219,61 @@ postsubmits:
           readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
+        testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root
+      - name: github
+        secret:
+          secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_tools_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: containers-arm64_tools_postsubmit
+    path_alias: istio.io/tools
+    run_if_changed: docker/.+|cmd/.+
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - containers
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: MANIFEST_ARCH
+        image: gcr.io/istio-testing/build-tools:master-arm64-boostrap
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 4Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: test-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -583,3 +583,50 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_tools
+    branches:
+    - ^master$
+    cluster: istio-prow-build-arm64
+    decorate: true
+    name: containers-test-arm64_tools
+    path_alias: istio.io/tools
+    run_if_changed: docker/.+|cmd/.+
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - containers-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-arm64-boostrap
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "8"
+            memory: 4Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -7,7 +7,7 @@ node_selector:
   testing: test-pool
 
 cluster_overrides:
-  arm64: istio-prow-build-arm64
+  arm64: prow-arm
 
 env:
 - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -27,6 +27,7 @@ jobs:
         value: "True"
     modifiers: [presubmit_optional]
 
+  # amd64 build
   - name: containers
     service_account_name: prowjob-advanced-sa
     types: [postsubmit]
@@ -44,6 +45,29 @@ jobs:
     regex: 'docker/.+|cmd/.+'
     requirements: [docker, github]
     repos: [istio/test-infra@master,istio/common-files@master]
+    env:
+    # For amd64, publish the manifest for arm64+amd64
+    - name: MANIFEST_ARCH
+      value: "arm64 amd64"
+  # arm64 build
+  - name: containers
+    service_account_name: prowjob-advanced-sa
+    architectures: [arm64]
+    types: [postsubmit]
+    command:
+    - entrypoint
+    - make
+    - containers
+    env:
+    # For arm64, we do not generate the manifest; the amd job will handle it
+    - name: MANIFEST_ARCH
+      value: ""
+    resources: build
+    regex: 'docker/.+|cmd/.+'
+    requirements: [docker, github]
+    # TODO: remove this
+    # The first run needs a bootstrap image since we need this job to produce the multi-arch image
+    image: gcr.io/istio-testing/build-tools:master-arm64-boostrap
 
   - name: containers-test
     service_account_name: prowjob-advanced-sa

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -76,6 +76,17 @@ jobs:
     resources: build
     regex: 'docker/.+|cmd/.+'
     requirements: [docker]
+  - name: containers-test
+    architectures: [arm64]
+    service_account_name: prowjob-advanced-sa
+    types: [presubmit]
+    command: [entrypoint, make, containers-test]
+    resources: build
+    regex: 'docker/.+|cmd/.+'
+    requirements: [docker]
+    # TODO: remove this
+    # The first run needs a bootstrap image since we need this job to produce the multi-arch image
+    image: gcr.io/istio-testing/build-tools:master-arm64-boostrap
 
   - name: deploy-perf-dashboard
     service_account_name: prowjob-advanced-sa


### PR DESCRIPTION
This sets up the initial build. We need a bootstrap image at first,
since we have a circular dependency