### PR TITLE
Increase gateway test memory to see if it helps gateway api test flakes

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -628,7 +628,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 3Gi
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -734,7 +734,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 3Gi
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -27,6 +27,7 @@ jobs:
     requirements: [kind]
     types: [presubmit]
     modifiers: [presubmit_optional, hidden]
+    resources: gateway
 
   - name: doc.test.multicluster
     command:
@@ -96,3 +97,11 @@ resources_presets:
     limits:
       memory: "24Gi"
       cpu: "5000m"
+  #test gateway-api tests with more memory
+  gateway:
+    requests:
+      memory: "8Gi"
+      cpu: "5000m"
+    limits:
+      memory: "24Gi"
+      cpu: "8000m"


### PR DESCRIPTION
The gateway tests are randomly getting errors (see https://github.com/istio/istio.io/issues/12464 for info) like:
```
'E0114 02:41:39.883594  180595 memcache.go:238] couldn'\''t get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E0114 02:41:39.884330  180595 memcache.go:238] couldn'\''t get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E0114 02:41:39.886287  180595 memcache.go:238] couldn'\''t get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
```
I separated those test out and let's see if increasing memory will help.  An internet search doesn't identify a specific fix, but implies running out of memory could be the cause.

This will allow us to run some tests to see if the flakiness improves.
