### PR TITLE
Try increasing memory more to further reduce test flakes

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -107,7 +107,7 @@ postsubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 4Gi
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -435,7 +435,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 4Gi
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -628,7 +628,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 4Gi
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -225,7 +225,7 @@ postsubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 4Gi
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -547,7 +547,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 4Gi
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -734,7 +734,7 @@ presubmits:
             memory: 24Gi
           requests:
             cpu: "5"
-            memory: 4Gi
+            memory: 6Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -13,7 +13,7 @@ jobs:
   - name: doc.test.profile_default
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_default]
     requirements: [kind]
-    resources: 4Gi
+    resources: 6Gi
 
   - name: doc.test.profile_demo
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_demo]
@@ -28,7 +28,7 @@ jobs:
     requirements: [kind]
     types: [presubmit]
     modifiers: [presubmit_optional, hidden]
-    resources: 4Gi
+    resources: 6Gi
 
   - name: doc.test.multicluster
     command:
@@ -99,9 +99,9 @@ resources_presets:
       memory: "24Gi"
       cpu: "5000m"
   # some gateway-api tests require more memory
-  4Gi:
+  6Gi:
     requests:
-      memory: "4Gi"
+      memory: "6Gi"
       cpu: "5000m"
     limits:
       memory: "24Gi"


### PR DESCRIPTION
Increasing the memory from 3Gi to 4Gi reduced the flakes overnight in half. Like to try increasing further to see if it helps some more. Picked the next larger divisor of 24.