### PR TITLE
A change in istio/tools pkg directory should cause new container build

### DIFF
--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -179,7 +179,7 @@ postsubmits:
       repo: common-files
     name: containers_tools_postsubmit
     path_alias: istio.io/tools
-    run_if_changed: docker/.+|cmd/.+
+    run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
       containers:
       - command:
@@ -241,7 +241,7 @@ postsubmits:
     decorate: true
     name: containers-arm64_tools_postsubmit
     path_alias: istio.io/tools
-    run_if_changed: docker/.+|cmd/.+
+    run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
       containers:
       - command:
@@ -604,7 +604,7 @@ presubmits:
     name: containers-test-arm64_tools
     path_alias: istio.io/tools
     rerun_command: /test containers-test-arm64
-    run_if_changed: docker/.+|cmd/.+
+    run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
       containers:
       - command:

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -42,7 +42,7 @@ jobs:
     - --token-path=/etc/github-token/oauth
     - --script-path=../common-files/bin/create-buildtools-and-update.sh
     resources: build
-    regex: 'docker/.+|cmd/.+'
+    regex: 'docker/.+|cmd/.+|pkg/.+'
     requirements: [docker, github]
     repos: [istio/test-infra@master,istio/common-files@master]
     env:
@@ -63,7 +63,7 @@ jobs:
     - name: MANIFEST_ARCH
       value: ""
     resources: build
-    regex: 'docker/.+|cmd/.+'
+    regex: 'docker/.+|cmd/.+|pkg/.+'
     requirements: [docker]
 
   - name: containers-test
@@ -79,7 +79,7 @@ jobs:
     types: [presubmit]
     command: [entrypoint, make, containers-test]
     resources: build
-    regex: 'docker/.+|cmd/.+'
+    regex: 'docker/.+|cmd/.+|pkg/.+'
     requirements: [docker]
 
   - name: deploy-perf-dashboard


### PR DESCRIPTION
An example is https://github.com/istio/tools/pull/2169 for which no new images were built. The PR updated `/pkg/markdown/md.go`. This is used in `cmd/protoc-gen-docs/htmlgenerator.go`. The files are `go install`ed in the build image. An earlier PR updated several files in the `cmd` directory so a new image was built.