### PR TITLE
Revert build-tools image in istio.io as the lint test is failing

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -18,7 +18,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -58,7 +58,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -100,7 +100,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -220,7 +220,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -280,7 +280,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -342,7 +342,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -404,7 +404,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -447,7 +447,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -492,7 +492,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -556,7 +556,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -620,7 +620,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -684,7 +684,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -750,7 +750,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -30,7 +30,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+      image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
       name: ""
       resources:
         limits:
@@ -88,7 +88,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+      image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
       name: ""
       resources:
         limits:
@@ -136,7 +136,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -176,7 +176,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -338,7 +338,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -398,7 +398,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -460,7 +460,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -520,7 +520,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -561,7 +561,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -604,7 +604,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -666,7 +666,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -728,7 +728,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -790,7 +790,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -854,7 +854,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:
@@ -924,7 +924,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+        image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio.io
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-d1c937bacd5fd54df479b065f2e56f3d643f68cb
+image: gcr.io/istio-testing/build-tools:master-24cb3cb93708d8739901dfb5cfbae6574caa1f19
 
 jobs:
   - name: lint


### PR DESCRIPTION
The istio.io lint job started failing with the new build-tools image in `htmlproofer`. I'm doing some investigation if something changed due to the test-infra tools update or something else. Since this build-tools change only affects the one test, let's revert the image just in the istio.io tests.

I'm still investigating the failure to see how the build-tools image might need to be updated.