### PR TITLE
Add istio/community to repos for updating after common-files change

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -60,7 +60,7 @@ postsubmits:
       - command:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
-        - --repo=test-infra,bots
+        - --repo=test-infra,bots,community
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
         - --strict

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -12,7 +12,7 @@ jobs:
     command:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
-    - --repo=test-infra,bots
+    - --repo=test-infra,bots,community
     - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
     - --strict


### PR DESCRIPTION
istio/community is now using common-files, replacing the 3 yr old build image.

This PR updates the pipeline to also update the common directory of istio/community. It gets added to the main only job as that repo only has the main branch.

Once this PR merges, there is an associated common files change, https://github.com/istio/common-files/pull/676, which we can merge that should drive this logic and update the common files in istio/community with the latest.