### PR TITLE
Add initial terraform infrastructure

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,60 @@
+# Istio Infrastructure
+
+This folder contains documentation and infrastructure-as-code for Istio's infrastructure.
+
+Warning: this document is a work in progress and should not be seen as authoritative.
+Istio is currently in the process of converting ad-hoc infrastructure to infrastructure-as-code;
+during this time the definitions and documentation should be seen as best-effort only.
+
+## Overview
+
+Istio infrastructure spans a variety of platforms, but is primarily hosted on GCP.
+
+### `istio-io` GCP Project
+
+`istio-io` hosts:
+* GCS bucket for terraform state (`istio-terraform`)
+
+### `istio-release` GCP Project
+
+`istio-release` hosts the `gcr.io/istio-release` registry, used in production.
+
+### `istio-testing` GCP Project
+
+This project hosts:
+* Prow control plane cluster
+* gcr.io/istio-testing, used for hosting all our development builds (and testing tools)
+
+### `istio-prow-build` GCP Project
+
+This project contains our prow *build* clusters.
+
+## Using terraform
+
+Currently, terraform configuration is applied by humans.
+Reach out to @howardjohn if changes are needed.
+
+Within each package, the following commands can be used:
+
+```shell
+terraform fmt
+terraform validate
+terraform plan # Dry run to see what changes
+terraform apply # Actually apply changes
+```
+
+Due to our current mixed state, generally its best to run `terraform plan` _before_ making any changes to detect any drift that may have occurred.
+
+### Structure
+
+Each project has its own folder, grouped by provider type.
+
+For example:
+
+```text
+gcp
+└── project-0
+└── project-1
+aws
+└── project-0
+```

--- a/infra/gcp/.gitignore
+++ b/infra/gcp/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate*

