### PR TITLE
Sync test-infra-trusted build cluster kubeconfig from GSM to prow

### DIFF
--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -33,3 +33,17 @@ spec:
   projectId: istio-testing
   dataFrom:
   - gke_istio-testing_us-west1-a_prow__test-pods__istio-testing-robot-ssh-key # Secret name in GSM
+---
+# test-infra-trusted build cluster
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-test-infra-trusted
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: gke_istio-testing_us-west1-a_prow__default__build-test-infra-trusted
+    name: kubeconfig
+    version: latest


### PR DESCRIPTION
Following #4373 , the secret was already uploaded into GSM