### PR TITLE
Update several images to 1.18 that were missed. Clean up some dupes

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -92,7 +92,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ postsubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           requests:
@@ -211,7 +211,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -263,7 +263,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -315,7 +315,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -367,7 +367,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -419,7 +419,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -472,7 +472,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -538,7 +538,7 @@ presubmits:
           value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           requests:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
@@ -234,7 +234,7 @@ presubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    - base_ref: master
+    - base_ref: release-1.18
       org: istio
       path_alias: istio.io/tools
       repo: tools

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.18.gen.yaml
@@ -12,7 +12,7 @@ presubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    - base_ref: master
+    - base_ref: release-1.18
       org: istio
       path_alias: istio.io/tools
       repo: tools

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -2176,7 +2176,7 @@ postsubmits:
     - ^release-1.18$
     decorate: true
     extra_refs:
-    - base_ref: master
+    - base_ref: release-1.18
       org: istio
       path_alias: istio.io/release-builder
       repo: release-builder
@@ -2196,7 +2196,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: VERSION
-          value: master
+          value: release-1.18
         - name: COSIGN_KEY
           valueFrom:
             secretKeyRef:
@@ -3870,7 +3870,7 @@ presubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    - base_ref: master
+    - base_ref: release-1.18
       org: istio
       path_alias: istio.io/tools
       repo: tools

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -141,7 +141,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           requests:
@@ -241,7 +241,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -388,7 +388,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -431,7 +431,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -522,7 +522,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           requests:
@@ -567,7 +567,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:
@@ -611,7 +611,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
@@ -23,7 +23,7 @@ periodics:
       - name: BUILD_WITH_CONTAINER
         value: "0"
       - name: VERSION
-        value: master
+        value: release-1.18
       - name: COSIGN_KEY
         valueFrom:
           secretKeyRef:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.18.gen.yaml
@@ -173,7 +173,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    - base_ref: master
+    - base_ref: release-1.18
       org: istio
       path_alias: istio.io/common-files
       repo: common-files

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - presubmit
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build
   node_selector:
     testing: test-pool
@@ -147,10 +143,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -292,10 +284,6 @@ jobs:
   - --modifier=update_api_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update_api_dep_client_go
   node_selector:
     testing: test-pool
@@ -436,10 +424,6 @@ jobs:
 - command:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -431,7 +431,7 @@ jobs:
     testing: test-pool
   repos:
   - istio/test-infra@master
-  - istio/tools@master
+  - istio/tools@release-1.18
   requirement_presets:
     cache:
       volumeMounts:

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - build
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build
   node_selector:
     testing: test-pool
@@ -147,10 +143,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -286,10 +278,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -433,10 +421,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update_client-go_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/common-files-1.18.yaml
+++ b/prow/config/jobs/common-files-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -154,10 +150,6 @@ jobs:
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common && make gen
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update-common
   node_selector:
     testing: test-pool
@@ -305,10 +297,6 @@ jobs:
   - --modifier=commonfiles
   - --token-path=/etc/github-token/oauth
   - --cmd=make update-common && make gen
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -460,10 +448,6 @@ jobs:
   - --
   - --post=make gen
   - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements-1.18.yaml
+++ b/prow/config/jobs/enhancements-1.18.yaml
@@ -9,10 +9,6 @@ jobs:
   - ../test-infra/scripts/validate_schema.sh
   - --document-path=./features.yaml
   - --schema-path=./features_schema.json
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/config/jobs/enhancements-1.18.yaml
+++ b/prow/config/jobs/enhancements-1.18.yaml
@@ -16,7 +16,7 @@ jobs:
     testing: test-pool
   repos:
   - istio/test-infra@master
-  - istio/tools@master
+  - istio/tools@release-1.18
   requirement_presets:
     cache:
       volumeMounts:

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -5996,7 +5996,7 @@ jobs:
     testing: test-pool
   repos:
   - istio/test-infra@master
-  - istio/tools@master
+  - istio/tools@release-1.18
   requirement_presets:
     cache:
       volumeMounts:
@@ -6156,7 +6156,7 @@ jobs:
   - name: BUILD_BASE_IMAGES
     value: "true"
   - name: VERSION
