### PR TITLE
Make integ-ds a required integration test

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2847,7 +2847,6 @@ presubmits:
       preset-override-deps: master-istio
       preset-override-envoy: "true"
     name: integ-ds_istio_pri
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2826,7 +2826,6 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-ds_istio
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -598,7 +598,6 @@ presubmits:
     - ^experimental-.*
     decorate: true
     name: integ-ds_istio_exp
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -90,8 +90,6 @@ jobs:
   - name: integ-ds
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.kube.environment]
     requirements: [kind]
-    modifiers:
-      - presubmit_optional
     env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"


### PR DESCRIPTION
The now unhidden integ-ds integration test is now passing. See https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/40964/integ-ds_istio/1569806596198895616