### PR TITLE
Do not report status of post-submit integration failures to slack

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -531,8 +531,7 @@ postsubmits:
     name: integ-ds_istio_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1972,8 +1971,7 @@ postsubmits:
     name: integ-k8s-124_istio_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.11.gen.yaml
@@ -193,8 +193,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.11_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -549,8 +548,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.11_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -763,8 +761,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.11_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.12.gen.yaml
@@ -263,8 +263,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.12_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -753,8 +752,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.12_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1033,8 +1031,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.12_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.13.gen.yaml
@@ -329,8 +329,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.13_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -885,8 +884,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.13_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1165,8 +1163,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.13_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1823,8 +1820,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.13_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.14.gen.yaml
@@ -332,8 +332,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.14_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -896,8 +895,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.14_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1180,8 +1178,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.14_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1847,8 +1844,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.14_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1924,8 +1920,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.14_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.15.gen.yaml
@@ -1898,8 +1898,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.15_postsubmit_pri
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -593,8 +593,7 @@ postsubmits:
     name: integ-ds_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1935,8 +1934,7 @@ postsubmits:
     name: integ-k8s-124_istio_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.11.gen.yaml
@@ -215,8 +215,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -546,8 +545,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -745,8 +743,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.11_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.12.gen.yaml
@@ -278,8 +278,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -733,8 +732,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -993,8 +991,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.12_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.13.gen.yaml
@@ -404,8 +404,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -920,8 +919,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1180,8 +1178,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1793,8 +1790,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.13_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.14.gen.yaml
@@ -408,8 +408,7 @@ postsubmits:
     name: integ-telemetry-istiodless-mc_istio_release-1.14_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -932,8 +931,7 @@ postsubmits:
     name: integ-pilot-istiodless-mc_istio_release-1.14_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1196,8 +1194,7 @@ postsubmits:
     name: integ-security-istiodless-mc_istio_release-1.14_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1818,8 +1815,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.14_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:
@@ -1890,8 +1886,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.14_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.15.gen.yaml
@@ -1866,8 +1866,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.15_postsubmit
     path_alias: istio.io/istio
     reporter_config:
-      slack:
-        report: false
+      slack: {}
     skip_report: true
     spec:
       containers:

--- a/tools/prowgen/pkg/decorator/modifier.go
+++ b/tools/prowgen/pkg/decorator/modifier.go
@@ -54,10 +54,9 @@ func ApplyModifiersPostsubmit(postsubmit *config.Postsubmit, jobModifiers []stri
 			// No effect on postsubmit
 		case ModifierHidden:
 			postsubmit.SkipReport = true
-			f := false
 			postsubmit.ReporterConfig = &prowjob.ReporterConfig{
 				Slack: &prowjob.SlackReporterConfig{
-					Report: &f,
+					JobStatesToReport: []prowjob.ProwJobState{},
 				},
 			}
 		default:


### PR DESCRIPTION
The integ-ds postsubmit job is failing on the prow config sets it to report by default. This is an attempt to silence that until we can get it working. Since the map it creates for the `report_config.slack` is empty it's possible that we will need to make another change.

From https://github.com/kubernetes/test-infra/blob/master/prow/cmd/crier/README.md#slack-reporter:

> To silence notifications at the ProwJob level you can pass an empty slice to reporter_config.slack.job_states_to_report: postsubmits:

```yaml
  some-org/some-repo:
    - name: example-job
      decorate: true
      reporter_config:
        slack:
          job_states_to_report: []
      spec:
        containers:
          - image: alpine
            command:
              - echo
```