### PR TITLE
Simplfy `/test` commands

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
@@ -101,6 +101,7 @@ presubmits:
       preset-enable-ssh: "true"
     name: build_api_pri
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -134,6 +135,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -146,6 +148,7 @@ presubmits:
       preset-enable-ssh: "true"
     name: gencheck_api_pri
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -179,3 +182,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -53,6 +54,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -63,6 +65,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -103,6 +106,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -113,6 +117,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -151,3 +156,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.11.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.11_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -53,6 +54,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -63,6 +65,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.11_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -103,6 +106,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -113,6 +117,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.11_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -151,3 +156,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.12.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.12_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -53,6 +54,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -63,6 +65,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.12_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -103,6 +106,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -113,6 +117,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.12_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -151,3 +156,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.13.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.13_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -53,6 +54,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -63,6 +65,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.13_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -103,6 +106,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -113,6 +117,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.13_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -151,3 +156,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.release-1.14.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.14_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -53,6 +54,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -63,6 +65,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.14_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -103,6 +106,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -113,6 +117,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.14_pri
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -151,3 +156,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -331,6 +331,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -362,6 +363,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -372,6 +374,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,6 +406,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -413,6 +417,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -463,6 +468,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -473,6 +480,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -523,6 +531,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -533,6 +543,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -583,6 +594,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -593,6 +606,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -645,3 +659,5 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.11.gen.yaml
@@ -331,6 +331,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.11_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -362,6 +363,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -372,6 +374,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.11_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,6 +406,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -413,6 +417,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.11_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -463,6 +468,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -473,6 +480,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.11_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -523,6 +531,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -533,6 +543,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.11_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -583,6 +594,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -593,6 +606,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.11_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -645,3 +659,5 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.12.gen.yaml
@@ -331,6 +331,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.12_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -362,6 +363,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -372,6 +374,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.12_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,6 +406,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -413,6 +417,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.12_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -463,6 +468,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -473,6 +480,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.12_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -523,6 +531,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -533,6 +543,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.12_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -583,6 +594,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -593,6 +606,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.12_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -645,3 +659,5 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.13.gen.yaml
@@ -331,6 +331,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.13_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -362,6 +363,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -372,6 +374,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.13_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,6 +406,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -413,6 +417,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.13_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -463,6 +468,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -473,6 +480,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.13_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -523,6 +531,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -533,6 +543,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.13_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -583,6 +594,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -593,6 +606,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.13_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -645,3 +659,5 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.14.gen.yaml
@@ -331,6 +331,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.14_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -362,6 +363,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -372,6 +374,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.14_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,6 +406,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -413,6 +417,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.14_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -463,6 +468,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -473,6 +480,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.14_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -523,6 +531,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -533,6 +543,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.14_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -583,6 +594,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -593,6 +606,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.14_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -645,3 +659,5 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.15.gen.yaml
@@ -331,6 +331,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.15_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -362,6 +363,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -372,6 +374,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.15_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,6 +406,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -413,6 +417,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.15_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -463,6 +468,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -473,6 +480,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.15_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -523,6 +531,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -533,6 +543,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.15_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -583,6 +594,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -593,6 +606,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.15_pri
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -645,3 +659,5 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2118,6 +2118,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2156,6 +2157,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2171,6 +2173,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests-arm64_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests-arm64
     spec:
       containers:
       - command:
