### PR TITLE
Rotate test-infra-trusted build cluster kubeconfig

### DIFF
--- a/prow/cluster/gencred-config/gencred-config.yaml
+++ b/prow/cluster/gencred-config/gencred-config.yaml
@@ -1,0 +1,8 @@
+clusters:
+# test-infra-trusted build cluster(aka the test-pods ns on the prow service cluster)
+- gke: projects/istio-testing/locations/us-west1-a/clusters/prow
+  name: test-infra-trusted
+  duration: 48h
+  gsm:
+    name: gke_istio-testing_us-west1-a_prow__default__build-test-infra-trusted
+    project: istio-testing

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -30,6 +30,25 @@ postsubmits:
           requests:
             memory: "1Gi"
 
+  - name: post-istio-test-infra-gencred-refresh-kubeconfig
+    cluster: test-infra-trusted
+    run_if_changed: '^prow/cluster/gencred-config/'
+    decorate: true
+    branches:
+    - ^master$
+    spec:
+      serviceAccountName: gencred-refresher
+      containers:
+      - name: gencred
+        image: gcr.io/k8s-prow/gencred:v20221028-a8625c1f93
+        command:
+        - gencred
+        args:
+        - --config=./prow/cluster/gencred-config/gencred-config.yaml
+    annotations:
+      testgrid-dashboards: istio_test-infra_postsubmit
+      testgrid-alert-email: k8s-infra-oncall@google.com
+
 periodics:
 - cron: "54 * * * *"  # Every hour at 54 minutes past the hour
   name: ci-test-infra-branchprotector
@@ -130,3 +149,22 @@ periodics:
       secret:
         secretName: istio-testing-robot-ssh-key
         defaultMode: 0400
+- cron: "17 */7 * * *"  # Every 7 hours at 17 minutes past the hour
+  name: ci-istio-test-infra-gencred-refresh-kubeconfig
+  cluster: test-infra-trusted
+  extra_refs:
+  - org: istio
+    repo: test-infra
+    base_ref: master
+  decorate: true
+  spec:
+    serviceAccountName: gencred-refresher
+    containers:
+    - name: gencred
+      image: gcr.io/k8s-prow/gencred:v20221028-a8625c1f93
+      command:
+      - gencred
+      args:
+      - --config=./prow/cluster/gencred-config/gencred-config.yaml
+  annotations:
+    testgrid-create-test-group: "false"

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -35,3 +35,11 @@ metadata:
     iam.gke.io/gcp-service-account: testgrid-updater@istio-testing.iam.gserviceaccount.com
   namespace: test-pods
   name: testgrid-updater
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gencred-refresher@istio-testing.iam.gserviceaccount.com
+  name: gencred-refresher
+  namespace: test-pods


### PR DESCRIPTION
The test-infra-trusted cluster root CA is expiring soon, which will need to be rotated, and the old kubeconfig for Prow service cluster to authenticate with this build cluster will be invalid after the rotation. So a new kubeconfig is needed to avoid breakage of the connection to this build cluster.

Due to security reasons GKE doesn't allow long lived tokens any more, and the newly generated tokens are at most valid for 2 days, so there needs a way to rotate the token. This PR follows the strategy adopted by k8s prow