### PR TITLE
Update the release-1.15 jobs to point to a 1.15 image

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.15.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -120,7 +120,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -339,7 +339,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -380,7 +380,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -482,7 +482,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -542,7 +542,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -604,7 +604,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.15.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
           value: istio-private-build/dev
         - name: HELM_BUCKET
           value: istio-private-build/dev/charts
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -260,7 +260,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -333,7 +333,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -402,7 +402,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -473,7 +473,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -612,7 +612,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -679,7 +679,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -748,7 +748,7 @@ postsubmits:
           value: "0"
         - name: GRPC_ECHO_IMAGE
           value: grpctesting/istio_echo_cpp
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -817,7 +817,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -890,7 +890,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -963,7 +963,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1030,7 +1030,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1099,7 +1099,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1172,7 +1172,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1239,7 +1239,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1314,7 +1314,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1389,7 +1389,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1464,7 +1464,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1539,7 +1539,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1614,7 +1614,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1689,7 +1689,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1764,7 +1764,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1837,7 +1837,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1914,7 +1914,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1987,7 +1987,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2058,7 +2058,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2132,7 +2132,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2185,7 +2185,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2239,7 +2239,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2294,7 +2294,7 @@ presubmits:
           value: "0"
         - name: DOCKER_ARCHITECTURES
           value: linux/amd64,linux/arm64
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2349,7 +2349,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2400,7 +2400,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2468,7 +2468,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2538,7 +2538,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2612,7 +2612,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2682,7 +2682,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2754,7 +2754,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2822,7 +2822,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2895,7 +2895,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2963,7 +2963,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3033,7 +3033,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3107,7 +3107,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3181,7 +3181,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3249,7 +3249,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3319,7 +3319,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3393,7 +3393,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3461,7 +3461,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3534,7 +3534,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3601,7 +3601,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3650,7 +3650,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3698,7 +3698,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.15.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           requests:
@@ -158,7 +158,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-centos:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -210,7 +210,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -260,7 +260,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -360,7 +360,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -415,7 +415,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           requests:
@@ -467,7 +467,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-centos:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.15.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -62,7 +62,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -104,7 +104,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -241,7 +241,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -284,7 +284,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -327,7 +327,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -375,7 +375,7 @@ presubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -216,7 +216,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -255,7 +255,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -70,7 +70,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -128,7 +128,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -190,7 +190,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.15.gen.yaml
@@ -28,7 +28,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -99,7 +99,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -158,7 +158,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -337,7 +337,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -416,7 +416,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -532,7 +532,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -592,7 +592,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -659,7 +659,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
@@ -21,7 +21,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+      image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
       name: ""
       resources:
         limits:
@@ -89,7 +89,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -137,7 +137,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -185,7 +185,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -234,7 +234,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -342,7 +342,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -410,7 +410,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -603,7 +603,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -670,7 +670,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -732,7 +732,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -796,7 +796,7 @@ postsubmits:
           value: "0"
         - name: GRPC_ECHO_IMAGE
           value: grpctesting/istio_echo_cpp
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -860,7 +860,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -928,7 +928,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -996,7 +996,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1058,7 +1058,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1122,7 +1122,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1190,7 +1190,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1252,7 +1252,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1322,7 +1322,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1392,7 +1392,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1462,7 +1462,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1532,7 +1532,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1602,7 +1602,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1672,7 +1672,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1742,7 +1742,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1810,7 +1810,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1882,7 +1882,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -1950,7 +1950,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2016,7 +2016,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2102,7 +2102,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2185,7 +2185,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2232,7 +2232,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2279,7 +2279,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2327,7 +2327,7 @@ presubmits:
           value: "0"
         - name: DOCKER_ARCHITECTURES
           value: linux/amd64,linux/arm64
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2375,7 +2375,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2419,7 +2419,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2480,7 +2480,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2543,7 +2543,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2610,7 +2610,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2673,7 +2673,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2738,7 +2738,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2800,7 +2800,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2866,7 +2866,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2927,7 +2927,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -2990,7 +2990,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3057,7 +3057,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3124,7 +3124,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3185,7 +3185,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3248,7 +3248,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3315,7 +3315,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3376,7 +3376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3442,7 +3442,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3502,7 +3502,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3544,7 +3544,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3585,7 +3585,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -3636,7 +3636,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -191,7 +191,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -277,7 +277,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -316,7 +316,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.15.gen.yaml
@@ -32,7 +32,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+      image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
       name: ""
       resources:
         limits:
