### PR TITLE
Extend time for istio/community sync job

### DIFF
--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      timeout: 3h0m0s
+      timeout: 4h0m0s
     name: sync-org_community_postsubmit
     path_alias: istio.io/community
     spec:

--- a/prow/config/jobs/community.yaml
+++ b/prow/config/jobs/community.yaml
@@ -13,4 +13,4 @@ jobs:
     types: [postsubmit]
     command: [sh, prow/sync-org.sh]
     requirements: [github]
-    timeout: 3h
+    timeout: 4h


### PR DESCRIPTION
The sync job did pass after updating the k8s test-infra tools, but I note that it is taking longer with the new format. Extend the timeout to give the job time to complete.

For times: https://prow.istio.io/job-history/gs/istio-prow/logs/sync-org_community_postsubmit