### PR TITLE
Automated job to update proxy sha in istio/istio experimental branch

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -182,6 +182,81 @@ postsubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    clone_uri: git@github.com:istio-private/proxy.git
+    cluster: private
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    extra_refs:
+    - base_ref: master
+      clone_uri: git@github.com:istio-private/test-infra.git
+      org: istio-private
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    labels:
+      preset-enable-netrc: "true"
+    name: update-istio-experimental-ambient_proxy_postsubmit_master_priv
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=istio
+        - --branch=experimental-ambient
+        - '--title=Automator: update proxy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --labels=auto-merge,release-notes-none
+        - --modifier=update_proxy_dep
+        - --token-path=/etc/github-token/oauth
+        - --git-exclude=^common/
+        - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: DOCKER_REPOSITORY
+          value: istio-prow-build/envoy
+        - name: ENVOY_PREFIX
+          value: envoy
+        - name: ENVOY_REPOSITORY
+          value: https://github.com/istio-private/envoy
+        - name: GCS_ARTIFACTS_BUCKET
+          value: istio-private-artifacts
+        - name: GCS_BUILD_BUCKET
+          value: istio-private-build
+        image: gcr.io/istio-testing/build-tools:master-fe925225ae6b796f54a13b0250b9474bf0dfb255
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: build-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: github
+        secret:
+          secretName: oauth-token
 presubmits:
   istio-private/proxy:
   - always_run: true

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -266,6 +266,67 @@ postsubmits:
       - name: github
         secret:
           secretName: oauth-token
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_proxy_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    extra_refs:
+    - base_ref: master
+      org: istio
+      path_alias: istio.io/test-infra
+      repo: test-infra
+    name: update-istio-experimental-ambient_proxy_postsubmit
+    path_alias: istio.io/proxy
+    spec:
+      containers:
+      - command:
+        - ../test-infra/tools/automator/automator.sh
+        - --org=istio
+        - --repo=istio
+        - --branch=experimental-ambient
+        - '--title=Automator: update proxy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+        - --labels=auto-merge,release-notes-none
+        - --modifier=update_proxy_dep
+        - --token-path=/etc/github-token/oauth
+        - --git-exclude=^common/
+        - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        image: gcr.io/istio-testing/build-tools:master-fe925225ae6b796f54a13b0250b9474bf0dfb255
+        name: ""
+        resources:
+          limits:
+            cpu: "64"
+            memory: 240G
+          requests:
+            cpu: "30"
+            memory: 100G
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /etc/github-token
+          name: github
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: build-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: github
+        secret:
+          secretName: oauth-token
 presubmits:
   istio/proxy:
   - always_run: true

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -106,6 +106,24 @@ jobs:
   image: gcr.io/istio-testing/build-tools:master-fe925225ae6b796f54a13b0250b9474bf0dfb255
   timeout: 4h
 
+- name: update-istio-experimental-ambient
+  types: [postsubmit]
+  command:
+  - ../test-infra/tools/automator/automator.sh
+  - --org=istio
+  - --repo=istio
+  - --branch=experimental-ambient
+  - "--title=Automator: update proxy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+  - --labels=auto-merge,release-notes-none
+  - --modifier=update_proxy_dep
+  - --token-path=/etc/github-token/oauth
+  - --git-exclude=^common/
+  - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
+  requirements: [github]
+  repos: [istio/test-infra@master]
+  image: gcr.io/istio-testing/build-tools:master-fe925225ae6b796f54a13b0250b9474bf0dfb255
+  timeout: 4h
+
 - name: update-proxy
   types: [periodic]
   interval: 24h

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -123,6 +123,7 @@ jobs:
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-fe925225ae6b796f54a13b0250b9474bf0dfb255
   timeout: 4h
+  disable_release_branching: true
 
 - name: update-proxy
   types: [periodic]


### PR DESCRIPTION
Add an automated job to update the proxy sha in the istio/istio experimental-ambient branch files when the proxy sha is updated.

The current issue is that the support_release_branching flag is at the file level so this job would be created at branch cut time which would cause changes in the new branch of istio/proxy to also update the proxy sha which is not desired. One could simply remove the job from the generated yaml, but that is a manual step (could be automated) that would need to be documented.