@@ -82,7 +82,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -134,7 +134,7 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           requests:
@@ -182,7 +182,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-centos:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -326,7 +326,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -367,7 +367,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -408,7 +408,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -455,7 +455,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           requests:
@@ -498,7 +498,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-centos:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.15.gen.yaml
@@ -37,7 +37,7 @@ periodics:
         value: /etc/grafana/token
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/rel-pipeline-service-account.json
-      image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+      image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
       name: ""
       resources:
         limits:
@@ -113,7 +113,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -153,7 +153,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -234,7 +234,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -293,7 +293,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -374,7 +374,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -442,7 +442,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -481,7 +481,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -520,7 +520,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -560,7 +560,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -605,7 +605,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -645,7 +645,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.15.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -98,7 +98,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -138,7 +138,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -197,7 +197,7 @@ postsubmits:
           value: "0"
         - name: MANIFEST_ARCH
           value: arm64 amd64
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -252,7 +252,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: MANIFEST_ARCH
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -306,7 +306,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -352,7 +352,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -391,7 +391,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -430,7 +430,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -469,7 +469,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -510,7 +510,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:
@@ -557,7 +557,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+        image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.15.yaml
+++ b/prow/config/jobs/api-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build
   node_selector:
     testing: test-pool
@@ -146,7 +146,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -283,7 +283,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update_api_dep_client_go
   node_selector:
     testing: test-pool
@@ -426,7 +426,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update_api_dep_istio
   node_selector:
     testing: test-pool
@@ -562,7 +562,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/config/jobs/client-go-1.15.yaml
+++ b/prow/config/jobs/client-go-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build
   node_selector:
     testing: test-pool
@@ -146,7 +146,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -277,7 +277,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -416,7 +416,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update_client-go_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/common-files-1.15.yaml
+++ b/prow/config/jobs/common-files-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -153,7 +153,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update-common
   node_selector:
     testing: test-pool
@@ -296,7 +296,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -443,7 +443,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements-1.15.yaml
+++ b/prow/config/jobs/enhancements-1.15.yaml
@@ -16,7 +16,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/config/jobs/istio-1.15.yaml
+++ b/prow/config/jobs/istio-1.15.yaml
@@ -20,7 +20,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -179,7 +179,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_skipped
   name: unit-tests
@@ -332,7 +332,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release-test
   node_selector:
     testing: test-pool
@@ -490,7 +490,7 @@ jobs:
     value: "0"
   - name: DOCKER_ARCHITECTURES
     value: linux/amd64,linux/arm64
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_skipped
   name: release-test-multiarch
@@ -648,7 +648,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release
   node_selector:
     testing: test-pool
@@ -805,7 +805,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -964,7 +964,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: benchmark-report
   node_selector:
     testing: test-pool
@@ -1122,7 +1122,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -1277,7 +1277,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -1432,7 +1432,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-telemetry-mc
   node_selector:
     testing: test-pool
@@ -1592,7 +1592,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
@@ -1748,7 +1748,7 @@ jobs:
     value: "0"
   - name: VARIANT
     value: distroless
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -1905,7 +1905,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-ipv6
   node_selector:
     testing: test-pool
@@ -2060,7 +2060,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_skipped
   name: integ-basic
@@ -2215,7 +2215,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-operator-controller
   node_selector:
     testing: test-pool
@@ -2368,7 +2368,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -2523,7 +2523,7 @@ jobs:
     value: "0"
   - name: GRPC_ECHO_IMAGE
     value: grpctesting/istio_echo_cpp
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-pilot-cpp
   node_selector:
     testing: test-pool
@@ -2680,7 +2680,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -2840,7 +2840,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
@@ -3000,7 +3000,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
@@ -3154,7 +3154,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-security
   node_selector:
     testing: test-pool
@@ -3308,7 +3308,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -3465,7 +3465,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -3625,7 +3625,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-security-istiodremote
   node_selector:
     testing: test-pool
@@ -3779,7 +3779,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -3938,7 +3938,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-116
   node_selector:
     testing: test-pool
@@ -4100,7 +4100,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-117
   node_selector:
     testing: test-pool
@@ -4262,7 +4262,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-118
   node_selector:
     testing: test-pool
@@ -4424,7 +4424,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-119
   node_selector:
     testing: test-pool
@@ -4586,7 +4586,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-120
   node_selector:
     testing: test-pool
@@ -4748,7 +4748,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-121
   node_selector:
     testing: test-pool
