### PR TITLE
Allow org for automator to be configurable in prow jobs

### DIFF
--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -99,7 +99,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=client-go
         - '--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in
           $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
@@ -110,6 +110,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -139,7 +139,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=istio
         - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency
           in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
@@ -152,6 +152,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -59,7 +59,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=test-infra,bots,community,ztunnel
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
@@ -70,6 +70,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:
@@ -117,7 +119,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=istio,api,tools,release-builder,pkg,client-go,proxy
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
@@ -128,6 +130,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:
@@ -175,7 +179,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=istio.io
         - '--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
@@ -186,6 +190,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:
@@ -233,7 +239,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=test-infra
         - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
         - --branch=master
@@ -248,6 +254,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -20,7 +20,7 @@ periodics:
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
-      - --org=istio
+      - --org=$ORG
       - --repo=istio.io
       - '--title=Automator: update istio.io@$AUTOMATOR_SRC_BRANCH reference docs'
       - --labels=auto-merge,release-notes-none
@@ -30,6 +30,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: ORG
+        value: istio
       image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
       name: ""
       resources:
@@ -79,7 +81,7 @@ periodics:
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
-      - --org=istio
+      - --org=$ORG
       - --repo=istio.io
       - '--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference'
       - --labels=release-notes-none
@@ -88,6 +90,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: ORG
+        value: istio
       image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
       name: ""
       resources:
@@ -916,7 +920,7 @@ presubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=istio.io
         - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
@@ -924,6 +928,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -85,7 +85,7 @@ periodics:
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
-      - --org=istio
+      - --org=$ORG
       - --repo=istio
       - '--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
       - --labels=auto-merge,release-notes-none
@@ -96,6 +96,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: ORG
+        value: istio
       image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
       name: ""
       resources:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -179,7 +179,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=istio
         - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in
           $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
@@ -191,6 +191,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -22,7 +22,7 @@ periodics:
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
-      - --org=istio
+      - --org=$ORG
       - --repo=proxy
       - '--title=Automator: update envoy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
       - --labels=auto-merge
@@ -32,6 +32,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: ORG
+        value: istio
       image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
       name: ""
       resources:
@@ -81,7 +83,7 @@ periodics:
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
-      - --org=istio
+      - --org=$ORG
       - --repo=proxy
       - '--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
       - --labels=auto-merge,release-notes-none
@@ -91,6 +93,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: ORG
+        value: istio
       image: gcr.io/istio-testing/build-tools-proxy:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
       name: ""
       resources:
@@ -285,7 +289,7 @@ postsubmits:
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=istio
         - '--title=Automator: update proxy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
@@ -296,6 +300,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -16,7 +16,7 @@ periodics:
     containers:
     - command:
       - ./tools/automator/automator.sh
-      - --org=istio
+      - --org=$ORG
       - --repo=test-infra
       - '--title=Automator: bump k8s-prow images'
       - --modifier=bump-k8s-prow-images
@@ -32,6 +32,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: ORG
+        value: istio
       image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
       name: ""
       resources:

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -185,7 +185,7 @@ postsubmits:
       - command:
         - entrypoint
         - ../test-infra/tools/automator/automator.sh
-        - --org=istio
+        - --org=$ORG
         - --repo=common-files
         - '--title=Automator: update build-tools image@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=release-notes-none
@@ -197,6 +197,8 @@ postsubmits:
           value: "0"
         - name: MANIFEST_ARCH
           value: arm64 amd64
+        - name: ORG
+          value: istio
         image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
         name: ""
         resources:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -14,7 +14,7 @@ jobs:
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=client-go
     - "--title=Automator: update istio/api@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -23,6 +23,9 @@ jobs:
     - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
   - name: release-notes
     types: [presubmit]

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -17,7 +17,7 @@ jobs:
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio
     - "--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -27,3 +27,6 @@ jobs:
     - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -11,7 +11,7 @@ jobs:
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=test-infra,bots,community,ztunnel
     - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -21,13 +21,16 @@ jobs:
     - --cmd=make update-common && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
     disable_release_branching: true
 
   - name: update-common
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio,api,tools,release-builder,pkg,client-go,proxy
     - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -37,12 +40,15 @@ jobs:
     - --cmd=make update-common && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
   - name: update-common-istio.io
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio.io
     - "--title=Automator: update common-files@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -52,12 +58,15 @@ jobs:
     - --cmd=make update-common && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
   - name: update-build-tools-image
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=test-infra
     - "--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH"
     - --branch=master
