### PR TITLE
Update 1.26 post-submit to 1.25.4

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2038,19 +2038,15 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-k8s-126_istio_postsubmit_pri
+    name: integ-k8s-125_istio_postsubmit_pri
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.26.0
+        - gcr.io/istio-testing/kind-node:v1.25.4
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2059,19 +2059,15 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-126_istio_postsubmit
+    name: integ-k8s-125_istio_postsubmit
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.26.0
+        - gcr.io/istio-testing/kind-node:v1.25.4
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -340,16 +340,15 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
-  - name: integ-k8s-126
+  - name: integ-k8s-125
     types: [postsubmit]
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.26.0
+      - gcr.io/istio-testing/kind-node:v1.25.4
       - test.integration.kube
     requirements: [kind]
-    modifiers: [hidden] # Hidden until job is stable
     timeout: 4h
     env:
       - name: INTEGRATION_TEST_FLAGS


### PR DESCRIPTION
This PR updates the post-submit job for 1.26 to 1.25.4. The pre-submit was moved from 1.25.4 to 1.26.1 in https://github.com/istio/istio/pull/42952.

