### PR TITLE
Pipeline updates to change post-submit to 1.25.4 for release-1.17

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.17.gen.yaml
@@ -2038,19 +2038,15 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: release-1.17-istio
       preset-override-envoy: "true"
-    name: integ-k8s-126_istio_release-1.17_postsubmit_pri
+    name: integ-k8s-125_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.26.0
+        - gcr.io/istio-testing/kind-node:v1.25.4
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -2059,19 +2059,15 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-126_istio_release-1.17_postsubmit
+    name: integ-k8s-125_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.26.0
+        - gcr.io/istio-testing/kind-node:v1.25.4
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -5400,15 +5400,13 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - --node-image
-  - gcr.io/istio-testing/kind-node:v1.26.0
+  - gcr.io/istio-testing/kind-node:v1.25.4
   - test.integration.kube
   env:
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
   image: gcr.io/istio-testing/build-tools:release-1.17-96c24712249499bf993ec2cbe9dd8f0e59612989
-  modifiers:
-  - hidden
-  name: integ-k8s-126
+  name: integ-k8s-125
   node_selector:
     testing: test-pool
   requirement_presets:


### PR DESCRIPTION
Pairs with https://github.com/istio/istio/pull/42969 which updates the pre-submit tests to 1.26.1 while this changes the post-submit to using 1.25.4 and makes it unhidden.