### PR TITLE
K8s 1.27.0 should be the default in master, so test k8s 1.26 in a postsubmit

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1753,19 +1753,15 @@ postsubmits:
       preset-enable-ssh: "true"
       preset-override-deps: master-istio
       preset-override-envoy: "true"
-    name: integ-k8s-127_istio_postsubmit_pri
+    name: integ-k8s-126_istio_postsubmit_pri
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.27.0-rc.0
+        - gcr.io/istio-testing/kind-node:v1.26.3
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1975,19 +1975,15 @@ postsubmits:
     decorate: true
     decoration_config:
       timeout: 4h0m0s
-    name: integ-k8s-127_istio_postsubmit
+    name: integ-k8s-126_istio_postsubmit
     path_alias: istio.io/istio
-    reporter_config:
-      slack:
-        report: false
-    skip_report: true
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --node-image
-        - gcr.io/istio-testing/kind-node:v1.27.0-rc.0
+        - gcr.io/istio-testing/kind-node:v1.26.3
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -302,14 +302,13 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
-  - name: integ-k8s-127
+  - name: integ-k8s-126
     types: [postsubmit]
-    modifiers: [hidden]
     command:
       - entrypoint
       - prow/integ-suite-kind.sh
       - --node-image
-      - gcr.io/istio-testing/kind-node:v1.27.0-rc.0
+      - gcr.io/istio-testing/kind-node:v1.26.3
       - test.integration.kube
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
See https://github.com/istio/istio/pull/44400