@@ -4910,7 +4910,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-122
   node_selector:
     testing: test-pool
@@ -5070,7 +5070,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-k8s-123
   node_selector:
     testing: test-pool
@@ -5230,7 +5230,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - hidden
   name: integ-k8s-125
@@ -5392,7 +5392,7 @@ jobs:
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -5550,7 +5550,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -5706,7 +5706,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: analyze-tests
   node_selector:
     testing: test-pool
@@ -5859,7 +5859,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -6013,7 +6013,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -6166,7 +6166,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release-notes
   node_selector:
     testing: test-pool
@@ -6329,7 +6329,7 @@ jobs:
     value: master
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.io-1.15.yaml
+++ b/prow/config/jobs/istio.io-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -153,7 +153,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -292,7 +292,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: doc.test.profile_default
   node_selector:
     testing: test-pool
@@ -432,7 +432,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: doc.test.profile_demo
   node_selector:
     testing: test-pool
@@ -572,7 +572,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: doc.test.profile_none
   node_selector:
     testing: test-pool
@@ -714,7 +714,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -857,7 +857,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/config/jobs/pkg-1.15.yaml
+++ b/prow/config/jobs/pkg-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build
   node_selector:
     testing: test-pool
@@ -146,7 +146,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -277,7 +277,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: test
   node_selector:
     testing: test-pool
@@ -408,7 +408,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -546,7 +546,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update_pkg_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/proxy-1.15.yaml
+++ b/prow/config/jobs/proxy-1.15.yaml
@@ -14,7 +14,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: test
   node_selector:
     testing: build-pool
@@ -152,7 +152,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: test-asan
   node_selector:
     testing: build-pool
@@ -290,7 +290,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: test-tsan
   node_selector:
     testing: build-pool
@@ -428,7 +428,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release-test
   node_selector:
     testing: build-pool
@@ -572,7 +572,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   name: release-test
@@ -713,7 +713,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-centos:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-centos:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -852,7 +852,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: check-wasm
   node_selector:
     testing: build-pool
@@ -992,7 +992,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release
   node_selector:
     testing: build-pool
@@ -1138,7 +1138,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release
   node_selector:
     testing: test-pool
@@ -1278,7 +1278,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-centos:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools-centos:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: release-centos
   node_selector:
     testing: build-pool
@@ -1424,7 +1424,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1571,7 +1571,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.15.yaml
+++ b/prow/config/jobs/release-builder-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -153,7 +153,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: test
   node_selector:
     testing: test-pool
@@ -291,7 +291,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -429,7 +429,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: dry-run
   node_selector:
     testing: test-pool
@@ -570,7 +570,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -712,7 +712,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -855,7 +855,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build-release
   node_selector:
     testing: test-pool
@@ -999,7 +999,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: publish-release
   node_selector:
     testing: test-pool
@@ -1148,7 +1148,7 @@ jobs:
     value: "true"
   - name: VERSION
     value: master
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/tools-1.15.yaml
+++ b/prow/config/jobs/tools-1.15.yaml
@@ -15,7 +15,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: build
   node_selector:
     testing: test-pool
@@ -153,7 +153,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: lint
   node_selector:
     testing: test-pool
@@ -291,7 +291,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: test
   node_selector:
     testing: test-pool
@@ -429,7 +429,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: gencheck
   node_selector:
     testing: test-pool
@@ -576,7 +576,7 @@ jobs:
     value: "0"
   - name: MANIFEST_ARCH
     value: arm64 amd64
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: containers
   node_selector:
     testing: test-pool
@@ -728,7 +728,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   - name: MANIFEST_ARCH
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: containers
   node_selector:
     testing: test-pool
@@ -873,7 +873,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: containers-test
   node_selector:
     testing: test-pool
@@ -1020,7 +1020,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: containers-test
   node_selector:
     testing: test-pool
@@ -1167,7 +1167,7 @@ jobs:
     value: "0"
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:master-700d1817d60f98e7d70ee9ec673b275486702ebc
+  image: gcr.io/istio-testing/build-tools:release-1.15-700d1817d60f98e7d70ee9ec673b275486702ebc
   name: deploy-perf-dashboard
   node_selector:
     testing: test-pool


### PR DESCRIPTION
The Step 3 job did not update the image names as desired because the branch job used the old branch-date regxx and not a newer regex that included branch-sha.

@Monkeyanator did update the regex so the new image was created but the Step 3 PR still used the old image. This PR includes the changes to the new branch image.