### PR TITLE
Unhide the integ-ds job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -530,10 +530,6 @@ postsubmits:
       preset-override-envoy: "true"
     name: integ-ds_istio_postsubmit_pri
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
@@ -2853,10 +2849,7 @@ presubmits:
     name: integ-ds_istio_pri
     optional: true
     path_alias: istio.io/istio
-    reporter_config:
-      slack: {}
     rerun_command: /test integ-ds
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -592,10 +592,6 @@ postsubmits:
     decorate: true
     name: integ-ds_istio_postsubmit
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
@@ -2832,10 +2828,7 @@ presubmits:
     name: integ-ds_istio
     optional: true
     path_alias: istio.io/istio
-    reporter_config:
-      slack: {}
     rerun_command: /test integ-ds
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -600,10 +600,7 @@ presubmits:
     name: integ-ds_istio_exp
     optional: true
     path_alias: istio.io/istio
-    reporter_config:
-      slack: {}
     rerun_command: /test integ-ds
-    skip_report: true
     spec:
       containers:
       - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -91,7 +91,6 @@ jobs:
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]
     requirements: [kind]
     modifiers:
-      - hidden # Hidden until job is stable
       - presubmit_optional
     env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED


### PR DESCRIPTION
Unhide the integ-ds job since it appears to be passing. See https://prow.istio.io/job-history/gs/istio-prow/logs/integ-ds_istio_postsubmit

We will make it required once I can see it passing on PRs in istio master branch.