### PR TITLE
ztunnel: cache dependency download

### DIFF
--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -33,6 +33,9 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /home/.cargo/registry
+          name: build-cache
+          subPath: crates
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
@@ -75,6 +78,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /home/.cargo/registry
+          name: build-cache
+          subPath: crates
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -77,6 +77,16 @@ requirement_presets:
         path: /var/tmp/prow/cache
         type: DirectoryOrCreate
       name: build-cache
+  cratescache:
+    volumeMounts:
+    - mountPath: /home/.cargo/registry
+      name: build-cache
+      subPath: crates
+    volumes:
+    - hostPath:
+        path: /var/tmp/prow/cache
+        type: DirectoryOrCreate
+      name: build-cache
   github:
     volumeMounts:
     - mountPath: /etc/github-token

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -5,3 +5,4 @@ image: gcr.io/istio-testing/build-tools:master-370c3316bcb3444f0c07806ff731edd0e
 jobs:
   - name: test
     command: [make, presubmit]
+    requirements: [cratescache]


### PR DESCRIPTION
This adds a cache for crates, mirroring the `go mod` cache we use for Go.

I tested this on my local cluster.