--- a/infra/gcp/istio-prow-build/cluster-prow-arm.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow-arm.tf
@@ -1,0 +1,281 @@
+# prow_arm provides a cluster that hosts ARM jobs.
+# This mirrors the "prow" cluster, but with ARM.
+# Ideally, this could just be the "prow" cluster with an ARM node pool.
+# However, ARM nodes availability is limited to us-central1-f, so we have our own.
+# In the future this could be consolidated.
+resource "google_container_cluster" "prow_arm" {
+  addons_config {
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
+
+    network_policy_config {
+      disabled = true
+    }
+  }
+
+  cluster_autoscaling {
+    enabled = false
+  }
+
+  cluster_ipv4_cidr = "10.12.0.0/14"
+
+  database_encryption {
+    state = "DECRYPTED"
+  }
+
+  enable_shielded_nodes = true
+  location              = "us-central1-f"
+
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = true
+    }
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+  }
+
+  name    = "prow-arm"
+  network = "projects/istio-prow-build/global/networks/default"
+
+  network_policy {
+    enabled  = false
+    provider = "PROVIDER_UNSPECIFIED"
+  }
+
+  networking_mode = "ROUTES"
+
+  node_version = "1.25.9-gke.2300"
+
+  notification_config {
+    pubsub {
+      enabled = false
+    }
+  }
+
+  private_cluster_config {
+    enable_private_endpoint = false
+
+    master_global_access_config {
+      enabled = false
+    }
+  }
+
+  project = "istio-prow-build"
+
+  release_channel {
+    channel = "RAPID"
+  }
+
+  resource_labels = {
+    role  = "prow"
+    owner = "oss-istio"
+  }
+
+  subnetwork = "projects/istio-prow-build/regions/us-central1/subnetworks/default"
+
+  workload_identity_config {
+    workload_pool = "istio-prow-build.svc.id.goog"
+  }
+}
+
+# The "build" cluster doesn't run anything as far as I can tell. This can probably be removed.
+resource "google_container_node_pool" "prow_arm_build" {
+  autoscaling {
+    max_node_count = 1
+    min_node_count = 1
+  }
+
+  cluster            = "prow-arm"
+  initial_node_count = 0
+  location           = "us-central1-f"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  name = "arm-build-pool-large"
+
+  node_config {
+    disk_size_gb = 100
+    disk_type    = "pd-balanced"
+
+    gvnic {
+      enabled = true
+    }
+
+    image_type   = "COS_CONTAINERD"
+    machine_type = "t2a-standard-16"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+    service_account = "default"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+    }
+
+    taint {
+      effect = "NO_SCHEDULE"
+      key    = "kubernetes.io/arch"
+      value  = "arm64"
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  node_count     = 1
+  node_locations = ["us-central1-f"]
+  project        = "istio-prow-build"
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 1
+  }
+
+  version = "1.25.9-gke.2300"
+}
+
+# The default pool hosts an x86 node pool. This is to run some of the prow infrastructure which isn't arm compatible.
+# This is just a single node without scaling, no tests run here.
+resource "google_container_node_pool" "prow_arm_default" {
+  cluster            = "prow-arm"
+  initial_node_count = 1
+  location           = "us-central1-f"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  name = "default-pool"
+
+  node_config {
+    disk_size_gb = 100
+    disk_type    = "pd-ssd"
+    image_type   = "COS_CONTAINERD"
+    machine_type = "n1-standard-8"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+    service_account = "default"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  node_count     = 1
+  node_locations = ["us-central1-f"]
+  project        = "istio-prow-build"
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  version = "1.25.9-gke.2300"
+}
+
+# This pool provides the actual ARM (t2a) instances for tests.
+# Spot instances are used as quota is capped for ARM nodes, and its cheaper.
+# Currently, autoscaling is disabled due to ongoing networking issues on ARM.
+resource "google_container_node_pool" "prow_arm_test_spot" {
+  autoscaling {
+    total_max_node_count = 6
+    total_min_node_count = 6
+  }
+
+  cluster  = "prow-arm"
+  location = "us-central1-f"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  name = "t2a-spot"
+
+  node_config {
+    disk_size_gb = 256
+    disk_type    = "pd-ssd"
+
+    gvnic {
+      enabled = true
+    }
+
+    image_type = "COS_CONTAINERD"
+
+    labels = {
+      testing = "test-pool"
+    }
+
+    machine_type = "t2a-standard-16"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+    service_account = "default"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+    }
+
+    spot = true
+
+
+    taint {
+      effect = "NO_SCHEDULE"
+      key    = "kubernetes.io/arch"
+      value  = "arm64"
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  node_count     = 6
+  node_locations = ["us-central1-f"]
+  project        = "istio-prow-build"
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  version = "1.25.9-gke.2300"
+
+  # ARM defaults to cgroups v2. However, our test setup (kind) do not yet support this
+  # Terraform does not yet support this mode, so we have to just set it manually and ignore changes
+  # TODO: https://github.com/hashicorp/terraform-provider-google/issues/12712
+  #    linux_node_config {
+  #      cgroup_mode = "CGROUP_MODE_V1"
+  #    }
+  lifecycle {
+    ignore_changes = [
+      node_config[0].linux_node_config,
+    ]
+  }
+}

--- a/infra/gcp/istio-prow-build/cluster-prow.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow.tf
@@ -1,0 +1,215 @@
+# Prow cluster is the core build cluster. Most jobs end up running here
+resource "google_container_cluster" "prow" {
+  addons_config {
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+
+    http_load_balancing {
+      disabled = false
+    }
+
+    network_policy_config {
+      disabled = true
+    }
+  }
+
+  cluster_autoscaling {
+    enabled = false
+  }
+
+  database_encryption {
+    state = "DECRYPTED"
+  }
+
+  default_max_pods_per_node = 110
+  enable_shielded_nodes     = false
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "10.44.0.0/14"
+    services_ipv4_cidr_block = "10.0.0.0/20"
+  }
+
+  location = "us-west1-a"
+
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  maintenance_policy {
+    recurring_window {
+      end_time   = "2021-01-12T08:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=SA,SU"
+      start_time = "2021-01-11T08:00:00Z"
+    }
+  }
+
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+  }
+
+  name    = "prow"
+  network = "projects/istio-prow-build/global/networks/default"
+
+  network_policy {
+    enabled = false
+  }
+
+  networking_mode = "VPC_NATIVE"
+
+  node_version = "1.24.12-gke.500"
+
+  project = "istio-prow-build"
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  resource_labels = {
+    role  = "prow"
+    owner = "oss-istio"
+  }
+
+  subnetwork = "projects/istio-prow-build/regions/us-west1/subnetworks/default"
+
+  workload_identity_config {
+    workload_pool = "istio-prow-build.svc.id.goog"
+  }
+}
+
+# Prow 'build' node pool is used for large jobs, mostly istio/proxy.
+# Consists of 64 core machines.
+# Note: despite the naming "build" vs "test", a lot of build jobs use the test pool.
+resource "google_container_node_pool" "prow_build" {
+  autoscaling {
+    max_node_count = 10
+    min_node_count = 0
+  }
+
+  cluster            = "prow"
+  initial_node_count = 2
+  location           = "us-west1-a"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  max_pods_per_node = 110
+  name              = "istio-build-pool-containerd-n2"
+
+  network_config {
+    pod_ipv4_cidr_block = "10.44.0.0/14"
+    pod_range           = "gke-prow-pods-477396f0"
+  }
+
+  node_config {
+    disk_size_gb = 2000
+    disk_type    = "pd-ssd"
+    image_type   = "COS_CONTAINERD"
+
+    labels = {
+      testing = "build-pool"
+    }
+
+    machine_type = "n1-standard-64"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+      testing                  = "build-pool"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/trace.append"]
+    service_account = "default"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  node_locations = ["us-west1-a"]
+  project        = "istio-prow-build"
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  version = "1.24.12-gke.500"
+}
+
+
+# Prow 'test' node pool is used for most jobs
+# Consists of e2-16 nodes.
+# Note: despite the naming "build" vs "test", a lot of build jobs use the test pool.
+resource "google_container_node_pool" "prow_test" {
+  autoscaling {
+    max_node_count = 60
+    min_node_count = 2
+  }
+
+  cluster            = "prow"
+  initial_node_count = 2
+  location           = "us-west1-a"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  max_pods_per_node = 110
+  name              = "istio-test-pool-e2"
+
+  network_config {
+    pod_ipv4_cidr_block = "10.44.0.0/14"
+    pod_range           = "gke-prow-pods-477396f0"
+  }
+
+  node_config {
+    disk_size_gb = 256
+    disk_type    = "pd-ssd"
+    image_type   = "COS_CONTAINERD"
+
+    labels = {
+      testing = "test-pool"
+    }
+
+    machine_type = "e2-standard-16"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  node_locations = ["us-west1-a"]
+  project        = "istio-prow-build"
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  version = "1.24.12-gke.500"
+}
+# terraform import google_container_node_pool.istio_test_pool_e2 istio-prow-build/us-west1-a/prow/istio-test-pool-e2

--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -1,0 +1,24 @@
+resource "google_service_account" "external_secrets_private" {
+  account_id   = "external-secrets-private"
+  description  = "Kubernetes External Secrets controller for private cluster"
+  display_name = "external-secrets-private"
+  project      = "istio-prow-build"
+}
+resource "google_service_account" "istio_prow_jobs" {
+  account_id   = "istio-prow-jobs"
+  description  = "The default service account that will be used for Prow job workloads."
+  display_name = "istio-prow-jobs"
+  project      = "istio-prow-build"
+}
+resource "google_service_account" "kubernetes_external_secrets_sa" {
+  account_id   = "kubernetes-external-secrets-sa"
+  description  = "Service account used by external secrets controller"
+  display_name = "kubernetes-external-secrets-sa"
+  project      = "istio-prow-build"
+}
+resource "google_service_account" "prow_internal_storage" {
+  account_id   = "prow-internal-storage"
+  description  = "Internal Prow SA for istio-private-build GCS. "
+  display_name = "Prow Internal Storage"
+  project      = "istio-prow-build"
+}

--- a/infra/gcp/istio-prow-build/keys.tf
+++ b/infra/gcp/istio-prow-build/keys.tf
@@ -1,0 +1,17 @@
+resource "google_kms_key_ring" "istio_cosign_keyring" {
+  location = "global"
+  name     = "istio-cosign-keyring"
+  project  = "istio-prow-build"
+}
+
+resource "google_kms_crypto_key" "istio_cosign_key" {
+  destroy_scheduled_duration = "86400s"
+  key_ring                   = "projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring"
+  name                       = "istio-cosign-key"
+  purpose                    = "ASYMMETRIC_SIGN"
+
+  version_template {
+    algorithm        = "EC_SIGN_P256_SHA256"
+    protection_level = "SOFTWARE"
+  }
+}

--- a/infra/gcp/istio-prow-build/main.tf
+++ b/infra/gcp/istio-prow-build/main.tf
@@ -1,8 +1,4 @@
-
 locals {
-  project_id = "istio-prow-build"
-}
-
-data "google_organization" "org" {
-  domain = "google.com"
+  project_id     = "istio-prow-build"
+  project_number = "560427374064"
 }

--- a/infra/gcp/istio-prow-build/main.tf
+++ b/infra/gcp/istio-prow-build/main.tf
@@ -1,0 +1,8 @@
+
+locals {
+  project_id = "istio-prow-build"
+}
+
+data "google_organization" "org" {
+  domain = "google.com"
+}

--- a/infra/gcp/istio-prow-build/providers.tf
+++ b/infra/gcp/istio-prow-build/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "gcs" {
+    bucket = "istio-terraform"
+    prefix = "istio-prow-build" // project name
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.69.1"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.69.1"
+    }
+  }
+}

