### PR TITLE
Use the make target instead of calling the release scripts directly

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -18,7 +18,8 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - prow/release-commit.sh
+        - make
+        - release.commit
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -2085,7 +2086,8 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/release-test.sh
+        - make
+        - release.test
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -305,7 +305,8 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - prow/release-commit.sh
+        - make
+        - release.commit
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -2317,7 +2318,8 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/release-test.sh
+        - make
+        - release.test
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -116,7 +116,8 @@ presubmits:
       containers:
       - command:
         - entrypoint
-        - prow/release-test.sh
+        - make
+        - release.test
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -10,14 +10,14 @@ jobs:
 
   - name: release-test
     types: [presubmit]
-    command: [entrypoint, prow/release-test.sh]
+    command: [entrypoint, make, release.test]
     requirements: [docker]
     resources: dedicated
 
   - name: release
     service_account_name: prowjob-advanced-sa
     types: [postsubmit]
-    command: [entrypoint, prow/release-commit.sh]
+    command: [entrypoint, make, release.commit]
     requirements: [docker]
     resources: dedicated
 


### PR DESCRIPTION
This will allow the script to reuse the `VERSION` variable defined in the Makefile.