### PR TITLE
Make `experimental` branches generic

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -5,7 +5,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: unit-tests_istio_exp_ds
@@ -52,7 +52,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: unit-tests-arm64_istio_exp_ds
@@ -104,7 +104,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: release-test_istio_exp_ds
@@ -151,7 +151,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: benchmark_istio_exp_ds
@@ -195,7 +195,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-cni_istio_exp_ds
@@ -259,7 +259,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-telemetry_istio_exp_ds
@@ -321,7 +321,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-telemetry-mc_istio_exp_ds
@@ -385,7 +385,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-telemetry-istiodremote_istio_exp_ds
@@ -453,7 +453,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-distroless_istio_exp_ds
@@ -517,7 +517,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-ipv6_istio_exp_ds
@@ -583,7 +583,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-basic-arm64_istio_exp_ds
@@ -650,7 +650,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-operator-controller_istio_exp_ds
@@ -712,7 +712,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-pilot_istio_exp_ds
@@ -774,7 +774,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-pilot-multicluster_istio_exp_ds
@@ -838,7 +838,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-pilot-istiodremote_istio_exp_ds
@@ -906,7 +906,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-pilot-istiodremote-mc_istio_exp_ds
@@ -974,7 +974,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-security_istio_exp_ds
@@ -1036,7 +1036,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-security-multicluster_istio_exp_ds
@@ -1100,7 +1100,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-security-istiodremote_istio_exp_ds
@@ -1168,7 +1168,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: integ-helm_istio_exp_ds
@@ -1230,7 +1230,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     decoration_config:
@@ -1297,7 +1297,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: analyze-tests_istio_exp_ds
@@ -1340,7 +1340,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: lint_istio_exp_ds
@@ -1382,7 +1382,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     name: gencheck_istio_exp_ds
@@ -1425,7 +1425,7 @@ presubmits:
     annotations:
       testgrid-dashboards: istio_istio
     branches:
-    - experimental-dual-stack
+    - ^experimental-.*
     cluster: public
     decorate: true
     extra_refs:

--- a/prow/config/experimental/istio.yaml
+++ b/prow/config/experimental/istio.yaml
@@ -4,7 +4,7 @@ support_release_branching: false
 
 defaults:
   branches: [master]
-  branches-out: [experimental-dual-stack]
+  branches-out: [^experimental-.*]
   repo-allowlist: [istio]
 
 transforms:


### PR DESCRIPTION
This would allow arbitrary expiriments instead of just dual-stack