-    value: master
+    value: release-1.18
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
   name: build-base-images
@@ -6164,7 +6164,7 @@ jobs:
     testing: test-pool
   regex: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
   repos:
-  - istio/release-builder@master
+  - istio/release-builder@release-1.18
   requirement_presets:
     cache:
       volumeMounts:

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -16,10 +16,6 @@ jobs:
   - build
   - racetest
   - binaries-test
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -176,10 +172,6 @@ jobs:
 - command:
   - entrypoint
   - prow/release-test.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release-test
   node_selector:
     testing: test-pool
@@ -340,10 +332,6 @@ jobs:
 - command:
   - entrypoint
   - prow/release-commit.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release
   node_selector:
     testing: test-pool
@@ -505,10 +493,6 @@ jobs:
   - entrypoint
   - make
   - benchtest
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -672,10 +656,6 @@ jobs:
   - make
   - benchtest
   - report-benchtest
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: benchmark-report
   node_selector:
     testing: test-pool
@@ -837,11 +817,8 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.pilot.kube.presubmit
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -1001,10 +978,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.telemetry.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -1164,10 +1137,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.telemetry.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-telemetry-mc
   node_selector:
     testing: test-pool
@@ -1331,11 +1300,8 @@ jobs:
   - prow/config/topology/external-istiod.json
   - test.integration.telemetry.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
@@ -1495,11 +1461,8 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.kube.environment
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: VARIANT
     value: distroless
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -1658,13 +1621,10 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.kube.environment
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: DOCKER_IN_DOCKER_IPV6_ENABLED
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-ipv6
   node_selector:
     testing: test-pool
@@ -1823,13 +1783,10 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.kube.environment
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: DOCKER_IN_DOCKER_IPV6_ENABLED
     value: "true"
   - name: IP_FAMILY
     value: dual
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-ds
   node_selector:
     testing: test-pool
@@ -1989,10 +1946,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.kube.environment
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-basic
   node_selector:
     testing: test-pool
@@ -2150,10 +2103,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.operator.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-operator-controller
   node_selector:
     testing: test-pool
@@ -2311,10 +2260,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.pilot.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -2473,11 +2418,8 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.pilot.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: GRPC_ECHO_IMAGE
     value: grpctesting/istio_echo_cpp
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-pilot-cpp
   node_selector:
     testing: test-pool
@@ -2639,10 +2581,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.pilot.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -2806,11 +2744,8 @@ jobs:
   - prow/config/topology/external-istiod.json
   - test.integration.pilot.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
@@ -2974,11 +2909,8 @@ jobs:
   - prow/config/topology/external-istiod-multicluster.json
   - test.integration.pilot.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
@@ -3137,10 +3069,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.security.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-security
   node_selector:
     testing: test-pool
@@ -3299,10 +3227,6 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration-fuzz.security.fuzz.kube
   cron: 0 7 * * *
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -3464,10 +3388,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - test.integration.security.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -3631,11 +3551,8 @@ jobs:
   - prow/config/topology/external-istiod.json
   - test.integration.security.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-security-istiodremote
   node_selector:
     testing: test-pool
@@ -3797,11 +3714,8 @@ jobs:
   - prow/config/ambient-sc.yaml
   - test.integration.ambient.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.ambient
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-ambient
   node_selector:
     testing: test-pool
@@ -3959,10 +3873,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - test.integration.helm.kube
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -4125,11 +4035,8 @@ jobs:
   - prow/config/mixedlb-service.yaml
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-120
   node_selector:
     testing: test-pool
@@ -4295,11 +4202,8 @@ jobs:
   - prow/config/mixedlb-service.yaml
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-121
   node_selector:
     testing: test-pool
@@ -4465,11 +4369,8 @@ jobs:
   - prow/config/mixedlb-service.yaml
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-122
   node_selector:
     testing: test-pool
@@ -4633,11 +4534,8 @@ jobs:
   - gcr.io/istio-testing/kind-node:v1.23.1
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-123
   node_selector:
     testing: test-pool
@@ -4801,11 +4699,8 @@ jobs:
   - gcr.io/istio-testing/kind-node:v1.24.3
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-124
   node_selector:
     testing: test-pool
