### PR TITLE
Fix minor issue on arm64 proxy builds

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -404,6 +404,8 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BUILD_ENVOY_BINARY_ONLY
+          value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: BAZEL_BUILD_RBE_INSTANCE

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -449,6 +449,8 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BUILD_ENVOY_BINARY_ONLY
+          value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
         image: gcr.io/istio-testing/build-tools-proxy:master-88a79b0889d7cefe8cefd4cd3cf051c626efb2d7

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -35,6 +35,8 @@ jobs:
   env:
   - name: ARCH_SUFFIX
     value: $(params.arch)
+  - name: BUILD_ENVOY_BINARY_ONLY
+    value: "1"
   service_account_name: prowjob-advanced-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]


### PR DESCRIPTION
We need to explicitly opt out of building things like wasm, etc