### PR TITLE
Manual update_image of latest 1.14 build-tools image

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.14.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -339,7 +339,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -380,7 +380,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -482,7 +482,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -542,7 +542,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -604,7 +604,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
           value: istio-private-build/dev
         - name: HELM_BUCKET
           value: istio-private-build/dev/charts
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -133,7 +133,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -273,7 +273,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -417,7 +417,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -488,7 +488,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -555,7 +555,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -622,7 +622,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -691,7 +691,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -764,7 +764,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -837,7 +837,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -912,7 +912,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -979,7 +979,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1048,7 +1048,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1121,7 +1121,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1196,7 +1196,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1263,7 +1263,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1338,7 +1338,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1413,7 +1413,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1488,7 +1488,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1563,7 +1563,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1638,7 +1638,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1713,7 +1713,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1786,7 +1786,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1863,7 +1863,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1940,7 +1940,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2013,7 +2013,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2084,7 +2084,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2158,7 +2158,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2206,7 +2206,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2261,7 +2261,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2312,7 +2312,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2380,7 +2380,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2450,7 +2450,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2522,7 +2522,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2598,7 +2598,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2668,7 +2668,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2740,7 +2740,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2808,7 +2808,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2876,7 +2876,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2946,7 +2946,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3020,7 +3020,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3094,7 +3094,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3170,7 +3170,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3238,7 +3238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3308,7 +3308,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3382,7 +3382,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3458,7 +3458,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3526,7 +3526,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3599,7 +3599,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3666,7 +3666,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3715,7 +3715,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3763,7 +3763,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.14.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -92,7 +92,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-centos:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -144,7 +144,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -194,7 +194,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -244,7 +244,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -294,7 +294,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -344,7 +344,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-centos:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.14.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -62,7 +62,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -104,7 +104,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -162,7 +162,7 @@ postsubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -211,7 +211,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -297,7 +297,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -216,7 +216,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -70,7 +70,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -190,7 +190,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.14.gen.yaml
@@ -28,7 +28,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -337,7 +337,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -416,7 +416,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -532,7 +532,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -592,7 +592,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -659,7 +659,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
@@ -21,7 +21,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+      image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
       name: ""
       resources:
         limits:
@@ -89,7 +89,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -131,7 +131,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -180,7 +180,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -224,7 +224,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -354,7 +354,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -424,7 +424,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -488,7 +488,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -554,7 +554,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -616,7 +616,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -678,7 +678,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -742,7 +742,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -810,7 +810,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -878,7 +878,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -948,7 +948,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1010,7 +1010,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1074,7 +1074,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1142,7 +1142,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1212,7 +1212,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1274,7 +1274,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1344,7 +1344,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1414,7 +1414,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1484,7 +1484,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1554,7 +1554,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1624,7 +1624,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1694,7 +1694,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1762,7 +1762,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1834,7 +1834,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1906,7 +1906,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -1974,7 +1974,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2040,7 +2040,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2107,7 +2107,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2148,7 +2148,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2196,7 +2196,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2240,7 +2240,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2301,7 +2301,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2364,7 +2364,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2429,7 +2429,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2498,7 +2498,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2561,7 +2561,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2626,7 +2626,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2687,7 +2687,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2748,7 +2748,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2811,7 +2811,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2878,7 +2878,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -2945,7 +2945,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3014,7 +3014,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3075,7 +3075,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3138,7 +3138,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3205,7 +3205,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3274,7 +3274,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.istio.istiodlessRemotes
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3335,7 +3335,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3401,7 +3401,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3461,7 +3461,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3503,7 +3503,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3544,7 +3544,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -3595,7 +3595,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -316,7 +316,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.14.gen.yaml
@@ -32,7 +32,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+      image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
       name: ""
       resources:
         limits:
@@ -82,7 +82,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-centos:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -231,7 +231,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -272,7 +272,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -354,7 +354,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -395,7 +395,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-centos:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.14.gen.yaml
@@ -31,7 +31,7 @@ periodics:
           secretKeyRef:
             key: key
             name: cosign-key
-      image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+      image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
       name: ""
       resources:
         limits:
@@ -84,7 +84,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -205,7 +205,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -258,7 +258,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ postsubmits:
             secretKeyRef:
               key: key
               name: cosign-key
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -394,7 +394,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -473,7 +473,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -558,7 +558,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.14.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -195,7 +195,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -296,7 +296,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -335,7 +335,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -374,7 +374,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -413,7 +413,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+        image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.14.yaml
+++ b/prow/config/jobs/api-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.14.yaml
+++ b/prow/config/jobs/client-go-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.14.yaml
+++ b/prow/config/jobs/common-files-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make

--- a/prow/config/jobs/enhancements-1.14.yaml
+++ b/prow/config/jobs/enhancements-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh

--- a/prow/config/jobs/istio-1.14.yaml
+++ b/prow/config/jobs/istio-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - entrypoint

--- a/prow/config/jobs/istio.io-1.14.yaml
+++ b/prow/config/jobs/istio.io-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.14.yaml
+++ b/prow/config/jobs/pkg-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.14.yaml
+++ b/prow/config/jobs/proxy-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools-proxy:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools-proxy:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -392,7 +392,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+  image: gcr.io/istio-testing/build-tools-centos:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -688,7 +688,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+  image: gcr.io/istio-testing/build-tools-centos:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
   name: release-centos
   node_selector:
     testing: build-pool
@@ -794,7 +794,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+  image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
   name: update-istio
   node_selector:
     testing: build-pool
@@ -901,7 +901,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=release/v1.22 scripts/update_envoy.sh
-  image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+  image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.14.yaml
+++ b/prow/config/jobs/release-builder-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.14.yaml
+++ b/prow/config/jobs/tools-1.14.yaml
@@ -1,6 +1,6 @@
 branches:
 - release-1.14
-image: gcr.io/istio-testing/build-tools:release-1.14-4ccccb9c73fd9fe0d3b32d31738c8bb16c6b849d
+image: gcr.io/istio-testing/build-tools:release-1.14-0c4413d13921234efc115a6acc7097c47de0e815
 jobs:
 - command:
   - make


### PR DESCRIPTION
The automated job runs and want to add a lot of license files (which then fails the gencheck test). Running the job locally does not want to add these files.

This is a manual PR updating the build tools image.

This supersedes https://github.com/istio/test-infra/pull/4209