### PR TITLE
Add break glass make target when test-infra-trusted cluster kubeconfi…

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -97,4 +97,17 @@ create-release-deps-configmap: get-private-cluster-credentials
 
 create-deps-configmaps: create-istio-deps-configmap create-release-deps-configmap
 
+# Run fix-gencred-refresher will generate kubeconfig for "trusted" build cluster
+# and store it in GSM, you will need "container.admin" and "secretManager.admin"
+# permission on k8s-prow GCP project to perform this action.
+# This target is for solving the bootstrapping problem of gencred refresher,
+# where it runs in "trusted" build cluster, as a prow job to rotate the
+# kubeconfig for "trusted" build cluster along with other build clusters. So
+# when the refresher job failed for more than 2 days, prow will stop working
+# with "trusted" build cluster and thus not able to schedule gencred refrsher
+# prow jobs any more. And this is when the admin of this repo need to run this
+# target manually.
+fix-gencred-refresher:
+	./run-k8s-binary.sh ./gencred --config=./cluster/gencred-config/gencred-config.yaml --gke-filter=projects/istio-testing/locations/us-west1-a/clusters/prow
+
 .PHONY: gen-private-jobs deploy deploy-gcsweb deploy-build deploy-private update-config update-config-dry-run create-istio-deps-configmap create-release-deps-configmap create-deps-configmaps

--- a/prow/run-k8s-binary.sh
+++ b/prow/run-k8s-binary.sh
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+# This script is for running arbitrary Go binaries from the k8s/test-infra repo.
+# Running this script when the binary cannot run inside a Docker container (for example,
+# when the binary needs to authenticate to GCP).
+# This script installs the binary directly from the k8s/test-infra repo instead of adding
+# k8s.io/test-infra as a Go module inside the current directory. This is because we've seen
+# dependency problems when doing so in other repos.
+#
+# Usage:
+# $1       : The relative path for installing Go binary from k8s/test-infra
+# $2..n    : The arguments for running the Go binary
+#
+# Example:
+# - ./run-k8s-binary.sh prow/cmd/generic-autobumper --config=istio-autobump-config.yaml
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}/../..")" && pwd -P)"
+
+TMP_DIR="$(mktemp -d)"
+K8S_INFRA_DIR="${TMP_DIR}/test-infra"
+BINARY="${TMP_DIR}/binary"
+
+# Install the Go binary directly from k8s/test-infra
+git clone git@github.com:kubernetes/test-infra.git "$K8S_INFRA_DIR"
+cd "$K8S_INFRA_DIR"
+go build -o "${BINARY}" "$1"
+shift
+
+cd "$ROOT_DIR"
+"${BINARY}" "$@"


### PR DESCRIPTION
…g is out of sync

This is a chicken and egg problem. The job that rotates the kubeconfig secrets runs on test-infra-trusted build cluster, which is also rotated by the job itself, so when it's out of sync it won't auto-heal. Oncall can run this make target to break glass.