### PR TITLE
Reduce test job memory to 4Gi and increase memory for flakey job.

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -107,7 +107,7 @@ postsubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 3Gi
+            memory: 4Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -435,7 +435,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 3Gi
+            memory: 4Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -628,7 +628,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 8Gi
+            memory: 4Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -225,7 +225,7 @@ postsubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 3Gi
+            memory: 4Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -547,7 +547,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 3Gi
+            memory: 4Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -734,7 +734,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 8Gi
+            memory: 4Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -13,6 +13,7 @@ jobs:
   - name: doc.test.profile_default
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_default]
     requirements: [kind]
+    resources: 4Gi
 
   - name: doc.test.profile_demo
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_demo]
@@ -27,7 +28,7 @@ jobs:
     requirements: [kind]
     types: [presubmit]
     modifiers: [presubmit_optional, hidden]
-    resources: gateway
+    resources: 4Gi
 
   - name: doc.test.multicluster
     command:
@@ -97,10 +98,10 @@ resources_presets:
     limits:
       memory: "24Gi"
       cpu: "5000m"
-  #test gateway-api tests with more memory
-  gateway:
+  # some gateway-api tests require more memory
+  4Gi:
     requests:
-      memory: "8Gi"
+      memory: "4Gi"
       cpu: "5000m"
     limits:
       memory: "24Gi"


### PR DESCRIPTION
The `traffic-management/tcp-traffic-shifting/gtwapi_test.sh/gtwapi_test.sh` test in istio.io has been flakey lately and this has been discussed in https://github.com/istio/istio.io/issues/12464 and specifically in https://github.com/istio/istio.io/pull/12520. In the later PR, we say 2./5 tests fail yesterday when using 3Gi for memory. I tried using the memory to 8Gi today and saw 5 out of 5 tests pass.

It doesn't make sense to increase the memory to 8Gi as that would have a larger impact on scheduling, but let's try using 4Gi, increasing the memory on the flakey test's job, and lowering on the test job.

The test failure is making a kubectl call to get the pod's name and then a kubectl call to exec using that pod. I don't expect that the kubeconfig should be getting corrupted between the calls. Internet searches did not yield any real clues other than possibly this is memory or ssh key related.