### PR TITLE
Fix update-deps_istio_periodic

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -91,8 +91,7 @@ periodics:
       - --labels=auto-merge,release-notes-none
       - --modifier=update_deps
       - --token-path=/etc/github-token/oauth
-      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy &&
-        make clean gen
+      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -376,7 +376,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_deps
     - --token-path=/etc/github-token/oauth
-    - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make clean gen
+    - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
     requirements: [github]
     repos: [istio/test-infra@master]
 


### PR DESCRIPTION
The mentioned test has never passed: https://prow.istio.io/job-history/gs/istio-prow/logs/update-deps_istio_periodic

The current failure is:
```
go: finding module for package github.com/kr/pretty
go: found github.com/kr/pretty in github.com/kr/pretty v0.3.1
/bin/bash: line 1: bazel: command not found
/bin/bash: line 1: bazel: command not found
/bin/bash: line 1: bazel: command not found
make: *** [Makefile.core.mk:108: clean] Error 127
```
Which is when it is trying to run the specified command, `go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make clean gen`, against the `proxy` repo. The command against the `istio` repo passes.

The failure is because the `gen` target against `proxy` runs `bezel` which requires the proxy build image instead of the normal tools build image.

There are several ways to fix this. One would be to break the job into two jobs, one against proxy and one against istio, each with their own commands and build tooling. Another would be to change the command. Since the main command is a `go get`, we will be OK only doing the `go mod tidy` in nearly all instances. I foresee the only time this would fail would be if a module that is updated had a license change which the `make gen` would catch. In the cause of the above failure, the PR would still be created, but the `gen` test would fail so the overall failure would not go unnoticed. For that reason, this is an implementation of the second.