### PR TITLE
proxy: fix arm builds

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -395,6 +395,7 @@ presubmits:
     labels:
       preset-enable-netrc: "true"
     name: release-test-arm64_proxy_master_priv
+    optional: true
     path_alias: istio.io/proxy
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -98,12 +98,9 @@ postsubmits:
         image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
-          limits:
-            cpu: "64"
-            memory: 240G
           requests:
-            cpu: "30"
-            memory: 100G
+            cpu: "4"
+            memory: 16G
         securityContext:
           privileged: true
         volumeMounts:
@@ -114,7 +111,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: arm64
-        testing: build-pool
+        testing: test-pool
       serviceAccountName: prowjob-private-sa
       tolerations:
       - effect: NoSchedule
@@ -247,61 +244,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-    name: test-arm64_proxy_master_priv
-    path_alias: istio.io/proxy
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-presubmit.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        - name: BAZEL_BUILD_RBE_INSTANCE
-        - name: ENVOY_PREFIX
-          value: envoy
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
-        name: ""
-        resources:
-          limits:
-            cpu: "64"
-            memory: 240G
-          requests:
-            cpu: "30"
-            memory: 100G
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      nodeSelector:
-        kubernetes.io/arch: arm64
-        testing: build-pool
-      serviceAccountName: prowjob-private-sa
-      tolerations:
-      - effect: NoSchedule
-        key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/proxy.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-enable-netrc: "true"
     name: test-asan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -352,61 +294,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-enable-netrc: "true"
-    name: test-asan-arm64_proxy_master_priv
-    path_alias: istio.io/proxy
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-presubmit-asan.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        - name: BAZEL_BUILD_RBE_INSTANCE
-        - name: ENVOY_PREFIX
-          value: envoy
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
-        name: ""
-        resources:
-          limits:
-            cpu: "64"
-            memory: 240G
-          requests:
-            cpu: "30"
-            memory: 100G
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      nodeSelector:
-        kubernetes.io/arch: arm64
-        testing: build-pool
-      serviceAccountName: prowjob-private-sa
-      tolerations:
-      - effect: NoSchedule
-        key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/proxy.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-enable-netrc: "true"
     name: test-tsan_proxy_master_priv
     path_alias: istio.io/proxy
     spec:
@@ -440,61 +327,6 @@ presubmits:
         kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-private-sa
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    branches:
-    - ^master$
-    clone_uri: git@github.com:istio-private/proxy.git
-    cluster: private
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-enable-netrc: "true"
-    name: test-tsan-arm64_proxy_master_priv
-    path_alias: istio.io/proxy
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-presubmit-tsan.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        - name: BAZEL_BUILD_RBE_INSTANCE
-        - name: ENVOY_PREFIX
-          value: envoy
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
-        name: ""
-        resources:
-          limits:
-            cpu: "64"
-            memory: 240G
-          requests:
-            cpu: "30"
-            memory: 100G
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      nodeSelector:
-        kubernetes.io/arch: arm64
-        testing: build-pool
-      serviceAccountName: prowjob-private-sa
-      tolerations:
-      - effect: NoSchedule
-        key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -581,12 +413,9 @@ presubmits:
         image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
-          limits:
-            cpu: "64"
-            memory: 240G
           requests:
-            cpu: "30"
-            memory: 100G
+            cpu: "4"
+            memory: 16G
         securityContext:
           privileged: true
         volumeMounts:
@@ -595,7 +424,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: arm64
-        testing: build-pool
+        testing: test-pool
       serviceAccountName: prowjob-private-sa
       tolerations:
       - effect: NoSchedule

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -440,6 +440,7 @@ presubmits:
     decoration_config:
       timeout: 4h0m0s
     name: release-test-arm64_proxy
+    optional: true
     path_alias: istio.io/proxy
     spec:
       containers:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -135,12 +135,9 @@ postsubmits:
         image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
-          limits:
-            cpu: "64"
-            memory: 240G
           requests:
-            cpu: "30"
-            memory: 100G
+            cpu: "4"
+            memory: 16G
         securityContext:
           privileged: true
         volumeMounts:
@@ -151,7 +148,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: arm64
-        testing: build-pool
+        testing: test-pool
       serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule
@@ -315,53 +312,6 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
-    cluster: prow-arm
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    name: test-arm64_proxy
-    path_alias: istio.io/proxy
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-presubmit.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
-        name: ""
-        resources:
-          limits:
-            cpu: "64"
-            memory: 240G
-          requests:
-            cpu: "30"
-            memory: 100G
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      nodeSelector:
-        kubernetes.io/arch: arm64
-        testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
-      tolerations:
-      - effect: NoSchedule
-        key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_proxy
-    branches:
-    - ^master$
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -403,53 +353,6 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
-    cluster: prow-arm
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    name: test-asan-arm64_proxy
-    path_alias: istio.io/proxy
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-presubmit-asan.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
-        name: ""
-        resources:
-          limits:
-            cpu: "64"
-            memory: 240G
-          requests:
-            cpu: "30"
-            memory: 100G
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      nodeSelector:
-        kubernetes.io/arch: arm64
-        testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
-      tolerations:
-      - effect: NoSchedule
-        key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_proxy
-    branches:
-    - ^master$
     decorate: true
     decoration_config:
       timeout: 4h0m0s
@@ -481,53 +384,6 @@ presubmits:
         kubernetes.io/arch: amd64
         testing: build-pool
       serviceAccountName: prowjob-advanced-sa
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - always_run: true
-    annotations:
-      testgrid-dashboards: istio_proxy
-    branches:
-    - ^master$
-    cluster: prow-arm
-    decorate: true
-    decoration_config:
-      timeout: 4h0m0s
-    name: test-tsan-arm64_proxy
-    path_alias: istio.io/proxy
-    spec:
-      containers:
-      - command:
-        - ./prow/proxy-presubmit-tsan.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
-        name: ""
-        resources:
-          limits:
-            cpu: "64"
-            memory: 240G
-          requests:
-            cpu: "30"
-            memory: 100G
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      nodeSelector:
-        kubernetes.io/arch: arm64
-        testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
-      tolerations:
-      - effect: NoSchedule
-        key: kubernetes.io/arch
-        operator: Equal
-        value: arm64
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -597,12 +453,9 @@ presubmits:
         image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7
         name: ""
         resources:
-          limits:
-            cpu: "64"
-            memory: 240G
           requests:
-            cpu: "30"
-            memory: 100G
+            cpu: "4"
+            memory: 16G
         securityContext:
           privileged: true
         volumeMounts:
@@ -611,7 +464,7 @@ presubmits:
           subPath: gomod
       nodeSelector:
         kubernetes.io/arch: arm64
-        testing: build-pool
+        testing: test-pool
       serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -31,6 +31,7 @@ jobs:
   timeout: 4h
 - name: release-test
   architectures: [arm64]
+  modifiers: [presubmit_optional]
   env:
   - name: ARCH_SUFFIX
     value: $(params.arch)

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -7,21 +7,18 @@ node_selector:
 
 jobs:
 - name: test
-  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 4h
 
 - name: test-asan
-  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
   timeout: 4h
 
 - name: test-tsan
-  architectures: [amd64, arm64]
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-tsan.sh]
@@ -41,6 +38,10 @@ jobs:
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
   timeout: 4h
+  # TODO: get build-pool for arm
+  resources: arm
+  node_selector:
+    testing: test-pool
 
 - name: release-centos-test
   service_account_name: prowjob-advanced-sa
@@ -72,6 +73,10 @@ jobs:
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
   timeout: 4h
+  # TODO: get build-pool for arm
+  resources: arm
+  node_selector:
+    testing: test-pool
 
 - name: release-centos
   service_account_name: prowjob-advanced-sa
@@ -122,3 +127,8 @@ resources_presets:
     limits:
       memory: "240G"
       cpu: "64"
+  # Currently our ARM nodes are tiny while we try to get more capacity
+  arm:
+    requests:
+      memory: "16G"
+      cpu: "4"


### PR DESCRIPTION
We need more capacity to do the original plan. instead, just run release
only for now with small nodes. Once we get more capacity we can expand
to the full set