### PR TITLE
Change modifier from exp_ds to exp

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -7,7 +7,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: unit-tests_istio_exp_ds
+    name: unit-tests_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
@@ -56,7 +56,7 @@ presubmits:
     - ^experimental-.*
     cluster: prow-arm
     decorate: true
-    name: unit-tests-arm64_istio_exp_ds
+    name: unit-tests-arm64_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
@@ -109,7 +109,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: release-test_istio_exp_ds
+    name: release-test_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
@@ -157,7 +157,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: benchmark_istio_exp_ds
+    name: benchmark_istio_exp
     optional: true
     path_alias: istio.io/istio
     rerun_command: /test benchmark
@@ -202,7 +202,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-cni_istio_exp_ds
+    name: integ-cni_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
@@ -267,7 +267,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-telemetry_istio_exp_ds
+    name: integ-telemetry_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
@@ -330,7 +330,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-telemetry-mc_istio_exp_ds
+    name: integ-telemetry-mc_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
@@ -395,7 +395,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-telemetry-istiodremote_istio_exp_ds
+    name: integ-telemetry-istiodremote_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
@@ -465,7 +465,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-distroless_istio_exp_ds
+    name: integ-distroless_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
@@ -530,7 +530,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-ipv6_istio_exp_ds
+    name: integ-ipv6_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
@@ -597,7 +597,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-ds_istio_exp_ds
+    name: integ-ds_istio_exp
     optional: true
     path_alias: istio.io/istio
     reporter_config:
@@ -669,7 +669,7 @@ presubmits:
     - ^experimental-.*
     cluster: prow-arm
     decorate: true
-    name: integ-basic-arm64_istio_exp_ds
+    name: integ-basic-arm64_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
@@ -737,7 +737,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-operator-controller_istio_exp_ds
+    name: integ-operator-controller_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
@@ -801,7 +801,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-pilot_istio_exp_ds
+    name: integ-pilot_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
@@ -864,7 +864,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-pilot-multicluster_istio_exp_ds
+    name: integ-pilot-multicluster_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
@@ -930,7 +930,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-pilot-istiodremote_istio_exp_ds
+    name: integ-pilot-istiodremote_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
@@ -1000,7 +1000,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-pilot-istiodremote-mc_istio_exp_ds
+    name: integ-pilot-istiodremote-mc_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
@@ -1070,7 +1070,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-security_istio_exp_ds
+    name: integ-security_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
@@ -1133,7 +1133,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-security-multicluster_istio_exp_ds
+    name: integ-security-multicluster_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
@@ -1199,7 +1199,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-security-istiodremote_istio_exp_ds
+    name: integ-security-istiodremote_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
@@ -1269,7 +1269,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: integ-helm_istio_exp_ds
+    name: integ-helm_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
@@ -1334,7 +1334,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-assertion_istio_exp_ds
+    name: integ-assertion_istio_exp
     optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
@@ -1400,7 +1400,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: analyze-tests_istio_exp_ds
+    name: analyze-tests_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
@@ -1444,7 +1444,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: lint_istio_exp_ds
+    name: lint_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
@@ -1487,7 +1487,7 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
-    name: gencheck_istio_exp_ds
+    name: gencheck_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
@@ -1540,7 +1540,7 @@ presubmits:
       org: istio
       path_alias: istio.io/tools
       repo: tools
-    name: release-notes_istio_exp_ds
+    name: release-notes_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test release-notes
     spec:

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -10,7 +10,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: release_proxy_postsubmit_exp_ds
+    name: release_proxy_postsubmit_exp
     path_alias: istio.io/proxy
     spec:
       containers:
@@ -58,7 +58,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: release-arm64_proxy_postsubmit_exp_ds
+    name: release-arm64_proxy_postsubmit_exp
     path_alias: istio.io/proxy
     spec:
       containers:
@@ -111,7 +111,7 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: release-centos_proxy_postsubmit_exp_ds
+    name: release-centos_proxy_postsubmit_exp
     path_alias: istio.io/proxy
     spec:
       containers:
@@ -154,7 +154,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: test_proxy_exp_ds
+    name: test_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
@@ -197,7 +197,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: test-asan_proxy_exp_ds
+    name: test-asan_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
@@ -240,7 +240,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: test-tsan_proxy_exp_ds
+    name: test-tsan_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
@@ -283,7 +283,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: release-test_proxy_exp_ds
+    name: release-test_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
@@ -327,7 +327,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: release-test-arm64_proxy_exp_ds
+    name: release-test-arm64_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
@@ -376,7 +376,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: release-centos-test_proxy_exp_ds
+    name: release-centos-test_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
@@ -419,7 +419,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: check-wasm_proxy_exp_ds
+    name: check-wasm_proxy_exp
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:

--- a/prow/config/experimental/.defaults.yaml
+++ b/prow/config/experimental/.defaults.yaml
@@ -3,4 +3,4 @@ defaults:
     istio: istio
   input: ./prow/cluster/jobs/
   output: ./prow/cluster/jobs/
-  modifier: exp_ds
+  modifier: exp


### PR DESCRIPTION
Looking at https://github.com/istio/istio/pull/40871 the CI jobs were `exp_ds`.