### PR TITLE
Fix the update-go-control-plane job

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -91,7 +91,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+      image: gcr.io/istio-testing/build-tools:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
       name: ""
       resources:
         limits:

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -137,6 +137,7 @@ jobs:
   - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
   requirements: [github]
   repos: [istio/test-infra@master]
+  image: gcr.io/istio-testing/build-tools:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
 
 resources_presets:
   default:


### PR DESCRIPTION
See https://prow.istio.io/job-history/gs/istio-prow/logs/update-go-control-plane_proxy_periodic for failures. WE should be using the build-tools image, not the proxy flavor 