@@ -71,3 +80,6 @@ jobs:
     - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -45,7 +45,7 @@ jobs:
     types: [presubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio.io
     - --token-path=/etc/github-token/oauth
     - --cmd=make update_ref_docs
@@ -53,6 +53,9 @@ jobs:
     requirements: [github]
     modifiers: [presubmit_optional]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
   - name: update-ref-docs
     disable_release_branching: true
@@ -60,7 +63,7 @@ jobs:
     cron: "0 2 * * *"  # every day at 02:00AM UTC
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio.io
     - "--title=Automator: update istio.io@$AUTOMATOR_SRC_BRANCH reference docs"
     - --labels=auto-merge,release-notes-none
@@ -69,6 +72,9 @@ jobs:
     - --cmd=make update_ref_docs
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
   - name: update-istio-ref
     disable_release_branching: true
@@ -76,7 +82,7 @@ jobs:
     cron: "0 2 * * 0"  # every Sunday at 02:00AM UTC
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio.io
     - "--title=Automator: update istio@$AUTOMATOR_SRC_BRANCH test reference"
     - --labels=release-notes-none
@@ -84,6 +90,9 @@ jobs:
     - --cmd=make update_test_reference
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
 resources_presets:
   default:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -370,7 +370,7 @@ jobs:
     cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio
     - "--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -379,6 +379,9 @@ jobs:
     - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio
 
 resources_presets:
   default:

--- a/prow/config/jobs/pkg.yaml
+++ b/prow/config/jobs/pkg.yaml
@@ -20,7 +20,7 @@ jobs:
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=istio
     - "--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
@@ -30,3 +30,6 @@ jobs:
     - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
     requirements: [github]
     repos: [istio/test-infra@master]
+    env:
+    - name: ORG
+      value: istio

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -93,7 +93,7 @@ jobs:
   types: [postsubmit]
   command:
   - ../test-infra/tools/automator/automator.sh
-  - --org=istio
+  - "--org=$ORG"
   - --repo=istio
   - "--title=Automator: update proxy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
   - --labels=auto-merge,release-notes-none
@@ -103,6 +103,9 @@ jobs:
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
   requirements: [github]
   repos: [istio/test-infra@master]
+  env:
+  - name: ORG
+    value: istio
   image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
   timeout: 4h
 
@@ -111,7 +114,7 @@ jobs:
   interval: 24h
   command:
   - ../test-infra/tools/automator/automator.sh
-  - --org=istio
+  - "--org=$ORG"
   - --repo=proxy
   - "--title=Automator: update envoy@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
   - --labels=auto-merge
@@ -120,6 +123,9 @@ jobs:
   - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
   requirements: [github]
   repos: [istio/test-infra@master]
+  env:
+  - name: ORG
+    value: istio
   image: gcr.io/istio-testing/build-tools:master-42499d67179f80bbbeb71bc0f793d1b483cf8937
   timeout: 4h
 
@@ -128,7 +134,7 @@ jobs:
   cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC
   command:
   - ../test-infra/tools/automator/automator.sh
-  - --org=istio
+  - "--org=$ORG"
   - --repo=proxy
   - "--title=Automator: update go-control-plane in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
   - --labels=auto-merge,release-notes-none
@@ -137,6 +143,9 @@ jobs:
   - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
   requirements: [github]
   repos: [istio/test-infra@master]
+  env:
+  - name: ORG
+    value: istio
 
 resources_presets:
   default:

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -95,7 +95,7 @@ jobs:
     cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
     command:
     - ./tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=test-infra
     - "--title=Automator: bump k8s-prow images"
     - --modifier=bump-k8s-prow-images
@@ -109,3 +109,6 @@ jobs:
     - --tag=v[0-9]{8}-[a-f0-9]{10}
     - --var=image
     requirements: [github]
+    env:
+    - name: ORG
+      value: istio

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -34,7 +34,7 @@ jobs:
     command:
     - entrypoint
     - ../test-infra/tools/automator/automator.sh
-    - --org=istio
+    - "--org=$ORG"
     - --repo=common-files
     - "--title=Automator: update build-tools image@$AUTOMATOR_SRC_BRANCH in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=release-notes-none
@@ -49,6 +49,8 @@ jobs:
     # For amd64, publish the manifest for arm64+amd64
     - name: MANIFEST_ARCH
       value: "arm64 amd64"
+    - name: ORG
+      value: istio
   # arm64 build
   - name: containers
     service_account_name: prowjob-advanced-sa


### PR DESCRIPTION
Org for automator is currently hardcoded to `istio`. This change will allow the organization to be changed using an environment variable `ORG`.