### PR TITLE
proxy: add arm64 jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -95,7 +95,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -116,6 +116,11 @@ postsubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -256,7 +261,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -275,6 +280,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -356,7 +366,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -375,6 +385,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -456,7 +471,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -475,6 +490,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -558,7 +578,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -577,6 +597,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -72,6 +72,68 @@ postsubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+    name: release-arm64_proxy_postsubmit_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - ./prow/proxy-postsubmit.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: DOCKER_REPOSITORY
+          value: istio-prow-build/envoy
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        - name: GCS_ARTIFACTS_BUCKET
+          value: istio-private-artifacts
+        - name: GCS_BUILD_BUCKET
+          value: istio-private-build
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
     name: release-centos_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -180,6 +242,56 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+    name: test-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit.sh
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
     name: test-asan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -211,6 +323,56 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: amd64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
+    name: test-asan-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-asan.sh
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:
@@ -280,6 +442,56 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
+    name: test-tsan-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-tsan.sh
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
     name: release-test_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -311,6 +523,58 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: amd64
+        testing: build-pool
+      serviceAccountName: prowjob-private-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-enable-netrc: "true"
+    name: release-test-arm64_proxy_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-release.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
       volumes:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -132,7 +132,7 @@ postsubmits:
           value: arm64
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -153,6 +153,11 @@ postsubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -323,7 +328,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -342,6 +347,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -406,7 +416,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -425,6 +435,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -489,7 +504,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -508,6 +523,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -574,7 +594,7 @@ presubmits:
           value: arm64
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
           limits:
@@ -593,6 +613,11 @@ presubmits:
         kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -116,6 +116,56 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
+    cluster: prow-arm
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: release-arm64_proxy_postsubmit
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - ./prow/proxy-postsubmit.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_proxy_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -260,6 +310,48 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
+    cluster: prow-arm
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: test-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit.sh
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -289,6 +381,48 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: amd64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
+    cluster: prow-arm
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: test-asan-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-asan.sh
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:
@@ -342,6 +476,48 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
+    cluster: prow-arm
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: test-tsan-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-tsan.sh
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -371,6 +547,50 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: amd64
+        testing: build-pool
+      serviceAccountName: prowjob-advanced-sa
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_proxy
+    branches:
+    - ^master$
+    cluster: prow-arm
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: release-test-arm64_proxy
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ./prow/proxy-presubmit-release.sh
+        env:
+        - name: ARCH_SUFFIX
+          value: arm64
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools-proxy:master-6154f6f0de07b3b1d5fccb7b3c2bcc6ff59bafee
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+      nodeSelector:
+        kubernetes.io/arch: arm64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
       volumes:

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -7,24 +7,36 @@ node_selector:
 
 jobs:
 - name: test
+  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 4h
 
 - name: test-asan
+  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
   timeout: 4h
 
 - name: test-tsan
+  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-tsan.sh]
   timeout: 4h
 
 - name: release-test
+  service_account_name: prowjob-advanced-sa
+  types: [presubmit]
+  command: [./prow/proxy-presubmit-release.sh]
+  timeout: 4h
+- name: release-test
+  architectures: [arm64]
+  env:
+  - name: ARCH_SUFFIX
+    value: $(params.arch)
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
@@ -45,6 +57,16 @@ jobs:
   timeout: 4h
 
 - name: release
+  service_account_name: prowjob-advanced-sa
+  types: [postsubmit]
+  command: [entrypoint, ./prow/proxy-postsubmit.sh]
+  requirements: [docker]
+  timeout: 4h
+- name: release
+  architectures: [arm64]
+  env:
+  - name: ARCH_SUFFIX
+    value: $(params.arch)
   service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]


### PR DESCRIPTION
This adds a few arm64 jobs, mirroring the amd64 ones:
* test, with tsan and asan
* release presubmit check and postsubmit publish