@@ -2214,6 +2217,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests-arm64,?($|\s.*))|((?m)^/test( | .* )unit-tests-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2229,6 +2233,7 @@ presubmits:
       preset-override-envoy: "true"
     name: release-test_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2267,6 +2272,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2283,6 +2289,7 @@ presubmits:
     name: benchmark_istio_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2317,6 +2324,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2332,6 +2340,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-cni_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2387,6 +2396,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2402,6 +2412,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2455,6 +2466,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2470,6 +2482,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-mc_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2525,6 +2538,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2540,6 +2554,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-istiodremote_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2599,6 +2614,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2614,6 +2631,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-distroless_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2669,6 +2687,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2684,6 +2703,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-ipv6_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2741,6 +2761,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2756,6 +2777,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-basic-arm64_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-basic-arm64
     spec:
       containers:
       - command:
@@ -2814,6 +2836,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2829,6 +2852,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-operator-controller_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2882,6 +2906,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2897,6 +2923,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2950,6 +2977,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2965,6 +2993,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -3020,6 +3049,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3035,6 +3066,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -3094,6 +3126,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3109,6 +3143,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote-mc_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -3168,6 +3203,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3183,6 +3220,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3236,6 +3274,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3251,6 +3290,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3306,6 +3346,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3321,6 +3363,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-istiodremote_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3380,6 +3423,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3395,6 +3440,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-helm_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3448,6 +3494,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3466,6 +3513,7 @@ presubmits:
     name: integ-assertion_istio_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3521,6 +3569,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3536,6 +3585,7 @@ presubmits:
       preset-override-envoy: "true"
     name: analyze-tests_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3570,6 +3620,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3585,6 +3636,7 @@ presubmits:
       preset-override-envoy: "true"
     name: lint_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3618,6 +3670,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3633,6 +3686,7 @@ presubmits:
       preset-override-envoy: "true"
     name: gencheck_istio_pri
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3667,3 +3721,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -1479,6 +1479,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -1517,6 +1518,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1532,6 +1534,7 @@ presubmits:
       preset-override-envoy: "true"
     name: release-test_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -1570,6 +1573,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -1586,6 +1590,7 @@ presubmits:
     name: benchmark_istio_release-1.11_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -1620,6 +1625,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1635,6 +1641,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -1689,6 +1696,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1704,6 +1712,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-cni_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -1760,6 +1769,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1775,6 +1785,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -1829,6 +1840,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1844,6 +1856,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -1898,6 +1911,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1913,6 +1927,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-multicluster_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-multicluster
     spec:
       containers:
       - command:
@@ -1969,6 +1984,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -1987,6 +2004,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2046,6 +2064,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2061,6 +2081,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-multicluster_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-multicluster
     spec:
       containers:
       - command:
@@ -2117,6 +2138,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-multicluster,?($|\s.*))|((?m)^/test( | .* )integ-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2132,6 +2154,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-istiodremote_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-istiodremote
     spec:
       containers:
       - command:
@@ -2190,6 +2213,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-istiodremote,?($|\s.*))|((?m)^/test( | .* )integ-istiodremote_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2205,6 +2229,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-distroless_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2261,6 +2286,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2276,6 +2302,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-ipv6_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2334,6 +2361,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2349,6 +2377,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-operator-controller_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2403,6 +2432,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2418,6 +2449,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2474,6 +2506,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2492,6 +2526,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2551,6 +2586,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2566,6 +2603,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -2622,6 +2660,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2640,6 +2680,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2699,6 +2740,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2714,6 +2757,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-helm_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -2766,6 +2810,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2781,6 +2826,7 @@ presubmits:
       preset-override-envoy: "true"
     name: analyze-tests_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -2814,6 +2860,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2829,6 +2876,7 @@ presubmits:
       preset-override-envoy: "true"
     name: lint_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -2862,6 +2910,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2877,6 +2926,7 @@ presubmits:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.11_pri
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -2910,3 +2960,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -1895,6 +1895,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -1933,6 +1934,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -1948,6 +1950,7 @@ presubmits:
       preset-override-envoy: "true"
     name: release-test_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -1986,6 +1989,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2002,6 +2006,7 @@ presubmits:
     name: benchmark_istio_release-1.12_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2036,6 +2041,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2051,6 +2057,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2105,6 +2112,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2120,6 +2128,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-cni_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2176,6 +2185,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2191,6 +2201,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -2245,6 +2256,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2260,6 +2272,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2314,6 +2327,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2329,6 +2343,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-mc_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2383,6 +2398,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2398,6 +2414,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-istiodremote_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2454,6 +2471,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2472,6 +2491,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2529,6 +2549,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2544,6 +2566,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-distroless_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2598,6 +2621,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2613,6 +2637,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-ipv6_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2669,6 +2694,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2684,6 +2710,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-operator-controller_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2738,6 +2765,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2753,6 +2782,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2807,6 +2837,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2822,6 +2854,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -2880,6 +2913,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2895,6 +2930,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote-mc_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -2953,6 +2989,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2971,6 +3009,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3028,6 +3067,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3043,6 +3084,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3097,6 +3139,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3112,6 +3156,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-istiodremote_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3170,6 +3215,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3188,6 +3235,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3245,6 +3293,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3260,6 +3310,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-helm_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3312,6 +3363,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3330,6 +3382,7 @@ presubmits:
     name: integ-assertion_istio_release-1.12_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3384,6 +3437,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3399,6 +3453,7 @@ presubmits:
       preset-override-envoy: "true"
     name: analyze-tests_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3432,6 +3487,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3447,6 +3503,7 @@ presubmits:
       preset-override-envoy: "true"
     name: lint_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3480,6 +3537,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3495,6 +3553,7 @@ presubmits:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.12_pri
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3528,3 +3587,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -2041,6 +2041,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2079,6 +2080,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2094,6 +2096,7 @@ presubmits:
       preset-override-envoy: "true"
     name: release-test_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2132,6 +2135,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2148,6 +2152,7 @@ presubmits:
     name: benchmark_istio_release-1.13_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2182,6 +2187,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2197,6 +2203,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-cni_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2251,6 +2258,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2266,6 +2274,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2318,6 +2327,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2333,6 +2343,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-mc_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2387,6 +2398,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2402,6 +2414,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-istiodremote_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2458,6 +2471,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2476,6 +2491,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2533,6 +2549,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2548,6 +2566,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-distroless_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2602,6 +2621,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2617,6 +2637,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-ipv6_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2673,6 +2694,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2688,6 +2710,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-operator-controller_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2740,6 +2763,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2755,6 +2780,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2807,6 +2833,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2822,6 +2849,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2876,6 +2904,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2891,6 +2921,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -2949,6 +2980,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2964,6 +2997,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote-mc_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -3022,6 +3056,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3040,6 +3076,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3097,6 +3134,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3112,6 +3151,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3164,6 +3204,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3179,6 +3220,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3233,6 +3275,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3248,6 +3292,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-istiodremote_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3306,6 +3351,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3324,6 +3371,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3381,6 +3429,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3396,6 +3446,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-helm_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3448,6 +3499,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3466,6 +3518,7 @@ presubmits:
     name: integ-assertion_istio_release-1.13_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3520,6 +3573,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3535,6 +3589,7 @@ presubmits:
       preset-override-envoy: "true"
     name: analyze-tests_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3568,6 +3623,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3583,6 +3639,7 @@ presubmits:
       preset-override-envoy: "true"
     name: lint_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3616,6 +3673,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3631,6 +3689,7 @@ presubmits:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.13_pri
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3664,3 +3723,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
@@ -2145,6 +2145,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2183,6 +2184,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2198,6 +2200,7 @@ presubmits:
       preset-override-envoy: "true"
     name: release-test_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2236,6 +2239,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2252,6 +2256,7 @@ presubmits:
     name: benchmark_istio_release-1.14_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2286,6 +2291,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2301,6 +2307,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-cni_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2356,6 +2363,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2371,6 +2379,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2424,6 +2433,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2439,6 +2449,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-mc_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2494,6 +2505,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2509,6 +2521,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-istiodremote_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2566,6 +2579,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2584,6 +2599,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2642,6 +2658,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2657,6 +2675,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-distroless_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2712,6 +2731,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2727,6 +2747,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-ipv6_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2784,6 +2805,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2799,6 +2821,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-operator-controller_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2852,6 +2875,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2867,6 +2892,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2920,6 +2946,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2935,6 +2962,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2990,6 +3018,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3005,6 +3035,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -3064,6 +3095,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3079,6 +3112,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote-mc_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -3138,6 +3172,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3156,6 +3192,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3214,6 +3251,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3229,6 +3268,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3282,6 +3322,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3297,6 +3338,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3352,6 +3394,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3367,6 +3411,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-istiodremote_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3426,6 +3471,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3444,6 +3491,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3502,6 +3550,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3517,6 +3567,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-helm_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3570,6 +3621,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3588,6 +3640,7 @@ presubmits:
     name: integ-assertion_istio_release-1.14_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3643,6 +3696,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3658,6 +3712,7 @@ presubmits:
       preset-override-envoy: "true"
     name: analyze-tests_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3692,6 +3747,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3707,6 +3763,7 @@ presubmits:
       preset-override-envoy: "true"
     name: lint_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3740,6 +3797,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3755,6 +3813,7 @@ presubmits:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.14_pri
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3789,3 +3848,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.15.gen.yaml
@@ -2119,6 +2119,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2157,6 +2158,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2172,6 +2174,7 @@ presubmits:
       preset-override-envoy: "true"
     name: unit-tests-arm64_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests-arm64
     spec:
       containers:
       - command:
@@ -2216,6 +2219,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests-arm64,?($|\s.*))|((?m)^/test( | .* )unit-tests-arm64_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2231,6 +2235,7 @@ presubmits:
       preset-override-envoy: "true"
     name: release-test_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2269,6 +2274,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -2285,6 +2291,7 @@ presubmits:
     name: benchmark_istio_release-1.15_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2319,6 +2326,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2334,6 +2342,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-cni_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2389,6 +2398,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2404,6 +2414,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2457,6 +2468,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2472,6 +2484,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-mc_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2527,6 +2540,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2542,6 +2556,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-telemetry-istiodremote_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2601,6 +2616,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2616,6 +2633,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-distroless_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2671,6 +2689,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2686,6 +2705,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-ipv6_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2743,6 +2763,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2758,6 +2779,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-basic-arm64_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-basic-arm64
     spec:
       containers:
       - command:
@@ -2816,6 +2838,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2831,6 +2854,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-operator-controller_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2884,6 +2908,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2899,6 +2925,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2952,6 +2979,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -2967,6 +2995,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-multicluster_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -3022,6 +3051,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3037,6 +3068,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -3096,6 +3128,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3111,6 +3145,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-pilot-istiodremote-mc_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -3170,6 +3205,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3185,6 +3222,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3238,6 +3276,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3253,6 +3292,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-multicluster_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3308,6 +3348,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3323,6 +3365,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-security-istiodremote_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3382,6 +3425,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3397,6 +3442,7 @@ presubmits:
       preset-override-envoy: "true"
     name: integ-helm_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3450,6 +3496,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -3468,6 +3515,7 @@ presubmits:
     name: integ-assertion_istio_release-1.15_pri
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3523,6 +3571,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3538,6 +3587,7 @@ presubmits:
       preset-override-envoy: "true"
     name: analyze-tests_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3572,6 +3622,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3587,6 +3638,7 @@ presubmits:
       preset-override-envoy: "true"
     name: lint_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3620,6 +3672,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -3635,6 +3688,7 @@ presubmits:
       preset-override-envoy: "true"
     name: gencheck_istio_release-1.15_pri
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3669,3 +3723,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -198,6 +198,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -234,6 +235,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -248,6 +250,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-asan_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -284,6 +287,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -298,6 +302,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -334,6 +339,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -348,6 +354,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -384,6 +391,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -398,6 +406,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test-arm64_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test-arm64
     spec:
       containers:
       - command:
@@ -440,6 +449,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test-arm64,?($|\s.*))|((?m)^/test( | .* )release-test-arm64_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -454,6 +464,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-centos-test_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -490,6 +501,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -504,6 +516,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_master_priv
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -545,3 +558,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.11.gen.yaml
@@ -132,6 +132,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -168,6 +169,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -182,6 +184,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-asan_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -218,6 +221,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -232,6 +236,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -268,6 +273,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -282,6 +288,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -318,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -332,6 +340,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-centos-test_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -382,6 +392,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_release-1.11_release-1.11_priv
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -423,3 +434,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.12.gen.yaml
@@ -132,6 +132,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -168,6 +169,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -182,6 +184,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-asan_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -218,6 +221,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -232,6 +236,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -268,6 +273,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -282,6 +288,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -318,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -332,6 +340,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-centos-test_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -382,6 +392,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_release-1.12_release-1.12_priv
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -423,3 +434,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.13.gen.yaml
@@ -132,6 +132,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_proxy_release-1.13_release-1.13_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -168,6 +169,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -182,6 +184,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-asan_proxy_release-1.13_release-1.13_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -218,6 +221,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -232,6 +236,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_release-1.13_release-1.13_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -268,6 +273,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -282,6 +288,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test_proxy_release-1.13_release-1.13_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -318,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -332,6 +340,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-centos-test_proxy_release-1.13_release-1.13_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -382,6 +392,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_release-1.13_release-1.13_priv
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -423,3 +434,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.14.gen.yaml
@@ -132,6 +132,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_proxy_release-1.14_release-1.14_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -168,6 +169,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -182,6 +184,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-asan_proxy_release-1.14_release-1.14_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -218,6 +221,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -232,6 +236,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_release-1.14_release-1.14_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -268,6 +273,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -282,6 +288,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test_proxy_release-1.14_release-1.14_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -318,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -332,6 +340,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-centos-test_proxy_release-1.14_release-1.14_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -368,6 +377,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -382,6 +392,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_release-1.14_release-1.14_priv
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -423,3 +434,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.15.gen.yaml
@@ -198,6 +198,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -234,6 +235,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -248,6 +250,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-asan_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -284,6 +287,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -298,6 +302,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-tsan_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -334,6 +339,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -348,6 +354,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -384,6 +391,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -398,6 +406,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-test-arm64_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-test-arm64
     spec:
       containers:
       - command:
@@ -440,6 +449,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test-arm64,?($|\s.*))|((?m)^/test( | .* )release-test-arm64_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -454,6 +464,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: release-centos-test_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -490,6 +501,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -504,6 +516,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: check-wasm_proxy_release-1.15_release-1.15_priv
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -545,3 +558,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -233,6 +233,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: lint_release-builder_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -264,6 +265,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -276,6 +278,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_release-builder_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -307,6 +310,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -319,6 +323,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: gencheck_release-builder_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -350,6 +355,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -361,6 +367,7 @@ presubmits:
     name: build-warning_release-builder_pri
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -398,3 +405,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.11.gen.yaml
@@ -231,6 +231,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: lint_release-builder_release-1.11_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -262,6 +263,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -274,6 +276,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_release-builder_release-1.11_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -305,6 +308,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -317,6 +321,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: gencheck_release-builder_release-1.11_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -348,6 +353,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -359,6 +365,7 @@ presubmits:
     name: build-warning_release-builder_release-1.11_pri
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -394,3 +401,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.12.gen.yaml
@@ -203,6 +203,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: lint_release-builder_release-1.12_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -234,6 +235,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -246,6 +248,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_release-builder_release-1.12_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -277,6 +280,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -289,6 +293,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: gencheck_release-builder_release-1.12_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -320,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -331,6 +337,7 @@ presubmits:
     name: build-warning_release-builder_release-1.12_pri
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -368,3 +375,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.13.gen.yaml
@@ -203,6 +203,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: lint_release-builder_release-1.13_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -234,6 +235,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -246,6 +248,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_release-builder_release-1.13_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -277,6 +280,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -289,6 +293,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: gencheck_release-builder_release-1.13_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -320,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -331,6 +337,7 @@ presubmits:
     name: build-warning_release-builder_release-1.13_pri
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -368,3 +375,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.14.gen.yaml
@@ -203,6 +203,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: lint_release-builder_release-1.14_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -234,6 +235,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -246,6 +248,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_release-builder_release-1.14_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -277,6 +280,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -289,6 +293,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: gencheck_release-builder_release-1.14_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -320,6 +325,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -331,6 +337,7 @@ presubmits:
     name: build-warning_release-builder_release-1.14_pri
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -368,3 +375,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.15.gen.yaml
@@ -233,6 +233,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: lint_release-builder_release-1.15_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -264,6 +265,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -276,6 +278,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test_release-builder_release-1.15_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -307,6 +310,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -319,6 +323,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: gencheck_release-builder_release-1.15_pri
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -350,6 +355,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -361,6 +367,7 @@ presubmits:
     name: build-warning_release-builder_release-1.15_pri
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -398,3 +405,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -149,6 +149,7 @@ presubmits:
     decorate: true
     name: build_api
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -180,6 +181,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_api
@@ -188,6 +190,7 @@ presubmits:
     decorate: true
     name: gencheck_api
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -219,6 +222,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_api
@@ -237,6 +241,7 @@ presubmits:
     name: release-notes_api
     optional: true
     path_alias: istio.io/api
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -274,3 +279,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.11.gen.yaml
@@ -208,6 +208,7 @@ presubmits:
     decorate: true
     name: build_api_release-1.11
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -239,6 +240,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_api
@@ -247,6 +249,7 @@ presubmits:
     decorate: true
     name: gencheck_api_release-1.11
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -278,6 +281,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_api
@@ -296,6 +300,7 @@ presubmits:
     name: release-notes_api_release-1.11
     optional: true
     path_alias: istio.io/api
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -333,3 +338,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.12.gen.yaml
@@ -208,6 +208,7 @@ presubmits:
     decorate: true
     name: build_api_release-1.12
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -239,6 +240,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_api
@@ -247,6 +249,7 @@ presubmits:
     decorate: true
     name: gencheck_api_release-1.12
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -278,6 +281,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_api
@@ -296,6 +300,7 @@ presubmits:
     name: release-notes_api_release-1.12
     optional: true
     path_alias: istio.io/api
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -333,3 +338,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.13.gen.yaml
@@ -208,6 +208,7 @@ presubmits:
     decorate: true
     name: build_api_release-1.13
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -239,6 +240,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_api
@@ -247,6 +249,7 @@ presubmits:
     decorate: true
     name: gencheck_api_release-1.13
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -278,6 +281,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_api
@@ -296,6 +300,7 @@ presubmits:
     name: release-notes_api_release-1.13
     optional: true
     path_alias: istio.io/api
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -333,3 +338,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.14.gen.yaml
@@ -208,6 +208,7 @@ presubmits:
     decorate: true
     name: build_api_release-1.14
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -239,6 +240,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_api
@@ -247,6 +249,7 @@ presubmits:
     decorate: true
     name: gencheck_api_release-1.14
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -278,6 +281,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_api
@@ -296,6 +300,7 @@ presubmits:
     name: release-notes_api_release-1.14
     optional: true
     path_alias: istio.io/api
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -333,3 +338,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.15.gen.yaml
@@ -149,6 +149,7 @@ presubmits:
     decorate: true
     name: build_api_release-1.15
     path_alias: istio.io/api
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -180,6 +181,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_api_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_api
@@ -188,6 +190,7 @@ presubmits:
     decorate: true
     name: gencheck_api_release-1.15
     path_alias: istio.io/api
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -219,6 +222,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_api_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_api
@@ -237,6 +241,7 @@ presubmits:
     name: release-notes_api_release-1.15
     optional: true
     path_alias: istio.io/api
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -274,3 +279,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -255,6 +255,7 @@ presubmits:
     decorate: true
     name: build_bots
     path_alias: istio.io/bots
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -286,6 +287,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_bots,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_bots
@@ -294,6 +296,7 @@ presubmits:
     decorate: true
     name: lint_bots
     path_alias: istio.io/bots
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -325,6 +328,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_bots,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_bots
@@ -333,6 +337,7 @@ presubmits:
     decorate: true
     name: test_bots
     path_alias: istio.io/bots
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -364,6 +369,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_bots,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_bots
@@ -372,6 +378,7 @@ presubmits:
     decorate: true
     name: gencheck_bots
     path_alias: istio.io/bots
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -403,3 +410,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_bots,?($|\s.*))

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_client-go
     path_alias: istio.io/client-go
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_client-go,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_client-go
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_client-go
     path_alias: istio.io/client-go
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_client-go,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_client-go
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_client-go
     path_alias: istio.io/client-go
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_client-go,?($|\s.*))

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.11.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_client-go_release-1.11
     path_alias: istio.io/client-go
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_client-go_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_client-go
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_client-go_release-1.11
     path_alias: istio.io/client-go
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_client-go_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_client-go
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_client-go_release-1.11
     path_alias: istio.io/client-go
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_client-go_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.12.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_client-go_release-1.12
     path_alias: istio.io/client-go
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_client-go_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_client-go
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_client-go_release-1.12
     path_alias: istio.io/client-go
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_client-go_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_client-go
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_client-go_release-1.12
     path_alias: istio.io/client-go
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_client-go_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.13.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_client-go_release-1.13
     path_alias: istio.io/client-go
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_client-go_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_client-go
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_client-go_release-1.13
     path_alias: istio.io/client-go
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_client-go_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_client-go
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_client-go_release-1.13
     path_alias: istio.io/client-go
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_client-go_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.14.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_client-go_release-1.14
     path_alias: istio.io/client-go
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_client-go_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_client-go
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_client-go_release-1.14
     path_alias: istio.io/client-go
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_client-go_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_client-go
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_client-go_release-1.14
     path_alias: istio.io/client-go
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_client-go_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.15.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_client-go_release-1.15
     path_alias: istio.io/client-go
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_client-go_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_client-go
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_client-go_release-1.15
     path_alias: istio.io/client-go
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_client-go_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_client-go
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_client-go_release-1.15
     path_alias: istio.io/client-go
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_client-go_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -287,6 +287,7 @@ presubmits:
     decorate: true
     name: lint_common-files
     path_alias: istio.io/common-files
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -318,3 +319,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_common-files,?($|\s.*))

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.11.gen.yaml
@@ -229,6 +229,7 @@ presubmits:
     decorate: true
     name: lint_common-files_release-1.11
     path_alias: istio.io/common-files
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -260,3 +261,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_common-files_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.12.gen.yaml
@@ -227,6 +227,7 @@ presubmits:
     decorate: true
     name: lint_common-files_release-1.12
     path_alias: istio.io/common-files
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -258,3 +259,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_common-files_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.13.gen.yaml
@@ -228,6 +228,7 @@ presubmits:
     decorate: true
     name: lint_common-files_release-1.13
     path_alias: istio.io/common-files
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -259,3 +260,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_common-files_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.14.gen.yaml
@@ -229,6 +229,7 @@ presubmits:
     decorate: true
     name: lint_common-files_release-1.14
     path_alias: istio.io/common-files
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -260,3 +261,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_common-files_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.15.gen.yaml
@@ -229,6 +229,7 @@ presubmits:
     decorate: true
     name: lint_common-files_release-1.15
     path_alias: istio.io/common-files
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -260,3 +261,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_common-files_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -138,6 +138,7 @@ presubmits:
     decorate: true
     name: lint_community
     path_alias: istio.io/community
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -168,6 +169,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_community,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_community
@@ -176,6 +178,7 @@ presubmits:
     decorate: true
     name: test_community
     path_alias: istio.io/community
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -207,3 +210,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_community,?($|\s.*))