@@ -4969,11 +4864,8 @@ jobs:
   - gcr.io/istio-testing/kind-node:v1.25.4
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-125
   node_selector:
     testing: test-pool
@@ -5137,11 +5029,8 @@ jobs:
   - gcr.io/istio-testing/kind-node:v1.26.3
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-k8s-126
   node_selector:
     testing: test-pool
@@ -5303,13 +5192,10 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: TEST_SELECT
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -5471,11 +5357,8 @@ jobs:
   - prow/integ-suite-kind.sh
   - test.integration.kube
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -5636,10 +5519,6 @@ jobs:
 - command:
   - make
   - test.integration.analyze
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: analyze-tests
   node_selector:
     testing: test-pool
@@ -5797,10 +5676,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -5959,10 +5834,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -6120,10 +5991,6 @@ jobs:
 - command:
   - ../test-infra/tools/check_release_notes.sh
   - --token-path=/etc/github-token/oauth
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release-notes
   node_selector:
     testing: test-pool
@@ -6286,15 +6153,12 @@ jobs:
   - entrypoint
   - ../release-builder/release/build.sh
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: BUILD_BASE_IMAGES
     value: "true"
   - name: VERSION
     value: master
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build-base-images
   node_selector:
     testing: test-pool
@@ -6466,10 +6330,6 @@ jobs:
   - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make
     gen
   cron: 0 2 * * 0
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update-go-control-plane
   node_selector:
     testing: test-pool
@@ -6636,10 +6496,6 @@ jobs:
   - --modifier=update_ztunnel_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=./bin/update_ztunnel.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   interval: 24h
   name: update-ztunnel
   node_selector:

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -161,10 +157,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -315,10 +307,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_default
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: doc.test.profile_default
   node_selector:
     testing: test-pool
@@ -472,10 +460,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_demo
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: doc.test.profile_demo
   node_selector:
     testing: test-pool
@@ -628,10 +612,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_none
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: doc.test.profile_none
   node_selector:
     testing: test-pool
@@ -784,10 +764,6 @@ jobs:
   - entrypoint
   - prow/integ-suite-kind.sh
   - doc.test.profile_minimal
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: doc.test.profile_minimal
   node_selector:
     testing: test-pool
@@ -942,10 +918,6 @@ jobs:
   - --topology
   - MULTICLUSTER
   - doc.test.multicluster
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -1101,10 +1073,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=make update_ref_docs
   - --dry-run
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - build
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build
   node_selector:
     testing: test-pool
@@ -147,10 +143,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -286,10 +278,6 @@ jobs:
 - command:
   - make
   - test
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test
   node_selector:
     testing: test-pool
@@ -425,10 +413,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -571,10 +555,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update_pkg_dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -7,10 +7,6 @@ image: gcr.io/istio-testing/build-tools-proxy:release-1.18-9bab62ff1c9c252ed3189
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test
   node_selector:
     testing: build-pool
@@ -153,10 +149,6 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-asan.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test-asan
   node_selector:
     testing: build-pool
@@ -299,10 +291,6 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-tsan.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test-tsan
   node_selector:
     testing: build-pool
@@ -446,9 +434,6 @@ jobs:
 - command:
   - ./prow/proxy-presubmit-release.sh
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release-test
   node_selector:
     testing: build-pool
@@ -594,13 +579,10 @@ jobs:
   command:
   - ./prow/proxy-presubmit-release.sh
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: ARCH_SUFFIX
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release-test
   node_selector:
     testing: test-pool
@@ -744,10 +726,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-centos:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+  image: gcr.io/istio-testing/build-tools-centos:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -891,10 +870,6 @@ jobs:
 - command:
   - entrypoint
   - ./prow/proxy-presubmit-wasm.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: check-wasm
   node_selector:
     testing: build-pool
@@ -1039,10 +1014,6 @@ jobs:
 - command:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release
   node_selector:
     testing: build-pool
@@ -1190,13 +1161,10 @@ jobs:
   - entrypoint
   - ./prow/proxy-postsubmit.sh
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: ARCH_SUFFIX
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release
   node_selector:
     testing: test-pool
