### PR TITLE
Update 1.15 jobs to call out 1.15 instead of master.

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
@@ -2088,7 +2088,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: VERSION
-          value: master
+          value: "1.15"
         - name: COSIGN_KEY
           valueFrom:
             secretKeyRef:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.15.gen.yaml
@@ -23,7 +23,7 @@ periodics:
       - name: BUILD_WITH_CONTAINER
         value: "0"
       - name: VERSION
-        value: master
+        value: "1.15"
       - name: COSIGN_KEY
         valueFrom:
           secretKeyRef:

--- a/prow/config/jobs/istio-1.15.yaml
+++ b/prow/config/jobs/istio-1.15.yaml
@@ -6162,7 +6162,7 @@ jobs:
   - name: BUILD_BASE_IMAGES
     value: "true"
   - name: VERSION
-    value: master
+    value: "1.15"
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
   image: gcr.io/istio-testing/build-tools:release-1.15-eaecd8e21b6ca1b09e720b1ace44f919930a3fd1

--- a/prow/config/jobs/release-builder-1.15.yaml
+++ b/prow/config/jobs/release-builder-1.15.yaml
@@ -1147,7 +1147,7 @@ jobs:
   - name: BUILD_BASE_IMAGES
     value: "true"
   - name: VERSION
-    value: master
+    value: "1.15"
   image: gcr.io/istio-testing/build-tools:release-1.15-eaecd8e21b6ca1b09e720b1ace44f919930a3fd1
   name: build-base-images
   node_selector:


### PR DESCRIPTION
One thing I notice in the files is there are duplicate env `  - name: BUILD_WITH_CONTAINER` lines.

Also curious about lines like:
```
  repos:
  - istio/release-builder@master
  ```
And if those should be updated to the current release branch (test-infra would have to stay at master). The are master in the older release branch job files as well.