### PR TITLE
Separate update-deps to two jobs in isito and proxy

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -80,18 +80,19 @@ periodics:
     org: istio
     path_alias: istio.io/test-infra
     repo: test-infra
-  name: update-deps_istio_periodic
+  name: update-go-control-plane_istio_periodic
   spec:
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
       - --org=istio
-      - --repo=istio,proxy
-      - '--title=Automator: update go dependencies@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+      - --repo=istio
+      - '--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
       - --labels=auto-merge,release-notes-none
       - --modifier=update_deps
       - --token-path=/etc/github-token/oauth
-      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
+      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy &&
+        make gen
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -61,6 +61,65 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
+- annotations:
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-dashboards: istio_proxy_periodic
+    testgrid-num-failures-to-alert: "1"
+  cron: 0 2 * * 0
+  decorate: true
+  extra_refs:
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/proxy
+    repo: proxy
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/test-infra
+    repo: test-infra
+  name: update-go-control-plane_proxy_periodic
+  spec:
+    containers:
+    - command:
+      - ../test-infra/tools/automator/automator.sh
+      - --org=istio
+      - --repo=proxy
+      - '--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
+      - --labels=auto-merge,release-notes-none
+      - --modifier=update_deps
+      - --token-path=/etc/github-token/oauth
+      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
+      image: gcr.io/istio-testing/build-tools-proxy:master-90202090a85fc6a345d57d99cb93b10c8bffa4f1
+      name: ""
+      resources:
+        limits:
+          cpu: "64"
+          memory: 240G
+        requests:
+          cpu: "30"
+          memory: 100G
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/prow/go/pkg
+        name: build-cache
+        subPath: gomod
+      - mountPath: /etc/github-token
+        name: github
+        readOnly: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      testing: build-pool
+    volumes:
+    - hostPath:
+        path: /var/tmp/prow/cache
+        type: DirectoryOrCreate
+      name: build-cache
+    - name: github
+      secret:
+        secretName: oauth-token
 postsubmits:
   istio/proxy:
   - annotations:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -365,18 +365,18 @@ jobs:
     command: [entrypoint, ../release-builder/release/build.sh]
     requirements: [release, docker, github-optional]
 
-  - name: update-deps
+  - name: update-go-control-plane
     types: [periodic]
     cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC
     command:
     - ../test-infra/tools/automator/automator.sh
     - --org=istio
-    - --repo=istio,proxy
-    - "--title=Automator: update go dependencies@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+    - --repo=istio
+    - "--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
     - --modifier=update_deps
     - --token-path=/etc/github-token/oauth
-    - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
+    - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
 

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -123,6 +123,21 @@ jobs:
   image: gcr.io/istio-testing/build-tools:master-90202090a85fc6a345d57d99cb93b10c8bffa4f1
   timeout: 4h
 
+- name: update-go-control-plane
+  types: [periodic]
+  cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC
+  command:
+  - ../test-infra/tools/automator/automator.sh
+  - --org=istio
+  - --repo=proxy
+  - "--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
+  - --labels=auto-merge,release-notes-none
+  - --modifier=update_deps
+  - --token-path=/etc/github-token/oauth
+  - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
+  requirements: [github]
+  repos: [istio/test-infra@master]
+
 resources_presets:
   default:
     requests:


### PR DESCRIPTION
The istio job from last weekend failed because it needed a `make gen` which we found in earlier jobs fails in istio/proxy. 

Separate the job against istio and proxy into two different jobs adding the `make gen` back to the istio job.