### PR TITLE
Prevent branch cut of two go-control-plane update jobs

### DIFF
--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -391,6 +391,7 @@ jobs:
     - --modifier=update_deps
     - --token-path=/etc/github-token/oauth
     - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make gen
+    disable_release_branching: true
     requirements: [github]
     repos: [istio/test-infra@master]
 

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -135,6 +135,7 @@ jobs:
   - --modifier=update_deps
   - --token-path=/etc/github-token/oauth
   - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
+  disable_release_branching: true
   requirements: [github]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-970749213941d253695587ab4a3f908def2153c8


### PR DESCRIPTION
Follow-on to https://github.com/istio/test-infra/pull/4684