--- a/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
+++ b/prow/cluster/jobs/istio/cri/istio.cri.master.gen.yaml
@@ -171,6 +171,7 @@ presubmits:
     decorate: true
     name: build_cri
     path_alias: istio.io/cri
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -202,6 +203,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_cri,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_cri
@@ -210,6 +212,7 @@ presubmits:
     decorate: true
     name: lint_cri
     path_alias: istio.io/cri
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -241,6 +244,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_cri,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_cri
@@ -249,6 +253,7 @@ presubmits:
     decorate: true
     name: test_cri
     path_alias: istio.io/cri
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -280,6 +285,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_cri,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_cri
@@ -288,6 +294,7 @@ presubmits:
     decorate: true
     name: gencheck_cri
     path_alias: istio.io/cri
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -319,3 +326,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_cri,?($|\s.*))

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
@@ -19,6 +19,7 @@ presubmits:
     name: validate-features_enhancements
     optional: true
     path_alias: istio.io/enhancements
+    rerun_command: /test validate-features
     spec:
       containers:
       - command:
@@ -51,3 +52,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )validate-features,?($|\s.*))|((?m)^/test( | .* )validate-features_enhancements,?($|\s.*))

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.11.gen.yaml
@@ -19,6 +19,7 @@ presubmits:
     name: validate-features_enhancements_release-1.11
     optional: true
     path_alias: istio.io/enhancements
+    rerun_command: /test validate-features
     spec:
       containers:
       - command:
@@ -51,3 +52,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )validate-features,?($|\s.*))|((?m)^/test( | .* )validate-features_enhancements_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.12.gen.yaml
@@ -19,6 +19,7 @@ presubmits:
     name: validate-features_enhancements_release-1.12
     optional: true
     path_alias: istio.io/enhancements
+    rerun_command: /test validate-features
     spec:
       containers:
       - command:
@@ -51,3 +52,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )validate-features,?($|\s.*))|((?m)^/test( | .* )validate-features_enhancements_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.13.gen.yaml
@@ -19,6 +19,7 @@ presubmits:
     name: validate-features_enhancements_release-1.13
     optional: true
     path_alias: istio.io/enhancements
+    rerun_command: /test validate-features
     spec:
       containers:
       - command:
@@ -51,3 +52,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )validate-features,?($|\s.*))|((?m)^/test( | .* )validate-features_enhancements_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.14.gen.yaml
@@ -19,6 +19,7 @@ presubmits:
     name: validate-features_enhancements_release-1.14
     optional: true
     path_alias: istio.io/enhancements
+    rerun_command: /test validate-features
     spec:
       containers:
       - command:
@@ -51,3 +52,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )validate-features,?($|\s.*))|((?m)^/test( | .* )validate-features_enhancements_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.15.gen.yaml
@@ -19,6 +19,7 @@ presubmits:
     name: validate-features_enhancements_release-1.15
     optional: true
     path_alias: istio.io/enhancements
+    rerun_command: /test validate-features
     spec:
       containers:
       - command:
@@ -51,3 +52,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )validate-features,?($|\s.*))|((?m)^/test( | .* )validate-features_enhancements_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -11,6 +11,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -51,6 +52,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_envoy
@@ -59,6 +61,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -99,6 +102,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_envoy
@@ -107,6 +111,7 @@ presubmits:
     decorate: true
     name: test-release_envoy
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -145,3 +150,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy,?($|\s.*))

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.11.gen.yaml
@@ -11,6 +11,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.11
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -51,6 +52,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_envoy
@@ -59,6 +61,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.11
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -99,6 +102,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_envoy
@@ -107,6 +111,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.11
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -145,3 +150,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.12.gen.yaml
@@ -11,6 +11,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.12
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -51,6 +52,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_envoy
@@ -59,6 +61,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.12
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -99,6 +102,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_envoy
@@ -107,6 +111,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.12
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -145,3 +150,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.13.gen.yaml
@@ -11,6 +11,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.13
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -51,6 +52,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_envoy
@@ -59,6 +61,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.13
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -99,6 +102,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_envoy
@@ -107,6 +111,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.13
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -145,3 +150,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.release-1.14.gen.yaml
@@ -11,6 +11,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_envoy_release-1.14
     path_alias: istio.io/envoy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -51,6 +52,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_envoy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_envoy
@@ -59,6 +61,7 @@ presubmits:
     decorate: true
     name: test-tsan_envoy_release-1.14
     path_alias: istio.io/envoy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -99,6 +102,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_envoy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_envoy
@@ -107,6 +111,7 @@ presubmits:
     decorate: true
     name: test-release_envoy_release-1.14
     path_alias: istio.io/envoy
+    rerun_command: /test test-release
     spec:
       containers:
       - command:
@@ -145,3 +150,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-release,?($|\s.*))|((?m)^/test( | .* )test-release_envoy_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.11.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_gogo-genproto_release-1.11
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_gogo-genproto_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_gogo-genproto
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_gogo-genproto_release-1.11
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_gogo-genproto_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_gogo-genproto
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_gogo-genproto_release-1.11
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_gogo-genproto_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.12.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_gogo-genproto_release-1.12
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_gogo-genproto_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_gogo-genproto
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_gogo-genproto_release-1.12
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_gogo-genproto_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_gogo-genproto
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_gogo-genproto_release-1.12
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_gogo-genproto_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/gogo-genproto/istio.gogo-genproto.release-1.13.gen.yaml
@@ -191,6 +191,7 @@ presubmits:
     decorate: true
     name: build_gogo-genproto_release-1.13
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -222,6 +223,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_gogo-genproto_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_gogo-genproto
@@ -230,6 +232,7 @@ presubmits:
     decorate: true
     name: lint_gogo-genproto_release-1.13
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -261,6 +264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_gogo-genproto_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_gogo-genproto
@@ -269,6 +273,7 @@ presubmits:
     decorate: true
     name: gencheck_gogo-genproto_release-1.13
     path_alias: istio.io/gogo-genproto
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -300,3 +305,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_gogo-genproto_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -447,6 +447,7 @@ presubmits:
     decorate: true
     name: lint_istio.io
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -478,6 +479,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio.io
@@ -486,6 +488,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -517,6 +520,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio.io
@@ -525,6 +529,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -575,6 +580,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio.io
@@ -583,6 +590,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -633,6 +641,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio.io
@@ -641,6 +651,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -691,6 +702,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio.io
@@ -699,6 +712,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -751,6 +765,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio.io
@@ -765,6 +781,7 @@ presubmits:
     name: update-ref-docs-dry-run_istio.io
     optional: true
     path_alias: istio.io/istio.io
+    rerun_command: /test update-ref-docs-dry-run
     spec:
       containers:
       - command:
@@ -806,3 +823,5 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
+      .* )update-ref-docs-dry-run_istio.io,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.11.gen.yaml
@@ -329,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.11
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -360,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio.io
@@ -368,6 +370,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.11
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -399,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio.io
@@ -407,6 +411,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.11
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -457,6 +462,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio.io
@@ -465,6 +472,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.11
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -515,6 +523,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio.io
@@ -523,6 +533,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.11
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -573,6 +584,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio.io
@@ -581,6 +594,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.11
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -633,6 +647,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio.io
@@ -647,6 +663,7 @@ presubmits:
     name: update-ref-docs-dry-run_istio.io_release-1.11
     optional: true
     path_alias: istio.io/istio.io
+    rerun_command: /test update-ref-docs-dry-run
     spec:
       containers:
       - command:
@@ -688,3 +705,5 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
+      .* )update-ref-docs-dry-run_istio.io_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.12.gen.yaml
@@ -329,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.12
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -360,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio.io
@@ -368,6 +370,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.12
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -399,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio.io
@@ -407,6 +411,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.12
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -457,6 +462,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio.io
@@ -465,6 +472,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.12
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -515,6 +523,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio.io
@@ -523,6 +533,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.12
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -573,6 +584,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio.io
@@ -581,6 +594,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.12
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -633,6 +647,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio.io
@@ -647,6 +663,7 @@ presubmits:
     name: update-ref-docs-dry-run_istio.io_release-1.12
     optional: true
     path_alias: istio.io/istio.io
+    rerun_command: /test update-ref-docs-dry-run
     spec:
       containers:
       - command:
@@ -688,3 +705,5 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
+      .* )update-ref-docs-dry-run_istio.io_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.13.gen.yaml
@@ -329,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.13
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -360,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio.io
@@ -368,6 +370,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.13
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -399,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio.io
@@ -407,6 +411,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.13
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -457,6 +462,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio.io
@@ -465,6 +472,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.13
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -515,6 +523,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio.io
@@ -523,6 +533,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.13
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -573,6 +584,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio.io
@@ -581,6 +594,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.13
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -633,6 +647,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio.io
@@ -647,6 +663,7 @@ presubmits:
     name: update-ref-docs-dry-run_istio.io_release-1.13
     optional: true
     path_alias: istio.io/istio.io
+    rerun_command: /test update-ref-docs-dry-run
     spec:
       containers:
       - command:
@@ -688,3 +705,5 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
+      .* )update-ref-docs-dry-run_istio.io_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.14.gen.yaml
@@ -329,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.14
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -360,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio.io
@@ -368,6 +370,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.14
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -399,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio.io
@@ -407,6 +411,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.14
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -457,6 +462,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio.io
@@ -465,6 +472,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.14
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -515,6 +523,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio.io
@@ -523,6 +533,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.14
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -573,6 +584,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio.io
@@ -581,6 +594,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.14
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -633,6 +647,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio.io
@@ -647,6 +663,7 @@ presubmits:
     name: update-ref-docs-dry-run_istio.io_release-1.14
     optional: true
     path_alias: istio.io/istio.io
+    rerun_command: /test update-ref-docs-dry-run
     spec:
       containers:
       - command:
@@ -688,3 +705,5 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
+      .* )update-ref-docs-dry-run_istio.io_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.15.gen.yaml
@@ -329,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_istio.io_release-1.15
     path_alias: istio.io/istio.io
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -360,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio.io
@@ -368,6 +370,7 @@ presubmits:
     decorate: true
     name: gencheck_istio.io_release-1.15
     path_alias: istio.io/istio.io
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -399,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio.io
@@ -407,6 +411,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_default_istio.io_release-1.15
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_default
     spec:
       containers:
       - command:
@@ -457,6 +462,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile_default_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio.io
@@ -465,6 +472,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_demo_istio.io_release-1.15
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_demo
     spec:
       containers:
       - command:
@@ -515,6 +523,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_demo_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio.io
@@ -523,6 +533,7 @@ presubmits:
     decorate: true
     name: doc.test.profile_none_istio.io_release-1.15
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.profile_none
     spec:
       containers:
       - command:
@@ -573,6 +584,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile_none_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio.io
@@ -581,6 +594,7 @@ presubmits:
     decorate: true
     name: doc.test.multicluster_istio.io_release-1.15
     path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.multicluster
     spec:
       containers:
       - command:
@@ -633,6 +647,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.multicluster_istio.io_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio.io
@@ -647,6 +663,7 @@ presubmits:
     name: update-ref-docs-dry-run_istio.io_release-1.15
     optional: true
     path_alias: istio.io/istio.io
+    rerun_command: /test update-ref-docs-dry-run
     spec:
       containers:
       - command:
@@ -688,3 +705,5 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
+      .* )update-ref-docs-dry-run_istio.io_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2171,6 +2171,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2209,6 +2210,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2218,6 +2220,7 @@ presubmits:
     decorate: true
     name: unit-tests-arm64_istio
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests-arm64
     spec:
       containers:
       - command:
@@ -2261,6 +2264,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests-arm64,?($|\s.*))|((?m)^/test( | .* )unit-tests-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2269,6 +2273,7 @@ presubmits:
     decorate: true
     name: release-test_istio
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2307,6 +2312,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
@@ -2316,6 +2322,7 @@ presubmits:
     name: benchmark_istio
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2350,6 +2357,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2358,6 +2366,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2413,6 +2422,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2421,6 +2431,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2474,6 +2485,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2482,6 +2494,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-mc_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2537,6 +2550,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2545,6 +2559,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-istiodremote_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2604,6 +2619,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2612,6 +2629,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2667,6 +2685,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2675,6 +2694,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2732,6 +2752,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2741,6 +2762,7 @@ presubmits:
     decorate: true
     name: integ-basic-arm64_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-basic-arm64
     spec:
       containers:
       - command:
@@ -2799,6 +2821,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2807,6 +2830,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2860,6 +2884,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2868,6 +2894,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2921,6 +2948,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2929,6 +2957,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2984,6 +3013,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -2992,6 +3023,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -3051,6 +3083,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3059,6 +3093,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote-mc_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -3118,6 +3153,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3126,6 +3163,7 @@ presubmits:
     decorate: true
     name: integ-security_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3179,6 +3217,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3187,6 +3226,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3242,6 +3282,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3250,6 +3292,7 @@ presubmits:
     decorate: true
     name: integ-security-istiodremote_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3309,6 +3352,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3317,6 +3362,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3370,6 +3416,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
@@ -3381,6 +3428,7 @@ presubmits:
     name: integ-assertion_istio
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3436,6 +3484,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3444,6 +3493,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3478,6 +3528,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3486,6 +3537,7 @@ presubmits:
     decorate: true
     name: lint_istio
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3519,6 +3571,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3527,6 +3580,7 @@ presubmits:
     decorate: true
     name: gencheck_istio
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3561,6 +3615,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -3578,6 +3633,7 @@ presubmits:
       repo: tools
     name: release-notes_istio
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -3618,3 +3674,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -1409,6 +1409,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -1447,6 +1448,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1455,6 +1457,7 @@ presubmits:
     decorate: true
     name: release-test_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -1493,6 +1496,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1502,6 +1506,7 @@ presubmits:
     name: benchmark_istio_release-1.11
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -1536,6 +1541,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1544,6 +1550,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -1598,6 +1605,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1606,6 +1614,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -1662,6 +1671,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1670,6 +1680,7 @@ presubmits:
     decorate: true
     name: integ-security_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -1724,6 +1735,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1732,6 +1744,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -1786,6 +1799,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1794,6 +1808,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-multicluster_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-multicluster
     spec:
       containers:
       - command:
@@ -1850,6 +1865,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1861,6 +1878,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -1920,6 +1938,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1928,6 +1948,7 @@ presubmits:
     decorate: true
     name: integ-multicluster_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-multicluster
     spec:
       containers:
       - command:
@@ -1984,6 +2005,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-multicluster,?($|\s.*))|((?m)^/test( | .* )integ-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -1992,6 +2014,7 @@ presubmits:
     decorate: true
     name: integ-istiodremote_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-istiodremote
     spec:
       containers:
       - command:
@@ -2050,6 +2073,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-istiodremote,?($|\s.*))|((?m)^/test( | .* )integ-istiodremote_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2058,6 +2082,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2114,6 +2139,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2122,6 +2148,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2180,6 +2207,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2188,6 +2216,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2242,6 +2271,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2250,6 +2281,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2306,6 +2338,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2317,6 +2351,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2376,6 +2411,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2384,6 +2421,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -2440,6 +2478,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2451,6 +2491,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2510,6 +2551,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2518,6 +2561,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -2570,6 +2614,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2578,6 +2623,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -2611,6 +2657,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2619,6 +2666,7 @@ presubmits:
     decorate: true
     name: lint_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -2652,6 +2700,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2660,6 +2709,7 @@ presubmits:
     decorate: true
     name: gencheck_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -2693,6 +2743,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_istio
@@ -2710,6 +2761,7 @@ presubmits:
       repo: tools
     name: release-notes_istio_release-1.11
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -2749,3 +2801,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -1793,6 +1793,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -1831,6 +1832,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -1839,6 +1841,7 @@ presubmits:
     decorate: true
     name: release-test_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -1877,6 +1880,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -1886,6 +1890,7 @@ presubmits:
     name: benchmark_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -1920,6 +1925,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -1928,6 +1934,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -1982,6 +1989,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -1990,6 +1998,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2046,6 +2055,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2054,6 +2064,7 @@ presubmits:
     decorate: true
     name: integ-security_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -2108,6 +2119,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2116,6 +2128,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2170,6 +2183,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2178,6 +2192,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-mc_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2232,6 +2247,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2240,6 +2256,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-istiodremote_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2296,6 +2313,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2307,6 +2326,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2364,6 +2384,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2372,6 +2394,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2426,6 +2449,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2434,6 +2458,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2490,6 +2515,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2498,6 +2524,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2552,6 +2579,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2560,6 +2589,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2614,6 +2644,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2622,6 +2654,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -2680,6 +2713,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2688,6 +2723,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote-mc_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -2746,6 +2782,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2757,6 +2795,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2814,6 +2853,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2822,6 +2863,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -2876,6 +2918,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2884,6 +2928,7 @@ presubmits:
     decorate: true
     name: integ-security-istiodremote_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -2942,6 +2987,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -2953,6 +3000,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3010,6 +3058,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -3018,6 +3068,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3070,6 +3121,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -3081,6 +3133,7 @@ presubmits:
     name: integ-assertion_istio_release-1.12
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3135,6 +3188,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -3143,6 +3197,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3176,6 +3231,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -3184,6 +3240,7 @@ presubmits:
     decorate: true
     name: lint_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3217,6 +3274,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -3225,6 +3283,7 @@ presubmits:
     decorate: true
     name: gencheck_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3258,6 +3317,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_istio
@@ -3275,6 +3335,7 @@ presubmits:
       repo: tools
     name: release-notes_istio_release-1.12
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -3314,3 +3375,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -1994,6 +1994,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2032,6 +2033,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2040,6 +2042,7 @@ presubmits:
     decorate: true
     name: release-test_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2078,6 +2081,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2087,6 +2091,7 @@ presubmits:
     name: benchmark_istio_release-1.13
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2121,6 +2126,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2129,6 +2135,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2183,6 +2190,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2191,6 +2199,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2243,6 +2252,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2251,6 +2261,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-mc_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2305,6 +2316,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2313,6 +2325,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-istiodremote_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2369,6 +2382,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2380,6 +2395,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2437,6 +2453,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2445,6 +2463,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2499,6 +2518,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2507,6 +2527,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2563,6 +2584,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2571,6 +2593,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2623,6 +2646,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2631,6 +2656,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2683,6 +2709,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2691,6 +2718,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2745,6 +2773,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2753,6 +2783,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -2811,6 +2842,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2819,6 +2852,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote-mc_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -2877,6 +2911,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2888,6 +2924,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2945,6 +2982,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -2953,6 +2992,7 @@ presubmits:
     decorate: true
     name: integ-security_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3005,6 +3045,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3013,6 +3054,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3067,6 +3109,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3075,6 +3119,7 @@ presubmits:
     decorate: true
     name: integ-security-istiodremote_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3133,6 +3178,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3144,6 +3191,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3201,6 +3249,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3209,6 +3259,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3261,6 +3312,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3272,6 +3324,7 @@ presubmits:
     name: integ-assertion_istio_release-1.13
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3326,6 +3379,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3334,6 +3388,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3367,6 +3422,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3375,6 +3431,7 @@ presubmits:
     decorate: true
     name: lint_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3408,6 +3465,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3416,6 +3474,7 @@ presubmits:
     decorate: true
     name: gencheck_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3449,6 +3508,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_istio
@@ -3466,6 +3526,7 @@ presubmits:
       repo: tools
     name: release-notes_istio_release-1.13
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -3505,3 +3566,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
@@ -2094,6 +2094,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2132,6 +2133,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2140,6 +2142,7 @@ presubmits:
     decorate: true
     name: release-test_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2178,6 +2181,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2187,6 +2191,7 @@ presubmits:
     name: benchmark_istio_release-1.14
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2221,6 +2226,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2229,6 +2235,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2284,6 +2291,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2292,6 +2300,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2345,6 +2354,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2353,6 +2363,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-mc_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2408,6 +2419,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2416,6 +2428,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-istiodremote_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2473,6 +2486,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2484,6 +2499,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-telemetry-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -2542,6 +2558,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodless-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2550,6 +2568,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2605,6 +2624,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2613,6 +2633,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2670,6 +2691,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2678,6 +2700,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2731,6 +2754,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2739,6 +2764,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2792,6 +2818,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2800,6 +2827,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2855,6 +2883,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2863,6 +2893,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -2922,6 +2953,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -2930,6 +2963,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote-mc_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -2989,6 +3023,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3000,6 +3036,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-pilot-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3058,6 +3095,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodless-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3066,6 +3105,7 @@ presubmits:
     decorate: true
     name: integ-security_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3119,6 +3159,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3127,6 +3168,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3182,6 +3224,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3190,6 +3234,7 @@ presubmits:
     decorate: true
     name: integ-security-istiodremote_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3249,6 +3294,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3260,6 +3307,7 @@ presubmits:
     path_alias: istio.io/istio
     reporter_config:
       slack: {}
+    rerun_command: /test integ-security-istiodless-mc
     skip_report: true
     spec:
       containers:
@@ -3318,6 +3366,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodless-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodless-mc_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3326,6 +3376,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3379,6 +3430,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3390,6 +3442,7 @@ presubmits:
     name: integ-assertion_istio_release-1.14
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3445,6 +3498,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3453,6 +3507,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3487,6 +3542,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3495,6 +3551,7 @@ presubmits:
     decorate: true
     name: lint_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3528,6 +3585,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3536,6 +3594,7 @@ presubmits:
     decorate: true
     name: gencheck_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3570,6 +3629,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_istio
@@ -3587,6 +3647,7 @@ presubmits:
       repo: tools
     name: release-notes_istio_release-1.14
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -3627,3 +3688,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
@@ -2172,6 +2172,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -2210,6 +2211,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2219,6 +2221,7 @@ presubmits:
     decorate: true
     name: unit-tests-arm64_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests-arm64
     spec:
       containers:
       - command:
@@ -2263,6 +2266,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests-arm64,?($|\s.*))|((?m)^/test( | .* )unit-tests-arm64_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2271,6 +2275,7 @@ presubmits:
     decorate: true
     name: release-test_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -2309,6 +2314,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2318,6 +2324,7 @@ presubmits:
     name: benchmark_istio_release-1.15
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -2352,6 +2359,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2360,6 +2368,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -2415,6 +2424,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2423,6 +2433,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -2476,6 +2487,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2484,6 +2496,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-mc_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -2539,6 +2552,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2547,6 +2561,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-istiodremote_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -2606,6 +2621,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2614,6 +2631,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -2669,6 +2687,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2677,6 +2696,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -2734,6 +2754,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2743,6 +2764,7 @@ presubmits:
     decorate: true
     name: integ-basic-arm64_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-basic-arm64
     spec:
       containers:
       - command:
@@ -2801,6 +2823,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2809,6 +2832,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -2862,6 +2886,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2870,6 +2896,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -2923,6 +2950,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2931,6 +2959,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -2986,6 +3015,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -2994,6 +3025,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -3053,6 +3085,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3061,6 +3095,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote-mc_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -3120,6 +3155,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3128,6 +3165,7 @@ presubmits:
     decorate: true
     name: integ-security_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -3181,6 +3219,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3189,6 +3228,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -3244,6 +3284,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3252,6 +3294,7 @@ presubmits:
     decorate: true
     name: integ-security-istiodremote_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -3311,6 +3354,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3319,6 +3364,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -3372,6 +3418,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3383,6 +3430,7 @@ presubmits:
     name: integ-assertion_istio_release-1.15
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -3438,6 +3486,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3446,6 +3495,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -3480,6 +3530,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3488,6 +3539,7 @@ presubmits:
     decorate: true
     name: lint_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -3521,6 +3573,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3529,6 +3582,7 @@ presubmits:
     decorate: true
     name: gencheck_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -3563,6 +3617,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_istio
@@ -3580,6 +3635,7 @@ presubmits:
       repo: tools
     name: release-notes_istio_release-1.15
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -3620,3 +3676,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -10,6 +10,7 @@ presubmits:
     decorate: true
     name: unit-tests_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests
     spec:
       containers:
       - command:
@@ -48,6 +49,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -57,6 +59,7 @@ presubmits:
     decorate: true
     name: unit-tests-arm64_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test unit-tests-arm64
     spec:
       containers:
       - command:
@@ -100,6 +103,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )unit-tests-arm64,?($|\s.*))|((?m)^/test( | .* )unit-tests-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -109,6 +113,7 @@ presubmits:
     decorate: true
     name: release-test_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -147,6 +152,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
@@ -157,6 +163,7 @@ presubmits:
     name: benchmark_istio_exp_ds
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test benchmark
     spec:
       containers:
       - command:
@@ -191,6 +198,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark,?($|\s.*))|((?m)^/test( | .* )benchmark_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -200,6 +208,7 @@ presubmits:
     decorate: true
     name: integ-cni_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-cni
     spec:
       containers:
       - command:
@@ -255,6 +264,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -264,6 +274,7 @@ presubmits:
     decorate: true
     name: integ-telemetry_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry
     spec:
       containers:
       - command:
@@ -317,6 +328,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -326,6 +338,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-mc_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-mc
     spec:
       containers:
       - command:
@@ -381,6 +394,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -390,6 +404,7 @@ presubmits:
     decorate: true
     name: integ-telemetry-istiodremote_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-telemetry-istiodremote
     spec:
       containers:
       - command:
@@ -449,6 +464,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-telemetry-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -458,6 +475,7 @@ presubmits:
     decorate: true
     name: integ-distroless_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-distroless
     spec:
       containers:
       - command:
@@ -513,6 +531,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -522,6 +541,7 @@ presubmits:
     decorate: true
     name: integ-ipv6_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-ipv6
     spec:
       containers:
       - command:
@@ -579,6 +599,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -588,6 +609,7 @@ presubmits:
     decorate: true
     name: integ-basic-arm64_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-basic-arm64
     spec:
       containers:
       - command:
@@ -646,6 +668,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -655,6 +678,7 @@ presubmits:
     decorate: true
     name: integ-operator-controller_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-operator-controller
     spec:
       containers:
       - command:
@@ -708,6 +732,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-operator-controller,?($|\s.*))|((?m)^/test(
+      | .* )integ-operator-controller_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -717,6 +743,7 @@ presubmits:
     decorate: true
     name: integ-pilot_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot
     spec:
       containers:
       - command:
@@ -770,6 +797,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -779,6 +807,7 @@ presubmits:
     decorate: true
     name: integ-pilot-multicluster_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-multicluster
     spec:
       containers:
       - command:
@@ -834,6 +863,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-multicluster_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -843,6 +874,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote
     spec:
       containers:
       - command:
@@ -902,6 +934,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -911,6 +945,7 @@ presubmits:
     decorate: true
     name: integ-pilot-istiodremote-mc_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-istiodremote-mc
     spec:
       containers:
       - command:
@@ -970,6 +1005,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
+      | .* )integ-pilot-istiodremote-mc_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -979,6 +1016,7 @@ presubmits:
     decorate: true
     name: integ-security_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-security
     spec:
       containers:
       - command:
@@ -1032,6 +1070,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1041,6 +1080,7 @@ presubmits:
     decorate: true
     name: integ-security-multicluster_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-multicluster
     spec:
       containers:
       - command:
@@ -1096,6 +1136,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-multicluster_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1105,6 +1147,7 @@ presubmits:
     decorate: true
     name: integ-security-istiodremote_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-security-istiodremote
     spec:
       containers:
       - command:
@@ -1164,6 +1207,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
+      | .* )integ-security-istiodremote_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1173,6 +1218,7 @@ presubmits:
     decorate: true
     name: integ-helm_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test integ-helm
     spec:
       containers:
       - command:
@@ -1226,6 +1272,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
@@ -1238,6 +1285,7 @@ presubmits:
     name: integ-assertion_istio_exp_ds
     optional: true
     path_alias: istio.io/istio
+    rerun_command: /test integ-assertion
     spec:
       containers:
       - command:
@@ -1293,6 +1341,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1302,6 +1351,7 @@ presubmits:
     decorate: true
     name: analyze-tests_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test analyze-tests
     spec:
       containers:
       - command:
@@ -1336,6 +1386,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )analyze-tests,?($|\s.*))|((?m)^/test( | .* )analyze-tests_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1345,6 +1396,7 @@ presubmits:
     decorate: true
     name: lint_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -1378,6 +1430,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1387,6 +1440,7 @@ presubmits:
     decorate: true
     name: gencheck_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -1421,6 +1475,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1439,6 +1494,7 @@ presubmits:
       repo: tools
     name: release-notes_istio_exp_ds
     path_alias: istio.io/istio
+    rerun_command: /test release-notes
     spec:
       containers:
       - command:
@@ -1479,3 +1535,4 @@ presubmits:
       - name: github
         secret:
           secretName: oauth-token
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio,?($|\s.*))

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -230,6 +230,7 @@ presubmits:
     decorate: true
     name: build_pkg
     path_alias: istio.io/pkg
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -261,6 +262,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_pkg,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_pkg
@@ -269,6 +271,7 @@ presubmits:
     decorate: true
     name: lint_pkg
     path_alias: istio.io/pkg
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -300,6 +303,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_pkg,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_pkg
@@ -308,6 +312,7 @@ presubmits:
     decorate: true
     name: test_pkg
     path_alias: istio.io/pkg
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -339,6 +344,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_pkg,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_pkg
@@ -347,6 +353,7 @@ presubmits:
     decorate: true
     name: gencheck_pkg
     path_alias: istio.io/pkg
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -378,3 +385,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_pkg,?($|\s.*))

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.11.gen.yaml
@@ -230,6 +230,7 @@ presubmits:
     decorate: true
     name: build_pkg_release-1.11
     path_alias: istio.io/pkg
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -261,6 +262,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_pkg_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_pkg
@@ -269,6 +271,7 @@ presubmits:
     decorate: true
     name: lint_pkg_release-1.11
     path_alias: istio.io/pkg
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -300,6 +303,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_pkg_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_pkg
@@ -308,6 +312,7 @@ presubmits:
     decorate: true
     name: test_pkg_release-1.11
     path_alias: istio.io/pkg
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -339,6 +344,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_pkg_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_pkg
@@ -347,6 +353,7 @@ presubmits:
     decorate: true
     name: gencheck_pkg_release-1.11
     path_alias: istio.io/pkg
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -378,3 +385,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_pkg_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.12.gen.yaml
@@ -230,6 +230,7 @@ presubmits:
     decorate: true
     name: build_pkg_release-1.12
     path_alias: istio.io/pkg
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -261,6 +262,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_pkg_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_pkg
@@ -269,6 +271,7 @@ presubmits:
     decorate: true
     name: lint_pkg_release-1.12
     path_alias: istio.io/pkg
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -300,6 +303,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_pkg_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_pkg
@@ -308,6 +312,7 @@ presubmits:
     decorate: true
     name: test_pkg_release-1.12
     path_alias: istio.io/pkg
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -339,6 +344,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_pkg_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_pkg
@@ -347,6 +353,7 @@ presubmits:
     decorate: true
     name: gencheck_pkg_release-1.12
     path_alias: istio.io/pkg
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -378,3 +385,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_pkg_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.13.gen.yaml
@@ -230,6 +230,7 @@ presubmits:
     decorate: true
     name: build_pkg_release-1.13
     path_alias: istio.io/pkg
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -261,6 +262,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_pkg_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_pkg
@@ -269,6 +271,7 @@ presubmits:
     decorate: true
     name: lint_pkg_release-1.13
     path_alias: istio.io/pkg
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -300,6 +303,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_pkg_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_pkg
@@ -308,6 +312,7 @@ presubmits:
     decorate: true
     name: test_pkg_release-1.13
     path_alias: istio.io/pkg
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -339,6 +344,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_pkg_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_pkg
@@ -347,6 +353,7 @@ presubmits:
     decorate: true
     name: gencheck_pkg_release-1.13
     path_alias: istio.io/pkg
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -378,3 +385,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_pkg_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.14.gen.yaml
@@ -230,6 +230,7 @@ presubmits:
     decorate: true
     name: build_pkg_release-1.14
     path_alias: istio.io/pkg
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -261,6 +262,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_pkg_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_pkg
@@ -269,6 +271,7 @@ presubmits:
     decorate: true
     name: lint_pkg_release-1.14
     path_alias: istio.io/pkg
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -300,6 +303,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_pkg_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_pkg
@@ -308,6 +312,7 @@ presubmits:
     decorate: true
     name: test_pkg_release-1.14
     path_alias: istio.io/pkg
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -339,6 +344,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_pkg_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_pkg
@@ -347,6 +353,7 @@ presubmits:
     decorate: true
     name: gencheck_pkg_release-1.14
     path_alias: istio.io/pkg
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -378,3 +385,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_pkg_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.15.gen.yaml
@@ -230,6 +230,7 @@ presubmits:
     decorate: true
     name: build_pkg_release-1.15
     path_alias: istio.io/pkg
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -261,6 +262,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_pkg_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_pkg
@@ -269,6 +271,7 @@ presubmits:
     decorate: true
     name: lint_pkg_release-1.15
     path_alias: istio.io/pkg
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -300,6 +303,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_pkg_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_pkg
@@ -308,6 +312,7 @@ presubmits:
     decorate: true
     name: test_pkg_release-1.15
     path_alias: istio.io/pkg
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -339,6 +344,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_pkg_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_pkg
@@ -347,6 +353,7 @@ presubmits:
     decorate: true
     name: gencheck_pkg_release-1.15
     path_alias: istio.io/pkg
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -378,3 +385,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_pkg_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -278,6 +278,7 @@ presubmits:
       timeout: 4h0m0s
     name: test_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -309,6 +310,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -319,6 +321,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -350,6 +353,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -360,6 +364,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-tsan_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -391,6 +396,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -401,6 +407,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -432,6 +439,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -443,6 +451,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test-arm64_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test release-test-arm64
     spec:
       containers:
       - command:
@@ -480,6 +489,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test-arm64,?($|\s.*))|((?m)^/test( | .* )release-test-arm64_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -490,6 +500,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-centos-test_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -521,6 +532,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
@@ -531,6 +543,7 @@ presubmits:
       timeout: 4h0m0s
     name: check-wasm_proxy
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -567,3 +580,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy,?($|\s.*))

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.11.gen.yaml
@@ -162,6 +162,7 @@ presubmits:
       timeout: 4h0m0s
     name: test_proxy_release-1.11
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -193,6 +194,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_proxy
@@ -203,6 +205,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_proxy_release-1.11
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -234,6 +237,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_proxy
@@ -244,6 +248,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-tsan_proxy_release-1.11
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -275,6 +280,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_proxy
@@ -285,6 +291,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test_proxy_release-1.11
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -316,6 +323,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_proxy
@@ -326,6 +334,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-centos-test_proxy_release-1.11
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -357,6 +366,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_proxy
@@ -367,6 +377,7 @@ presubmits:
       timeout: 4h0m0s
     name: check-wasm_proxy_release-1.11
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -403,3 +414,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.12.gen.yaml
@@ -162,6 +162,7 @@ presubmits:
       timeout: 4h0m0s
     name: test_proxy_release-1.12
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -193,6 +194,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_proxy
@@ -203,6 +205,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_proxy_release-1.12
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -234,6 +237,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_proxy
@@ -244,6 +248,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-tsan_proxy_release-1.12
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -275,6 +280,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_proxy
@@ -285,6 +291,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test_proxy_release-1.12
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -316,6 +323,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_proxy
@@ -326,6 +334,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-centos-test_proxy_release-1.12
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -357,6 +366,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_proxy
@@ -367,6 +377,7 @@ presubmits:
       timeout: 4h0m0s
     name: check-wasm_proxy_release-1.12
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -403,3 +414,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.13.gen.yaml
@@ -224,6 +224,7 @@ presubmits:
       timeout: 4h0m0s
     name: test_proxy_release-1.13
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -255,6 +256,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_proxy
@@ -265,6 +267,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_proxy_release-1.13
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -296,6 +299,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_proxy
@@ -306,6 +310,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-tsan_proxy_release-1.13
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -337,6 +342,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_proxy
@@ -347,6 +353,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test_proxy_release-1.13
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -378,6 +385,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_proxy
@@ -388,6 +396,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-centos-test_proxy_release-1.13
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -419,6 +428,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_proxy
@@ -429,6 +439,7 @@ presubmits:
       timeout: 4h0m0s
     name: check-wasm_proxy_release-1.13
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -465,3 +476,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.14.gen.yaml
@@ -224,6 +224,7 @@ presubmits:
       timeout: 4h0m0s
     name: test_proxy_release-1.14
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -255,6 +256,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_proxy
@@ -265,6 +267,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_proxy_release-1.14
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -296,6 +299,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_proxy
@@ -306,6 +310,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-tsan_proxy_release-1.14
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -337,6 +342,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_proxy
@@ -347,6 +353,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test_proxy_release-1.14
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -378,6 +385,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_proxy
@@ -388,6 +396,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-centos-test_proxy_release-1.14
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -419,6 +428,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_proxy
@@ -429,6 +439,7 @@ presubmits:
       timeout: 4h0m0s
     name: check-wasm_proxy_release-1.14
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -465,3 +476,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.15.gen.yaml
@@ -278,6 +278,7 @@ presubmits:
       timeout: 4h0m0s
     name: test_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -309,6 +310,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_proxy
@@ -319,6 +321,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-asan_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test test-asan
     spec:
       containers:
       - command:
@@ -350,6 +353,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-asan,?($|\s.*))|((?m)^/test( | .* )test-asan_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_proxy
@@ -360,6 +364,7 @@ presubmits:
       timeout: 4h0m0s
     name: test-tsan_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test test-tsan
     spec:
       containers:
       - command:
@@ -391,6 +396,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_proxy
@@ -401,6 +407,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test release-test
     spec:
       containers:
       - command:
@@ -432,6 +439,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test,?($|\s.*))|((?m)^/test( | .* )release-test_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_proxy
@@ -443,6 +451,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-test-arm64_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test release-test-arm64
     spec:
       containers:
       - command:
@@ -480,6 +489,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-test-arm64,?($|\s.*))|((?m)^/test( | .* )release-test-arm64_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_proxy
@@ -490,6 +500,7 @@ presubmits:
       timeout: 4h0m0s
     name: release-centos-test_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test release-centos-test
     spec:
       containers:
       - command:
@@ -521,6 +532,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )release-centos-test,?($|\s.*))|((?m)^/test( | .* )release-centos-test_proxy_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_proxy
@@ -531,6 +543,7 @@ presubmits:
       timeout: 4h0m0s
     name: check-wasm_proxy_release-1.15
     path_alias: istio.io/proxy
+    rerun_command: /test check-wasm
     spec:
       containers:
       - command:
@@ -567,3 +580,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -434,6 +434,7 @@ presubmits:
     decorate: true
     name: lint_release-builder
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -465,6 +466,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-builder
@@ -473,6 +475,7 @@ presubmits:
     decorate: true
     name: test_release-builder
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -504,6 +507,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-builder
@@ -512,6 +516,7 @@ presubmits:
     decorate: true
     name: gencheck_release-builder
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -543,6 +548,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-builder
@@ -551,6 +557,7 @@ presubmits:
     decorate: true
     name: dry-run_release-builder
     path_alias: istio.io/release-builder
+    rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
       containers:
@@ -588,6 +595,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )dry-run,?($|\s.*))|((?m)^/test( | .* )dry-run_release-builder,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-builder
@@ -597,6 +605,7 @@ presubmits:
     name: build-warning_release-builder
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -628,6 +637,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-builder
@@ -637,6 +647,7 @@ presubmits:
     name: publish-warning_release-builder
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
       containers:
@@ -668,3 +679,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )publish-warning,?($|\s.*))|((?m)^/test( | .* )publish-warning_release-builder,?($|\s.*))

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.11.gen.yaml
@@ -339,6 +339,7 @@ presubmits:
     decorate: true
     name: lint_release-builder_release-1.11
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -370,6 +371,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_release-builder
@@ -378,6 +380,7 @@ presubmits:
     decorate: true
     name: test_release-builder_release-1.11
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -409,6 +412,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_release-builder
@@ -417,6 +421,7 @@ presubmits:
     decorate: true
     name: gencheck_release-builder_release-1.11
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -448,6 +453,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_release-builder
@@ -456,6 +462,7 @@ presubmits:
     decorate: true
     name: dry-run_release-builder_release-1.11
     path_alias: istio.io/release-builder
+    rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
       containers:
@@ -493,6 +500,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )dry-run,?($|\s.*))|((?m)^/test( | .* )dry-run_release-builder_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_release-builder
@@ -502,6 +510,7 @@ presubmits:
     name: build-warning_release-builder_release-1.11
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -533,6 +542,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_release-builder
@@ -542,6 +552,7 @@ presubmits:
     name: publish-warning_release-builder_release-1.11
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
       containers:
@@ -573,3 +584,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )publish-warning,?($|\s.*))|((?m)^/test( | .* )publish-warning_release-builder_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.12.gen.yaml
@@ -281,6 +281,7 @@ presubmits:
     decorate: true
     name: lint_release-builder_release-1.12
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -312,6 +313,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_release-builder
@@ -320,6 +322,7 @@ presubmits:
     decorate: true
     name: test_release-builder_release-1.12
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -351,6 +354,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_release-builder
@@ -359,6 +363,7 @@ presubmits:
     decorate: true
     name: gencheck_release-builder_release-1.12
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -390,6 +395,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_release-builder
@@ -398,6 +404,7 @@ presubmits:
     decorate: true
     name: dry-run_release-builder_release-1.12
     path_alias: istio.io/release-builder
+    rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
       containers:
@@ -435,6 +442,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )dry-run,?($|\s.*))|((?m)^/test( | .* )dry-run_release-builder_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_release-builder
@@ -444,6 +452,7 @@ presubmits:
     name: build-warning_release-builder_release-1.12
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -475,6 +484,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_release-builder
@@ -484,6 +494,7 @@ presubmits:
     name: publish-warning_release-builder_release-1.12
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
       containers:
@@ -515,3 +526,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )publish-warning,?($|\s.*))|((?m)^/test( | .* )publish-warning_release-builder_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.13.gen.yaml
@@ -347,6 +347,7 @@ presubmits:
     decorate: true
     name: lint_release-builder_release-1.13
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -378,6 +379,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_release-builder
@@ -386,6 +388,7 @@ presubmits:
     decorate: true
     name: test_release-builder_release-1.13
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -417,6 +420,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_release-builder
@@ -425,6 +429,7 @@ presubmits:
     decorate: true
     name: gencheck_release-builder_release-1.13
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -456,6 +461,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_release-builder
@@ -464,6 +470,7 @@ presubmits:
     decorate: true
     name: dry-run_release-builder_release-1.13
     path_alias: istio.io/release-builder
+    rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
       containers:
@@ -501,6 +508,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )dry-run,?($|\s.*))|((?m)^/test( | .* )dry-run_release-builder_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_release-builder
@@ -510,6 +518,7 @@ presubmits:
     name: build-warning_release-builder_release-1.13
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -541,6 +550,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_release-builder
@@ -550,6 +560,7 @@ presubmits:
     name: publish-warning_release-builder_release-1.13
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
       containers:
@@ -581,3 +592,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )publish-warning,?($|\s.*))|((?m)^/test( | .* )publish-warning_release-builder_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.14.gen.yaml
@@ -347,6 +347,7 @@ presubmits:
     decorate: true
     name: lint_release-builder_release-1.14
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -378,6 +379,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_release-builder
@@ -386,6 +388,7 @@ presubmits:
     decorate: true
     name: test_release-builder_release-1.14
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -417,6 +420,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_release-builder
@@ -425,6 +429,7 @@ presubmits:
     decorate: true
     name: gencheck_release-builder_release-1.14
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -456,6 +461,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_release-builder
@@ -464,6 +470,7 @@ presubmits:
     decorate: true
     name: dry-run_release-builder_release-1.14
     path_alias: istio.io/release-builder
+    rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
       containers:
@@ -501,6 +508,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )dry-run,?($|\s.*))|((?m)^/test( | .* )dry-run_release-builder_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_release-builder
@@ -510,6 +518,7 @@ presubmits:
     name: build-warning_release-builder_release-1.14
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -541,6 +550,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_release-builder
@@ -550,6 +560,7 @@ presubmits:
     name: publish-warning_release-builder_release-1.14
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
       containers:
@@ -581,3 +592,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )publish-warning,?($|\s.*))|((?m)^/test( | .* )publish-warning_release-builder_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.15.gen.yaml
@@ -434,6 +434,7 @@ presubmits:
     decorate: true
     name: lint_release-builder_release-1.15
     path_alias: istio.io/release-builder
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -465,6 +466,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_release-builder_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_release-builder
@@ -473,6 +475,7 @@ presubmits:
     decorate: true
     name: test_release-builder_release-1.15
     path_alias: istio.io/release-builder
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -504,6 +507,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_release-builder_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_release-builder
@@ -512,6 +516,7 @@ presubmits:
     decorate: true
     name: gencheck_release-builder_release-1.15
     path_alias: istio.io/release-builder
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -543,6 +548,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_release-builder_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_release-builder
@@ -551,6 +557,7 @@ presubmits:
     decorate: true
     name: dry-run_release-builder_release-1.15
     path_alias: istio.io/release-builder
+    rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
       containers:
@@ -588,6 +595,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )dry-run,?($|\s.*))|((?m)^/test( | .* )dry-run_release-builder_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_release-builder
@@ -597,6 +605,7 @@ presubmits:
     name: build-warning_release-builder_release-1.15
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
       containers:
@@ -628,6 +637,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build-warning,?($|\s.*))|((?m)^/test( | .* )build-warning_release-builder_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_release-builder
@@ -637,6 +647,7 @@ presubmits:
     name: publish-warning_release-builder_release-1.15
     optional: true
     path_alias: istio.io/release-builder
+    rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
       containers:
@@ -668,3 +679,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )publish-warning,?($|\s.*))|((?m)^/test( | .* )publish-warning_release-builder_release-1.15,?($|\s.*))

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -398,6 +398,7 @@ presubmits:
     decorate: true
     name: lint_test-infra
     path_alias: istio.io/test-infra
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -429,6 +430,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_test-infra,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_test-infra
@@ -437,6 +439,7 @@ presubmits:
     decorate: true
     name: test_test-infra
     path_alias: istio.io/test-infra
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -468,6 +471,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_test-infra,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_test-infra
@@ -476,6 +480,7 @@ presubmits:
     decorate: true
     name: gencheck_test-infra
     path_alias: istio.io/test-infra
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -507,3 +512,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_test-infra,?($|\s.*))

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -344,6 +344,7 @@ presubmits:
     decorate: true
     name: build_tools
     path_alias: istio.io/tools
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -375,6 +376,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_tools,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_tools
@@ -383,6 +385,7 @@ presubmits:
     decorate: true
     name: lint_tools
     path_alias: istio.io/tools
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -414,6 +417,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_tools,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_tools
@@ -422,6 +426,7 @@ presubmits:
     decorate: true
     name: test_tools
     path_alias: istio.io/tools
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -453,6 +458,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_tools,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_tools
@@ -461,6 +467,7 @@ presubmits:
     decorate: true
     name: gencheck_tools
     path_alias: istio.io/tools
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -492,6 +499,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_tools,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_tools
@@ -501,6 +509,7 @@ presubmits:
     name: benchmark_check_tools
     optional: true
     path_alias: istio.io/tools
