### PR TITLE
Adding cron decorator overlay support

### DIFF
--- a/tools/prowgen/pkg/generate.go
+++ b/tools/prowgen/pkg/generate.go
@@ -351,6 +351,11 @@ func (cli *Client) ConvertJobConfig(fileName string, jobsConfig spec.JobsConfig,
 					Cron:     job.Cron,
 					Tags:     job.Tags,
 				}
+				for _, requirement := range job.Requirements {
+					if cronstr := jobsConfig.RequirementPresets[requirement].Cron; cronstr != "" {
+						periodic.Cron = cronstr
+					}
+				}
 				if testgridConfig.Enabled {
 					if err := mergo.Merge(&periodic.JobBase.Annotations, map[string]string{
 						TestGridDashboard:   testgridJobPrefix + "_periodic",

--- a/tools/prowgen/pkg/spec/spec.go
+++ b/tools/prowgen/pkg/spec/spec.go
@@ -143,6 +143,7 @@ type RequirementPreset struct {
 	Volumes      []v1.Volume       `json:"volumes,omitempty"`
 	VolumeMounts []v1.VolumeMount  `json:"volumeMounts,omitempty"`
 	Args         []string          `json:"args,omitempty"`
+	Cron         string            `json:"cron,omitempty"`
 	PodSpec      *v1.PodSpec       `json:"podSpec,omitempty"` // Use this field to add extra PodSpec fields except containers and metadata
 }
 


### PR DESCRIPTION
Allows you to define a Cron entry in a requirement preset, to override default.