--- a/infra/gcp/istio-prow-build/services.tf
+++ b/infra/gcp/istio-prow-build/services.tf
@@ -1,0 +1,30 @@
+resource "google_project_service" "project" {
+  project = local.project_number
+
+  for_each = toset([
+    "bigquery.googleapis.com",
+    "bigquerystorage.googleapis.com",
+    "cloudkms.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "containerregistry.googleapis.com",
+    "iam.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "pubsub.googleapis.com",
+    "secretmanager.googleapis.com",
+    "servicemanagement.googleapis.com",
+    "serviceusage.googleapis.com",
+    "stackdriver.googleapis.com",
+  ])
+
+  service = each.key
+  timeouts {}
+
+  // TODO: terraform wants to set this. I think its basically a NOP, but to keep the plan empty for now we ignore this.
+  lifecycle {
+    ignore_changes = [
+      disable_on_destroy,
+    ]
+  }
+}

--- a/infra/gcp/istio-prow-build/storage.tf
+++ b/infra/gcp/istio-prow-build/storage.tf
@@ -1,0 +1,36 @@
+resource "google_storage_bucket" "artifacts_istio_prow_build_appspot_com" {
+  force_destroy               = false
+  location                    = "US"
+  name                        = "artifacts.istio-prow-build.appspot.com"
+  project                     = "istio-prow-build"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+resource "google_storage_bucket" "istio_private_artifacts" {
+  force_destroy               = false
+  location                    = "US"
+  name                        = "istio-private-artifacts"
+  project                     = "istio-prow-build"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+resource "google_storage_bucket" "istio_private_build" {
+  force_destroy               = false
+  location                    = "US"
+  name                        = "istio-private-build"
+  project                     = "istio-prow-build"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+resource "google_storage_bucket" "istio_private_prerelease" {
+  force_destroy               = false
+  location                    = "US"
+  name                        = "istio-private-prerelease"
+  project                     = "istio-prow-build"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}


### PR DESCRIPTION
This PR introduces initial importing of our infrastructure as terraform. This is VERY WIP.

What is done in this PR:
* Setup initial state bucket
* Import a few resources
  Resources are created by using `gcloud beta resource-config bulk-export --resource-format=terraform` with some manual corrections. They are then imported to terraform.
  Imports done
```
terraform import google_storage_bucket.artifacts_istio_prow_build_appspot_com artifacts.istio-prow-build.appspot.com
terraform import google_storage_bucket.istio_private_artifacts istio-private-artifacts
terraform import google_storage_bucket.istio_private_build istio-private-build
terraform import google_storage_bucket.istio_private_prerelease istio-private-prerelease

terraform import google_container_cluster.prow istio-prow-build/us-west1-a/prow
terraform import google_container_node_pool.istio_build_pool_containerd_n2 istio-prow-build/us-west1-a/prow/istio-build-pool-containerd-n2
terraform import google_container_node_pool.istio_test_pool_e2 istio-prow-build/us-west1-a/prow/istio-test-pool-e2

terraform import google_container_cluster.prow_arm istio-prow-build/us-central1-f/prow-arm
terraform import google_container_node_pool.arm_build_pool_large istio-prow-build/us-central1-f/prow-arm/arm-build-pool-large
terraform import google_container_node_pool.default_pool istio-prow-build/us-central1-f/prow-arm/default-pool
terraform import google_container_node_pool.t2a_spot istio-prow-build/us-central1-f/prow-arm/t2a-spot

terraform import google_project_service.project[\"bigquery.googleapis.com\"] 560427374064/bigquery.googleapis.com
terraform import google_project_service.project[\"bigquerystorage.googleapis.com\"] 560427374064/bigquerystorage.googleapis.com
terraform import google_project_service.project[\"cloudapis.googleapis.com\"] 560427374064/cloudapis.googleapis.com
terraform import google_project_service.project[\"cloudkms.googleapis.com\"] 560427374064/cloudkms.googleapis.com
terraform import google_project_service.project[\"compute.googleapis.com\"] 560427374064/compute.googleapis.com
terraform import google_project_service.project[\"container.googleapis.com\"] 560427374064/container.googleapis.com
terraform import google_project_service.project[\"containerregistry.googleapis.com\"] 560427374064/containerregistry.googleapis.com
terraform import google_project_service.project[\"iam.googleapis.com\"] 560427374064/iam.googleapis.com
terraform import google_project_service.project[\"logging.googleapis.com\"] 560427374064/logging.googleapis.com
terraform import google_project_service.project[\"monitoring.googleapis.com\"] 560427374064/monitoring.googleapis.com
terraform import google_project_service.project[\"pubsub.googleapis.com\"] 560427374064/pubsub.googleapis.com
terraform import google_project_service.project[\"run.googleapis.com\"] 560427374064/run.googleapis.com
terraform import google_project_service.project[\"secretmanager.googleapis.com\"] 560427374064/secretmanager.googleapis.com
terraform import google_project_service.project[\"servicemanagement.googleapis.com\"] 560427374064/servicemanagement.googleapis.com
terraform import google_project_service.project[\"serviceusage.googleapis.com\"] 560427374064/serviceusage.googleapis.com
terraform import google_project_service.project[\"stackdriver.googleapis.com\"] 560427374064/stackdriver.googleapis.com
terraform import google_project_service.project[\"storage_api.googleapis.com\"] 560427374064/storage-api.googleapis.com
terraform import google_project_service.project[\"storage_component.googleapis.com\"] 560427374064/storage-component.googleapis.com

```

Basically we currently have only istio-prow-build, and only GCS buckets and public GKE clusters. So left TODO for this project is:

* ~KMSKeyRings~
* ComputeAddress/us-west1/boskos-metrics.tf
* Private build clusters (arm and standard)
* All IAM related (update: added service accounts, but not the bindings)
* Service enablement

That should be it for this project (but we have plenty of other projects!).

Currently, my intent was to import resources as-is. There are no changes to resources from `terraform plan`. This is intentionally _not_ abstracting anything into modules, etc - I think its fine to do that but want to import as-is first then we can refactor things (and even make changes to resources, if desired) as needed.