+    rerun_command: /test benchmark_check
     run_if_changed: ^perf/benchmark/
     spec:
       containers:
@@ -536,6 +545,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )benchmark_check,?($|\s.*))|((?m)^/test( | .* )benchmark_check_tools,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_tools
@@ -544,6 +554,7 @@ presubmits:
     decorate: true
     name: containers-test_tools
     path_alias: istio.io/tools
+    rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -582,6 +593,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test,?($|\s.*))|((?m)^/test( | .* )containers-test_tools,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_tools
@@ -591,6 +603,7 @@ presubmits:
     decorate: true
     name: containers-test-arm64_tools
     path_alias: istio.io/tools
+    rerun_command: /test containers-test-arm64
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -634,3 +647,5 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test-arm64,?($|\s.*))|((?m)^/test( | .*
+      )containers-test-arm64_tools,?($|\s.*))

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.11.gen.yaml
@@ -267,6 +267,7 @@ presubmits:
     decorate: true
     name: build_tools_release-1.11
     path_alias: istio.io/tools
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -298,6 +299,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_tools_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_tools
@@ -306,6 +308,7 @@ presubmits:
     decorate: true
     name: lint_tools_release-1.11
     path_alias: istio.io/tools
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -337,6 +340,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_tools_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_tools
@@ -345,6 +349,7 @@ presubmits:
     decorate: true
     name: test_tools_release-1.11
     path_alias: istio.io/tools
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -376,6 +381,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_tools_release-1.11,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.11_tools
@@ -384,6 +390,7 @@ presubmits:
     decorate: true
     name: gencheck_tools_release-1.11
     path_alias: istio.io/tools
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -415,6 +422,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_tools_release-1.11,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.11_tools
@@ -423,6 +431,7 @@ presubmits:
     decorate: true
     name: containers-test_tools_release-1.11
     path_alias: istio.io/tools
+    rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -461,3 +470,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test,?($|\s.*))|((?m)^/test( | .* )containers-test_tools_release-1.11,?($|\s.*))

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.12.gen.yaml
@@ -288,6 +288,7 @@ presubmits:
     decorate: true
     name: build_tools_release-1.12
     path_alias: istio.io/tools
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -319,6 +320,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_tools_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_tools
@@ -327,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_tools_release-1.12
     path_alias: istio.io/tools
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -358,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_tools_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_tools
@@ -366,6 +370,7 @@ presubmits:
     decorate: true
     name: test_tools_release-1.12
     path_alias: istio.io/tools
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -397,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_tools_release-1.12,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.12_tools
@@ -405,6 +411,7 @@ presubmits:
     decorate: true
     name: gencheck_tools_release-1.12
     path_alias: istio.io/tools
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -436,6 +443,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_tools_release-1.12,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.12_tools
@@ -444,6 +452,7 @@ presubmits:
     decorate: true
     name: containers-test_tools_release-1.12
     path_alias: istio.io/tools
+    rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -482,3 +491,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test,?($|\s.*))|((?m)^/test( | .* )containers-test_tools_release-1.12,?($|\s.*))

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.13.gen.yaml
@@ -288,6 +288,7 @@ presubmits:
     decorate: true
     name: build_tools_release-1.13
     path_alias: istio.io/tools
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -319,6 +320,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_tools_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_tools
@@ -327,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_tools_release-1.13
     path_alias: istio.io/tools
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -358,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_tools_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_tools
@@ -366,6 +370,7 @@ presubmits:
     decorate: true
     name: test_tools_release-1.13
     path_alias: istio.io/tools
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -397,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_tools_release-1.13,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.13_tools
@@ -405,6 +411,7 @@ presubmits:
     decorate: true
     name: gencheck_tools_release-1.13
     path_alias: istio.io/tools
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -436,6 +443,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_tools_release-1.13,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.13_tools
@@ -444,6 +452,7 @@ presubmits:
     decorate: true
     name: containers-test_tools_release-1.13
     path_alias: istio.io/tools
+    rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -482,3 +491,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test,?($|\s.*))|((?m)^/test( | .* )containers-test_tools_release-1.13,?($|\s.*))

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.14.gen.yaml
@@ -288,6 +288,7 @@ presubmits:
     decorate: true
     name: build_tools_release-1.14
     path_alias: istio.io/tools
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -319,6 +320,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_tools_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_tools
@@ -327,6 +329,7 @@ presubmits:
     decorate: true
     name: lint_tools_release-1.14
     path_alias: istio.io/tools
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -358,6 +361,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_tools_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_tools
@@ -366,6 +370,7 @@ presubmits:
     decorate: true
     name: test_tools_release-1.14
     path_alias: istio.io/tools
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -397,6 +402,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_tools_release-1.14,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.14_tools
@@ -405,6 +411,7 @@ presubmits:
     decorate: true
     name: gencheck_tools_release-1.14
     path_alias: istio.io/tools
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -436,6 +443,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_tools_release-1.14,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.14_tools
@@ -444,6 +452,7 @@ presubmits:
     decorate: true
     name: containers-test_tools_release-1.14
     path_alias: istio.io/tools
+    rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -482,3 +491,4 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test,?($|\s.*))|((?m)^/test( | .* )containers-test_tools_release-1.14,?($|\s.*))

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.15.gen.yaml
@@ -344,6 +344,7 @@ presubmits:
     decorate: true
     name: build_tools_release-1.15
     path_alias: istio.io/tools
+    rerun_command: /test build
     spec:
       containers:
       - command:
@@ -375,6 +376,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )build,?($|\s.*))|((?m)^/test( | .* )build_tools_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_tools
@@ -383,6 +385,7 @@ presubmits:
     decorate: true
     name: lint_tools_release-1.15
     path_alias: istio.io/tools
+    rerun_command: /test lint
     spec:
       containers:
       - command:
@@ -414,6 +417,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_tools_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_tools
@@ -422,6 +426,7 @@ presubmits:
     decorate: true
     name: test_tools_release-1.15
     path_alias: istio.io/tools
+    rerun_command: /test test
     spec:
       containers:
       - command:
@@ -453,6 +458,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_tools_release-1.15,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_release-1.15_tools
@@ -461,6 +467,7 @@ presubmits:
     decorate: true
     name: gencheck_tools_release-1.15
     path_alias: istio.io/tools
+    rerun_command: /test gencheck
     spec:
       containers:
       - command:
@@ -492,6 +499,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_tools_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_tools
@@ -500,6 +508,7 @@ presubmits:
     decorate: true
     name: containers-test_tools_release-1.15
     path_alias: istio.io/tools
+    rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -538,6 +547,7 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test,?($|\s.*))|((?m)^/test( | .* )containers-test_tools_release-1.15,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.15_tools
@@ -547,6 +557,7 @@ presubmits:
     decorate: true
     name: containers-test-arm64_tools_release-1.15
     path_alias: istio.io/tools
+    rerun_command: /test containers-test-arm64
     run_if_changed: docker/.+|cmd/.+
     spec:
       containers:
@@ -590,3 +601,5 @@ presubmits:
         name: build-cache
       - emptyDir: {}
         name: docker-root
+    trigger: ((?m)^/test( | .* )containers-test-arm64,?($|\s.*))|((?m)^/test( | .*
+      )containers-test-arm64_tools_release-1.15,?($|\s.*))

--- a/tools/prowgen/pkg/testdata/matrix.gen.yaml
+++ b/tools/prowgen/pkg/testdata/matrix.gen.yaml
@@ -635,6 +635,7 @@ presubmits:
     decorate: true
     name: test-kind-arg1-val1_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-kind-arg1-val1
     spec:
       containers:
       - command:
@@ -686,7 +687,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )test-kind-arg1-val1,?($|\s.*)|(?m)^/test( | .* )test-kind-arg1-val1_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-kind-arg1-val1,?($|\s.*))|((?m)^/test( | .* )test-kind-arg1-val1_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -697,6 +698,7 @@ presubmits:
       preset-service-account: "true"
     name: test-gcp-arg1-val1_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-gcp-arg1-val1
     spec:
       containers:
       - command:
@@ -730,7 +732,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-gcp-arg1-val1,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg1-val1_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-gcp-arg1-val1,?($|\s.*))|((?m)^/test( | .* )test-gcp-arg1-val1_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -739,6 +741,7 @@ presubmits:
     decorate: true
     name: test-kind-arg1-val2_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-kind-arg1-val2
     spec:
       containers:
       - command:
@@ -790,7 +793,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )test-kind-arg1-val2,?($|\s.*)|(?m)^/test( | .* )test-kind-arg1-val2_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-kind-arg1-val2,?($|\s.*))|((?m)^/test( | .* )test-kind-arg1-val2_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -801,6 +804,7 @@ presubmits:
       preset-service-account: "true"
     name: test-gcp-arg1-val2_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-gcp-arg1-val2
     spec:
       containers:
       - command:
@@ -834,7 +838,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-gcp-arg1-val2,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg1-val2_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-gcp-arg1-val2,?($|\s.*))|((?m)^/test( | .* )test-gcp-arg1-val2_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -843,6 +847,7 @@ presubmits:
     decorate: true
     name: test-kind-arg2-val1_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-kind-arg2-val1
     spec:
       containers:
       - command:
@@ -894,7 +899,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )test-kind-arg2-val1,?($|\s.*)|(?m)^/test( | .* )test-kind-arg2-val1_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-kind-arg2-val1,?($|\s.*))|((?m)^/test( | .* )test-kind-arg2-val1_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -905,6 +910,7 @@ presubmits:
       preset-service-account: "true"
     name: test-gcp-arg2-val1_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-gcp-arg2-val1
     spec:
       containers:
       - command:
@@ -938,7 +944,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-gcp-arg2-val1,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg2-val1_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-gcp-arg2-val1,?($|\s.*))|((?m)^/test( | .* )test-gcp-arg2-val1_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -947,6 +953,7 @@ presubmits:
     decorate: true
     name: test-kind-arg2-val2_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-kind-arg2-val2
     spec:
       containers:
       - command:
@@ -998,7 +1005,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )test-kind-arg2-val2,?($|\s.*)|(?m)^/test( | .* )test-kind-arg2-val2_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-kind-arg2-val2,?($|\s.*))|((?m)^/test( | .* )test-kind-arg2-val2_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1009,6 +1016,7 @@ presubmits:
       preset-service-account: "true"
     name: test-gcp-arg2-val2_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-gcp-arg2-val2
     spec:
       containers:
       - command:
@@ -1042,7 +1050,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-gcp-arg2-val2,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg2-val2_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-gcp-arg2-val2,?($|\s.*))|((?m)^/test( | .* )test-gcp-arg2-val2_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1051,6 +1059,7 @@ presubmits:
     decorate: true
     name: test-kind-arg3-val1_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-kind-arg3-val1
     spec:
       containers:
       - command:
@@ -1102,7 +1111,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )test-kind-arg3-val1,?($|\s.*)|(?m)^/test( | .* )test-kind-arg3-val1_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-kind-arg3-val1,?($|\s.*))|((?m)^/test( | .* )test-kind-arg3-val1_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1113,6 +1122,7 @@ presubmits:
       preset-service-account: "true"
     name: test-gcp-arg3-val1_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-gcp-arg3-val1
     spec:
       containers:
       - command:
@@ -1146,7 +1156,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-gcp-arg3-val1,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg3-val1_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-gcp-arg3-val1,?($|\s.*))|((?m)^/test( | .* )test-gcp-arg3-val1_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1155,6 +1165,7 @@ presubmits:
     decorate: true
     name: test-kind-arg3-val2_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-kind-arg3-val2
     spec:
       containers:
       - command:
@@ -1206,7 +1217,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )test-kind-arg3-val2,?($|\s.*)|(?m)^/test( | .* )test-kind-arg3-val2_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-kind-arg3-val2,?($|\s.*))|((?m)^/test( | .* )test-kind-arg3-val2_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1217,6 +1228,7 @@ presubmits:
       preset-service-account: "true"
     name: test-gcp-arg3-val2_istio
     path_alias: istio.io/istio
+    rerun_command: /test test-gcp-arg3-val2
     spec:
       containers:
       - command:
@@ -1250,4 +1262,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-gcp-arg3-val2,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg3-val2_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-gcp-arg3-val2,?($|\s.*))|((?m)^/test( | .* )test-gcp-arg3-val2_istio,?($|\s.*))