@@ -1341,10 +1309,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools-centos:master-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
+  image: gcr.io/istio-testing/build-tools-centos:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release-centos
   node_selector:
     testing: build-pool
@@ -1495,9 +1460,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update-istio
   node_selector:
@@ -1650,9 +1612,6 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   interval: 24h
   name: update-proxy
@@ -1807,9 +1766,6 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
   cron: 0 2 * * 0
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: update-go-control-plane
   node_selector:

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -1173,7 +1173,7 @@ jobs:
   - name: BUILD_BASE_IMAGES
     value: "true"
   - name: VERSION
-    value: master
+    value: release-1.18
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -154,10 +150,6 @@ jobs:
 - command:
   - make
   - test
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test
   node_selector:
     testing: test-pool
@@ -300,10 +292,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -446,10 +434,6 @@ jobs:
 - command:
   - entrypoint
   - test/publish.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: dry-run
   node_selector:
     testing: test-pool
@@ -595,10 +579,6 @@ jobs:
   service_account_name: prowjob-advanced-sa
 - command:
   - release/build-warning.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -745,10 +725,6 @@ jobs:
   - presubmit
 - command:
   - release/publish-warning.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -896,10 +872,6 @@ jobs:
 - command:
   - entrypoint
   - release/build.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build-release
   node_selector:
     testing: test-pool
@@ -1048,10 +1020,6 @@ jobs:
 - command:
   - entrypoint
   - release/publish.sh
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: publish-release
   node_selector:
     testing: test-pool
@@ -1202,13 +1170,10 @@ jobs:
   - release/build.sh
   cron: 0 19 * * *
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: BUILD_BASE_IMAGES
     value: "true"
   - name: VERSION
     value: master
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - build
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: build
   node_selector:
     testing: test-pool
@@ -154,10 +150,6 @@ jobs:
 - command:
   - make
   - lint
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: lint
   node_selector:
     testing: test-pool
@@ -300,10 +292,6 @@ jobs:
 - command:
   - make
   - test
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test
   node_selector:
     testing: test-pool
@@ -446,10 +434,6 @@ jobs:
 - command:
   - make
   - gen-check
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: gencheck
   node_selector:
     testing: test-pool
@@ -600,11 +584,8 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --script-path=../common-files/bin/create-buildtools-and-update.sh
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: MANIFEST_ARCH
     value: arm64 amd64
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: containers
   node_selector:
     testing: test-pool
@@ -761,10 +742,7 @@ jobs:
   - make
   - containers
   env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
   - name: MANIFEST_ARCH
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: containers
   node_selector:
     testing: test-pool
@@ -914,10 +892,6 @@ jobs:
   - entrypoint
   - make
   - containers-test
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: containers-test
   node_selector:
     testing: test-pool
@@ -1069,10 +1043,6 @@ jobs:
   - entrypoint
   - make
   - containers-test
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: containers-test
   node_selector:
     testing: test-pool
@@ -1224,10 +1194,6 @@ jobs:
   - -C
   - perf_dashboard
   - deploy
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: deploy-perf-dashboard
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -592,7 +592,7 @@ jobs:
   regex: docker/.+|cmd/.+|pkg/.+
   repos:
   - istio/test-infra@master
-  - istio/common-files@master
+  - istio/common-files@release-1.18
   requirement_presets:
     cache:
       volumeMounts:

--- a/prow/config/jobs/ztunnel-1.18.yaml
+++ b/prow/config/jobs/ztunnel-1.18.yaml
@@ -8,10 +8,6 @@ jobs:
 - command:
   - make
   - presubmit
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: test
   node_selector:
     testing: test-pool
@@ -151,10 +147,6 @@ jobs:
   command:
   - make
   - release
-  env:
-  - name: BUILD_WITH_CONTAINER
-    value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.18-9bab62ff1c9c252ed3189a6cb4eb0bec674ad3a1
   name: release
   node_selector:
     testing: test-pool


### PR DESCRIPTION
I'm not sure we really care about the duplicate entries anymore, but I removed part of it anyway. Feel free to suggest just leaving the entries alone.

The real issue is that some of the job images in the proxy-1.18 yaml still pointed to the master image.