### PR TITLE
Fix typo in auto update of go-control-plane; do the same for istio/proxy

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -78,9 +78,72 @@ periodics:
     repo: istio
   - base_ref: master
     org: istio
-    path_alias: istio.io/stio
-    repo: stio
-  name: update-deps_istio_periodic
+    path_alias: istio.io/istio
+    repo: istio
+  name: update-deps-istio_istio_periodic
+  spec:
+    containers:
+    - command:
+      - ../test-infra/tools/automator/automator.sh
+      - --org=istio
+      - --repo=istio
+      - '--title=Automator: update go dependencies@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+      - --labels=auto-merge,release-notes-none
+      - --modifier=update_deps
+      - --token-path=/etc/github-token/oauth
+      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy &&
+        make clean gen
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
+      image: gcr.io/istio-testing/build-tools:master-5dae0f9ba19425390de0ea46c9e6d3eae91e0a36
+      name: ""
+      resources:
+        limits:
+          cpu: "5"
+          memory: 24Gi
+        requests:
+          cpu: "5"
+          memory: 3Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/prow/go/pkg
+        name: build-cache
+        subPath: gomod
+      - mountPath: /gocache
+        name: build-cache
+        subPath: gocache
+      - mountPath: /etc/github-token
+        name: github
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      testing: test-pool
+    volumes:
+    - hostPath:
+        path: /var/tmp/prow/cache
+        type: DirectoryOrCreate
+      name: build-cache
+    - name: github
+      secret:
+        secretName: oauth-token
+- annotations:
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-dashboards: istio_istio_periodic
+    testgrid-num-failures-to-alert: "1"
+  cron: 0 2 * * 0
+  decorate: true
+  extra_refs:
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/istio
+    repo: istio
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/proxy
+    repo: proxy
+  name: update-deps-proxy_istio_periodic
   spec:
     containers:
     - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -418,7 +418,22 @@ jobs:
     command: [entrypoint, ../release-builder/release/build.sh]
     requirements: [release, docker, github-optional]
 
-  - name: update-deps
+  - name: update-deps-istio
+    types: [periodic]
+    cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC
+    command:
+    - ../test-infra/tools/automator/automator.sh
+    - --org=istio
+    - --repo=istio
+    - "--title=Automator: update go dependencies@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --labels=auto-merge,release-notes-none
+    - --modifier=update_deps
+    - --token-path=/etc/github-token/oauth
+    - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make clean gen
+    requirements: [github]
+    repos: [istio/istio@master]
+
+  - name: update-deps-proxy
     types: [periodic]
     cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC
     command:
@@ -431,7 +446,7 @@ jobs:
     - --token-path=/etc/github-token/oauth
     - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make clean gen
     requirements: [github]
-    repos: [istio/stio@master]
+    repos: [istio/proxy@master]
 
 resources_presets:
   default:


### PR DESCRIPTION
1. Org and repo were incorrect in previous PR.
2. Added a new job to update istio/proxy's go-control-plane as well