--- a/tools/prowgen/pkg/testdata/matrix.gen.yaml
+++ b/tools/prowgen/pkg/testdata/matrix.gen.yaml
@@ -686,6 +686,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )test-kind-arg1-val1,?($|\s.*)|(?m)^/test( | .* )test-kind-arg1-val1_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -729,6 +730,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-gcp-arg1-val1,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg1-val1_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -788,6 +790,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )test-kind-arg1-val2,?($|\s.*)|(?m)^/test( | .* )test-kind-arg1-val2_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -831,6 +834,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-gcp-arg1-val2,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg1-val2_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -890,6 +894,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )test-kind-arg2-val1,?($|\s.*)|(?m)^/test( | .* )test-kind-arg2-val1_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -933,6 +938,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-gcp-arg2-val1,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg2-val1_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -992,6 +998,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )test-kind-arg2-val2,?($|\s.*)|(?m)^/test( | .* )test-kind-arg2-val2_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1035,6 +1042,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-gcp-arg2-val2,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg2-val2_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1094,6 +1102,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )test-kind-arg3-val1,?($|\s.*)|(?m)^/test( | .* )test-kind-arg3-val1_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1137,6 +1146,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-gcp-arg3-val1,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg3-val1_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1196,6 +1206,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )test-kind-arg3-val2,?($|\s.*)|(?m)^/test( | .* )test-kind-arg3-val2_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
@@ -1239,3 +1250,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-gcp-arg3-val2,?($|\s.*)|(?m)^/test( | .* )test-gcp-arg3-val2_istio,?($|\s.*)

--- a/tools/prowgen/pkg/testdata/params.gen.yaml
+++ b/tools/prowgen/pkg/testdata/params.gen.yaml
@@ -129,3 +129,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )test-params-job1,?($|\s.*)|(?m)^/test( | .* )test-params-job1_istio_release-1.10,?($|\s.*)

--- a/tools/prowgen/pkg/testdata/params.gen.yaml
+++ b/tools/prowgen/pkg/testdata/params.gen.yaml
@@ -95,6 +95,7 @@ presubmits:
     decorate: true
     name: test-params-job1_istio_release-1.10
     path_alias: istio.io/istio
+    rerun_command: /test test-params-job1
     spec:
       containers:
       - args:
@@ -129,4 +130,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test-params-job1,?($|\s.*)|(?m)^/test( | .* )test-params-job1_istio_release-1.10,?($|\s.*)
+    trigger: ((?m)^/test( | .* )test-params-job1,?($|\s.*))|((?m)^/test( | .* )test-params-job1_istio_release-1.10,?($|\s.*))

--- a/tools/prowgen/pkg/testdata/simple.gen.yaml
+++ b/tools/prowgen/pkg/testdata/simple.gen.yaml
@@ -150,6 +150,7 @@ presubmits:
     - ^master$
     decorate: true
     name: test_istio
+    rerun_command: /test test
     run_if_changed: foo.*
     spec:
       containers:
@@ -181,7 +182,8 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )test,?($|\s.*)|(?m)^/test( | .* )test_istio,?($|\s.*)|((?m)^/test basic(\s+|$))
+    trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_istio,?($|\s.*))|((?m)^/test
+      basic(\s+|$))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -194,6 +196,7 @@ presubmits:
       path_alias: istio.io/istio
       repo: istio
     name: presubmit-kind_istio
+    rerun_command: /test presubmit-kind
     spec:
       containers:
       - command:
@@ -249,7 +252,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: (?m)^/test( | .* )presubmit-kind,?($|\s.*)|(?m)^/test( | .* )presubmit-kind_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )presubmit-kind,?($|\s.*))|((?m)^/test( | .* )presubmit-kind_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -259,6 +262,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     name: custom-node-selector_istio
+    rerun_command: /test custom-node-selector
     spec:
       containers:
       - args:
@@ -294,7 +298,8 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )custom-node-selector,?($|\s.*)|(?m)^/test( | .* )custom-node-selector_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )custom-node-selector,?($|\s.*))|((?m)^/test( | .*
+      )custom-node-selector_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -307,6 +312,7 @@ presubmits:
       path_alias: istio.io/istio
       repo: istio
     name: presubmit-skipped_istio
+    rerun_command: /test presubmit-skipped
     spec:
       containers:
       - command:
@@ -340,7 +346,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )presubmit-skipped,?($|\s.*)|(?m)^/test( | .* )presubmit-skipped_istio,?($|\s.*)|((?m)^/test
+    trigger: ((?m)^/test( | .* )presubmit-skipped,?($|\s.*))|((?m)^/test( | .* )presubmit-skipped_istio,?($|\s.*))|((?m)^/test
       basic(\s+|$))
   - always_run: true
     annotations:
@@ -349,6 +355,7 @@ presubmits:
     - ^master$
     decorate: true
     name: multi-arch_istio
+    rerun_command: /test multi-arch
     spec:
       containers:
       - command:
@@ -379,7 +386,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )multi-arch,?($|\s.*)|(?m)^/test( | .* )multi-arch_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )multi-arch,?($|\s.*))|((?m)^/test( | .* )multi-arch_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -388,6 +395,7 @@ presubmits:
     cluster: arm64-cluster
     decorate: true
     name: multi-arch-arm64_istio
+    rerun_command: /test multi-arch-arm64
     spec:
       containers:
       - command:
@@ -423,7 +431,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )multi-arch-arm64,?($|\s.*)|(?m)^/test( | .* )multi-arch-arm64_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )multi-arch-arm64,?($|\s.*))|((?m)^/test( | .* )multi-arch-arm64_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -431,6 +439,7 @@ presubmits:
     - ^master$
     decorate: true
     name: multi-arch-param_istio
+    rerun_command: /test multi-arch-param
     spec:
       containers:
       - command:
@@ -462,7 +471,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )multi-arch-param,?($|\s.*)|(?m)^/test( | .* )multi-arch-param_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )multi-arch-param,?($|\s.*))|((?m)^/test( | .* )multi-arch-param_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -471,6 +480,7 @@ presubmits:
     cluster: arm64-cluster
     decorate: true
     name: multi-arch-param-arm64_istio
+    rerun_command: /test multi-arch-param-arm64
     spec:
       containers:
       - command:
@@ -507,4 +517,5 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: (?m)^/test( | .* )multi-arch-param-arm64,?($|\s.*)|(?m)^/test( | .* )multi-arch-param-arm64_istio,?($|\s.*)
+    trigger: ((?m)^/test( | .* )multi-arch-param-arm64,?($|\s.*))|((?m)^/test( | .*
+      )multi-arch-param-arm64_istio,?($|\s.*))

--- a/tools/prowgen/pkg/testdata/simple.gen.yaml
+++ b/tools/prowgen/pkg/testdata/simple.gen.yaml
@@ -181,7 +181,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: ((?m)^/test( | .* )test_istio,?($|\s.*))|((?m)^/test basic(\s+|$))
+    trigger: (?m)^/test( | .* )test,?($|\s.*)|(?m)^/test( | .* )test_istio,?($|\s.*)|((?m)^/test basic(\s+|$))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -249,6 +249,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
+    trigger: (?m)^/test( | .* )presubmit-kind,?($|\s.*)|(?m)^/test( | .* )presubmit-kind_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -293,6 +294,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )custom-node-selector,?($|\s.*)|(?m)^/test( | .* )custom-node-selector_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -338,7 +340,8 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: ((?m)^/test( | .* )presubmit-skipped_istio,?($|\s.*))|((?m)^/test basic(\s+|$))
+    trigger: (?m)^/test( | .* )presubmit-skipped,?($|\s.*)|(?m)^/test( | .* )presubmit-skipped_istio,?($|\s.*)|((?m)^/test
+      basic(\s+|$))
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -376,6 +379,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )multi-arch,?($|\s.*)|(?m)^/test( | .* )multi-arch_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -419,6 +423,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )multi-arch-arm64,?($|\s.*)|(?m)^/test( | .* )multi-arch-arm64_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -457,6 +462,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )multi-arch-param,?($|\s.*)|(?m)^/test( | .* )multi-arch-param_istio,?($|\s.*)
   - always_run: true
     annotations:
       testgrid-dashboards: gerrit.istio_istio
@@ -501,3 +507,4 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+    trigger: (?m)^/test( | .* )multi-arch-param-arm64,?($|\s.*)|(?m)^/test( | .* )multi-arch-param-arm64_istio,?($|\s.*)


### PR DESCRIPTION
Currently we turn a test like `test-foo` into `test-foo_repo_branch`.
This makes it so we can do `/test test-foo` instead of needing to add
all the extra repo_branch junk. The old form is still use-able