### PR TITLE
testgrid: dashboards must belong to dashboard groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module istio.io/test-infra
 go 1.18
 
 require (
+	github.com/GoogleCloudPlatform/testgrid v0.0.123
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-containerregistry v0.8.1-0.20220216220642-00c59d91847c
@@ -14,6 +15,7 @@ require (
 )
 
 require (
+	bitbucket.org/creachadair/stringset v0.0.9 // indirect
 	cloud.google.com/go v0.102.0 // indirect
 	cloud.google.com/go/compute v1.6.1 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
@@ -26,7 +28,6 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/GoogleCloudPlatform/testgrid v0.0.123 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+bitbucket.org/creachadair/stringset v0.0.9 h1:L4vld9nzPt90UZNrXjNelTshD74ps4P5NGs3Iq6yN3o=
 bitbucket.org/creachadair/stringset v0.0.9/go.mod h1:t+4WcQ4+PXTa8aQdNKe40ZP6iwesoMFWAxPGd3UGjyY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -283,10 +284,8 @@ github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE
 github.com/go-openapi/jsonreference v0.19.6 h1:UBIxjkht+AWIgYzCDSv2GN+E/togfwXUJFRTWhl2Jjs=
 github.com/go-openapi/jsonreference v0.19.6/go.mod h1:diGHMEHg2IqXZGKxqyvWdfWU/aim5Dprw5bqpKkTvns=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
-github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
-github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrKU=
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
@@ -502,7 +501,6 @@ github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/licenses/bitbucket.org/creachadair/stringset/LICENSE
+++ b/licenses/bitbucket.org/creachadair/stringset/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Michael J. Fromberger
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -175,6 +175,30 @@ dashboards:
 - name: istio_tools_postsubmit
 # Group all dashboards
 dashboard_groups:
+- name: istio_release-1.16
+  dashboard_names:
+  - istio_release-1.16_api
+  - istio_release-1.16_api_postsubmit
+  - istio_release-1.16_client-go
+  - istio_release-1.16_client-go_postsubmit
+  - istio_release-1.16_common-files
+  - istio_release-1.16_common-files_postsubmit
+  - istio_release-1.16_enhancements
+  - istio_release-1.16_istio
+  - istio_release-1.16_istio.io
+  - istio_release-1.16_istio.io_postsubmit
+  - istio_release-1.16_istio_periodic
+  - istio_release-1.16_istio_postsubmit
+  - istio_release-1.16_pkg
+  - istio_release-1.16_pkg_postsubmit
+  - istio_release-1.16_proxy
+  - istio_release-1.16_proxy_periodic
+  - istio_release-1.16_proxy_postsubmit
+  - istio_release-1.16_release-builder
+  - istio_release-1.16_release-builder_periodic
+  - istio_release-1.16_release-builder_postsubmit
+  - istio_release-1.16_tools
+  - istio_release-1.16_tools_postsubmit
 - name: istio_release-1.15
   dashboard_names:
   - istio_release-1.15_istio_postsubmit
@@ -196,6 +220,9 @@ dashboard_groups:
   - istio_release-1.15_proxy
   - istio_release-1.15_tools
   - istio_release-1.15_release-builder
+  - istio_release-1.15_enhancements
+  - istio_release-1.15_istio_periodic
+  - istio_release-1.15_proxy_periodic
 - name: istio_release-1.14
   dashboard_names:
   - istio_release-1.14_istio_postsubmit
@@ -217,6 +244,10 @@ dashboard_groups:
   - istio_release-1.14_proxy
   - istio_release-1.14_tools
   - istio_release-1.14_release-builder
+  - istio_release-1.14_enhancements
+  - istio_release-1.14_envoy
+  - istio_release-1.14_istio_periodic
+  - istio_release-1.14_proxy_periodic
 - name: istio_release-1.13
   dashboard_names:
   - istio_release-1.13_istio_postsubmit
@@ -241,6 +272,9 @@ dashboard_groups:
   - istio_release-1.13_proxy
   - istio_release-1.13_tools
   - istio_release-1.13_release-builder
+  - istio_release-1.13_enhancements
+  - istio_release-1.13_istio_periodic
+  - istio_release-1.13_proxy_periodic
 - name: istio_release-1.12
   dashboard_names:
   - istio_release-1.12_istio_postsubmit
@@ -264,6 +298,7 @@ dashboard_groups:
   - istio_release-1.12_proxy
   - istio_release-1.12_tools
   - istio_release-1.12_release-builder
+  - istio_release-1.12_enhancements
 - name: istio_release-1.11
   dashboard_names:
   - istio_release-1.11_istio_postsubmit
@@ -287,6 +322,7 @@ dashboard_groups:
   - istio_release-1.11_proxy
   - istio_release-1.11_tools
   - istio_release-1.11_release-builder
+  - istio_release-1.11_enhancements
 - name: istio
   dashboard_names:
   - istio_istio.io_periodic
@@ -321,3 +357,7 @@ dashboard_groups:
   - istio_proxy_periodic
   - istio_test-infra
   - istio_tools
+  - istio_enhancements
+  - istio_release-builder
+  - istio_release-builder_periodic
+  - istio_release-builder_postsubmit

--- a/testgrid/config_test.go
+++ b/testgrid/config_test.go
@@ -1,0 +1,163 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testgrids
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/GoogleCloudPlatform/testgrid/config"
+	config_pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	prow_config "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/testgrid/pkg/configurator/configurator"
+	"k8s.io/test-infra/testgrid/pkg/configurator/options"
+
+	configflagutil "k8s.io/test-infra/prow/flagutil/config"
+)
+
+var (
+	dashboardPrefixes = []string{
+		"istio",
+	}
+)
+
+var defaultInputs options.MultiString = []string{"."}
+var prowPath = flag.String("prow-config", "../prow/config.yaml", "Path to prow config")
+var jobPath = flag.String("job-config", "../prow/cluster/jobs", "Path to prow job config")
+var defaultYAML = flag.String("default", "./default.yaml", "Default yaml for testgrid")
+var inputs options.MultiString
+var protoPath = flag.String("config", "", "Path to TestGrid config proto")
+
+// Shared testgrid config, loaded at TestMain.
+var cfg *config_pb.Configuration
+
+// Shared prow config, loaded at Test Main
+var prowConfig *prow_config.Config
+
+func TestMain(m *testing.M) {
+	flag.Var(&inputs, "yaml", "comma-separated list of input YAML files or directories")
+	flag.Parse()
+	if *protoPath == "" {
+		if len(inputs) == 0 {
+			inputs = defaultInputs
+		}
+		// Generate proto from testgrid config
+		tmpDir, err := os.MkdirTemp("", "testgrid-config-test")
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		defer os.RemoveAll(tmpDir)
+		tmpFile := path.Join(tmpDir, "test-proto")
+
+		opt := options.Options{
+			Inputs: inputs,
+			ProwConfig: configflagutil.ConfigOptions{
+				ConfigPath:    *prowPath,
+				JobConfigPath: *jobPath,
+			},
+			DefaultYAML:     *defaultYAML,
+			Output:          flagutil.NewStringsBeenSet(tmpFile),
+			Oneshot:         true,
+			StrictUnmarshal: true,
+		}
+
+		if err := configurator.RealMain(&opt); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		protoPath = &tmpFile
+	}
+
+	var err error
+	cfg, err = config.Read(context.Background(), *protoPath, nil)
+	if err != nil {
+		fmt.Printf("Could not load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	prowConfig, err = prow_config.Load(*prowPath, *jobPath, nil, "")
+	if err != nil {
+		fmt.Printf("Could not load prow configs: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestConfig(t *testing.T) {
+	dashboardNames := sets.NewString()
+	dashboardGroupNames := sets.NewString()
+	dashboardToGroupMap := make(map[string]string)
+
+	for _, db := range cfg.Dashboards {
+		dashboardNames.Insert(db.Name)
+
+	}
+	for _, dbg := range cfg.DashboardGroups {
+		dashboardGroupNames.Insert(dbg.Name)
+		for _, dashboard := range dbg.DashboardNames {
+			dashboardToGroupMap[dashboard] = dbg.Name
+		}
+	}
+
+	// Convention: all dashboard (group) names must start with a well known prefix
+	names := sets.NewString()
+	names = names.Union(dashboardNames)
+	names = names.Union(dashboardGroupNames)
+	for name := range names {
+		found := false
+		for _, prefix := range dashboardPrefixes {
+			if strings.HasPrefix(name, prefix) || name == prefix {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Dashboard/DashboardGroup %v: must prefix with one of: %v", name, dashboardPrefixes)
+		}
+
+	}
+
+	// Convention: all dashboards must be under a dashboard group
+	// Convention: dashboards should live under the dashboard group with the longest common prefix
+	// (e.g. project-foo-bar dashboard should be in project-foo group over project group).
+	for dashboard := range dashboardNames {
+		assignedGroup, ok := dashboardToGroupMap[dashboard]
+		if !ok {
+			t.Errorf("Dashboard %v: must be in a dashboard_group", dashboard)
+		}
+		longestGroupPrefix := ""
+		for thisGroup := range dashboardGroupNames {
+			if strings.HasPrefix(dashboard, thisGroup) && len(thisGroup) > len(longestGroupPrefix) {
+				longestGroupPrefix = thisGroup
+			}
+		}
+		if longestGroupPrefix == "" {
+			t.Errorf("Dashboard %v: should be in a dashboard_group with a common prefix instead of dashboard_group '%v'", dashboard, assignedGroup)
+		} else if assignedGroup != longestGroupPrefix {
+			t.Errorf("Dashboard %v: should be in dashboard_group '%v' instead of dashboard_group '%v'", dashboard, longestGroupPrefix, assignedGroup)
+		}
+	}
+}

--- a/testgrid/config_test.go
+++ b/testgrid/config_test.go
@@ -23,30 +23,28 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/GoogleCloudPlatform/testgrid/config"
 	config_pb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+	"k8s.io/apimachinery/pkg/util/sets"
 	prow_config "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
+	configflagutil "k8s.io/test-infra/prow/flagutil/config"
 	"k8s.io/test-infra/testgrid/pkg/configurator/configurator"
 	"k8s.io/test-infra/testgrid/pkg/configurator/options"
-
-	configflagutil "k8s.io/test-infra/prow/flagutil/config"
 )
+
+var dashboardPrefixes = []string{
+	"istio",
+}
 
 var (
-	dashboardPrefixes = []string{
-		"istio",
-	}
+	defaultInputs options.MultiString = []string{"."}
+	prowPath                          = flag.String("prow-config", "../prow/config.yaml", "Path to prow config")
+	jobPath                           = flag.String("job-config", "../prow/cluster/jobs", "Path to prow job config")
+	defaultYAML                       = flag.String("default", "./default.yaml", "Default yaml for testgrid")
+	inputs        options.MultiString
+	protoPath     = flag.String("config", "", "Path to TestGrid config proto")
 )
-
-var defaultInputs options.MultiString = []string{"."}
-var prowPath = flag.String("prow-config", "../prow/config.yaml", "Path to prow config")
-var jobPath = flag.String("job-config", "../prow/cluster/jobs", "Path to prow job config")
-var defaultYAML = flag.String("default", "./default.yaml", "Default yaml for testgrid")
-var inputs options.MultiString
-var protoPath = flag.String("config", "", "Path to TestGrid config proto")
 
 // Shared testgrid config, loaded at TestMain.
 var cfg *config_pb.Configuration
@@ -113,7 +111,6 @@ func TestConfig(t *testing.T) {
 
 	for _, db := range cfg.Dashboards {
 		dashboardNames.Insert(db.Name)
-
 	}
 	for _, dbg := range cfg.DashboardGroups {
 		dashboardGroupNames.Insert(dbg.Name)


### PR DESCRIPTION
The goal here is to prevent istio from littering testgrid.k8s.io with a bunch of top-level dashboards. 
<img width="1878" alt="Screen Shot 2022-10-21 at 5 21 48 PM" src="https://user-images.githubusercontent.com/49258/197307838-69647580-1fd1-470e-a070-3e441ce9968b.png">

We follow a convention there of placing all dashboards under a group (see all the sig-foo groups at the bottom)

This PR adds a minimal version of [the testgrid config test used in kubernetes/test-infra](https://github.com/kubernetes/test-infra/blob/master/config/tests/testgrids/config_test.go). It verifies that testgrid config parses correctly, and then verifies the following conventions:

- dashboard and dashboard group names must start with "istio"
- dashboards must belong to a dashboard group
- dashboards should be in the group with the longest common prefix

With the test in place, the config failed, so the config was then modified to pass the test:

- add istio_release-1.16 group
- move other dashboards to appropriate groups