### PR TITLE
jobs: deny usage of underscore in name

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.16.gen.yaml
@@ -103,7 +103,7 @@ postsubmits:
     labels:
       preset-enable-ssh: "true"
       preset-override-envoy: "true"
-    name: update_api_dep_client_go_api_release-1.16_postsubmit_pri
+    name: update-api-dep-client-go_api_release-1.16_postsubmit_pri
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.17.gen.yaml
@@ -103,7 +103,7 @@ postsubmits:
     labels:
       preset-enable-ssh: "true"
       preset-override-envoy: "true"
-    name: update_api_dep_client_go_api_release-1.17_postsubmit_pri
+    name: update-api-dep-client-go_api_release-1.17_postsubmit_pri
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
@@ -103,7 +103,7 @@ postsubmits:
     labels:
       preset-enable-ssh: "true"
       preset-override-envoy: "true"
-    name: update_api_dep_client_go_api_release-1.18_postsubmit_pri
+    name: update-api-dep-client-go_api_release-1.18_postsubmit_pri
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_postsubmit_pri
+    name: doc.test.profile-default_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_postsubmit_pri
+    name: doc.test.profile-demo_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_postsubmit_pri
+    name: doc.test.profile-none_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -268,7 +268,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_minimal_istio.io_postsubmit_pri
+    name: doc.test.profile-minimal_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -276,7 +276,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -479,16 +479,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_pri
+    name: doc.test.profile-default_istio.io_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -533,8 +533,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -543,16 +543,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_pri
+    name: doc.test.profile-demo_istio.io_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -597,8 +597,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -607,16 +607,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_pri
+    name: doc.test.profile-none_istio.io_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -661,8 +661,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -671,16 +671,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_minimal_istio.io_pri
+    name: doc.test.profile-minimal_istio.io_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_minimal
+    rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -725,8 +725,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_minimal,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_minimal_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-minimal,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-minimal_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.16.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.16_postsubmit_pri
+    name: doc.test.profile-default_istio.io_release-1.16_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.16_postsubmit_pri
+    name: doc.test.profile-demo_istio.io_release-1.16_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.16_postsubmit_pri
+    name: doc.test.profile-none_istio.io_release-1.16_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -419,16 +419,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.16_pri
+    name: doc.test.profile-default_istio.io_release-1.16_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -473,8 +473,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io_release-1.16,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io_release-1.16,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -483,16 +483,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.16_pri
+    name: doc.test.profile-demo_istio.io_release-1.16_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -537,8 +537,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io_release-1.16,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io_release-1.16,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -547,16 +547,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.16_pri
+    name: doc.test.profile-none_istio.io_release-1.16_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -601,8 +601,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io_release-1.16,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io_release-1.16,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.17.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.17_postsubmit_pri
+    name: doc.test.profile-default_istio.io_release-1.17_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.17_postsubmit_pri
+    name: doc.test.profile-demo_istio.io_release-1.17_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.17_postsubmit_pri
+    name: doc.test.profile-none_istio.io_release-1.17_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -419,16 +419,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.17_pri
+    name: doc.test.profile-default_istio.io_release-1.17_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -473,8 +473,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io_release-1.17,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io_release-1.17,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -483,16 +483,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.17_pri
+    name: doc.test.profile-demo_istio.io_release-1.17_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -537,8 +537,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io_release-1.17,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io_release-1.17,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -547,16 +547,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.17_pri
+    name: doc.test.profile-none_istio.io_release-1.17_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -601,8 +601,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io_release-1.17,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io_release-1.17,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.18_postsubmit_pri
+    name: doc.test.profile-default_istio.io_release-1.18_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.18_postsubmit_pri
+    name: doc.test.profile-demo_istio.io_release-1.18_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.18_postsubmit_pri
+    name: doc.test.profile-none_istio.io_release-1.18_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -268,7 +268,7 @@ postsubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_minimal_istio.io_release-1.18_postsubmit_pri
+    name: doc.test.profile-minimal_istio.io_release-1.18_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -276,7 +276,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -479,16 +479,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.18_pri
+    name: doc.test.profile-default_istio.io_release-1.18_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -533,8 +533,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -543,16 +543,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.18_pri
+    name: doc.test.profile-demo_istio.io_release-1.18_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -597,8 +597,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -607,16 +607,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.18_pri
+    name: doc.test.profile-none_istio.io_release-1.18_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -661,8 +661,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"
@@ -671,16 +671,16 @@ presubmits:
     clone_uri: git@github.com:istio-private/istio.io.git
     cluster: private
     decorate: true
-    name: doc.test.profile_minimal_istio.io_release-1.18_pri
+    name: doc.test.profile-minimal_istio.io_release-1.18_pri
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_minimal
+    rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -725,8 +725,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_minimal,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_minimal_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-minimal,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-minimal_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_api_dep_client_go_api_postsubmit
+    name: update-api-dep-client-go_api_postsubmit
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_api_dep_client_go_api_release-1.16_postsubmit
+    name: update-api-dep-client-go_api_release-1.16_postsubmit
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_api_dep_client_go_api_release-1.17_postsubmit
+    name: update-api-dep-client-go_api_release-1.17_postsubmit
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_api_dep_client_go_api_release-1.18_postsubmit
+    name: update-api-dep-client-go_api_release-1.18_postsubmit
     path_alias: istio.io/api
     spec:
       containers:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -133,7 +133,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_client-go_dep_client-go_postsubmit
+    name: update-client-go-dep_client-go_postsubmit
     path_alias: istio.io/client-go
     spec:
       containers:
@@ -144,7 +144,7 @@ postsubmits:
         - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency
           in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_client-go_dep
+        - --modifier=update-client-go-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
@@ -133,7 +133,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_client-go_dep_client-go_release-1.16_postsubmit
+    name: update-client-go-dep_client-go_release-1.16_postsubmit
     path_alias: istio.io/client-go
     spec:
       containers:
@@ -144,7 +144,7 @@ postsubmits:
         - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency
           in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_client-go_dep
+        - --modifier=update-client-go-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.17.gen.yaml
@@ -133,7 +133,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_client-go_dep_client-go_release-1.17_postsubmit
+    name: update-client-go-dep_client-go_release-1.17_postsubmit
     path_alias: istio.io/client-go
     spec:
       containers:
@@ -144,7 +144,7 @@ postsubmits:
         - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency
           in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_client-go_dep
+        - --modifier=update-client-go-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
@@ -133,7 +133,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_client-go_dep_client-go_release-1.18_postsubmit
+    name: update-client-go-dep_client-go_release-1.18_postsubmit
     path_alias: istio.io/client-go
     spec:
       containers:
@@ -144,7 +144,7 @@ postsubmits:
         - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency
           in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_client-go_dep
+        - --modifier=update-client-go-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -210,7 +210,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_default_istio.io_postsubmit
+    name: doc.test.profile-default_istio.io_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -218,7 +218,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -270,7 +270,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_demo_istio.io_postsubmit
+    name: doc.test.profile-demo_istio.io_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -278,7 +278,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -330,7 +330,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_none_istio.io_postsubmit
+    name: doc.test.profile-none_istio.io_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -338,7 +338,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -390,7 +390,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_minimal_istio.io_postsubmit
+    name: doc.test.profile-minimal_istio.io_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -398,7 +398,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -595,16 +595,16 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_default_istio.io
+    name: doc.test.profile-default_istio.io
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -649,24 +649,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio.io
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_demo_istio.io
+    name: doc.test.profile-demo_istio.io
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -711,24 +711,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio.io
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_none_istio.io
+    name: doc.test.profile-none_istio.io
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -773,24 +773,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio.io
     branches:
     - ^master$
     decorate: true
-    name: doc.test.profile_minimal_istio.io
+    name: doc.test.profile-minimal_istio.io
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_minimal
+    rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -835,8 +835,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_minimal,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_minimal_istio.io,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-minimal,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-minimal_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio.io

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     branches:
     - ^release-1.16$
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.16_postsubmit
+    name: doc.test.profile-default_istio.io_release-1.16_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     branches:
     - ^release-1.16$
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.16_postsubmit
+    name: doc.test.profile-demo_istio.io_release-1.16_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     branches:
     - ^release-1.16$
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.16_postsubmit
+    name: doc.test.profile-none_istio.io_release-1.16_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -413,16 +413,16 @@ presubmits:
     branches:
     - ^release-1.16$
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.16
+    name: doc.test.profile-default_istio.io_release-1.16
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -467,24 +467,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io_release-1.16,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io_release-1.16,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.16_istio.io
     branches:
     - ^release-1.16$
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.16
+    name: doc.test.profile-demo_istio.io_release-1.16
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -529,24 +529,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io_release-1.16,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io_release-1.16,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.16_istio.io
     branches:
     - ^release-1.16$
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.16
+    name: doc.test.profile-none_istio.io_release-1.16
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -591,8 +591,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io_release-1.16,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io_release-1.16,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.16_istio.io

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.17.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     branches:
     - ^release-1.17$
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.17_postsubmit
+    name: doc.test.profile-default_istio.io_release-1.17_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     branches:
     - ^release-1.17$
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.17_postsubmit
+    name: doc.test.profile-demo_istio.io_release-1.17_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     branches:
     - ^release-1.17$
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.17_postsubmit
+    name: doc.test.profile-none_istio.io_release-1.17_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -413,16 +413,16 @@ presubmits:
     branches:
     - ^release-1.17$
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.17
+    name: doc.test.profile-default_istio.io_release-1.17
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -467,24 +467,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io_release-1.17,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io_release-1.17,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.17_istio.io
     branches:
     - ^release-1.17$
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.17
+    name: doc.test.profile-demo_istio.io_release-1.17
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -529,24 +529,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io_release-1.17,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io_release-1.17,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.17_istio.io
     branches:
     - ^release-1.17$
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.17
+    name: doc.test.profile-none_istio.io_release-1.17
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -591,8 +591,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io_release-1.17,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io_release-1.17,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.17_istio.io

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
@@ -88,7 +88,7 @@ postsubmits:
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.18_postsubmit
+    name: doc.test.profile-default_istio.io_release-1.18_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -96,7 +96,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -148,7 +148,7 @@ postsubmits:
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.18_postsubmit
+    name: doc.test.profile-demo_istio.io_release-1.18_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -156,7 +156,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -208,7 +208,7 @@ postsubmits:
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.18_postsubmit
+    name: doc.test.profile-none_istio.io_release-1.18_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -216,7 +216,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -268,7 +268,7 @@ postsubmits:
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_minimal_istio.io_release-1.18_postsubmit
+    name: doc.test.profile-minimal_istio.io_release-1.18_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
@@ -276,7 +276,7 @@ postsubmits:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -473,16 +473,16 @@ presubmits:
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_default_istio.io_release-1.18
+    name: doc.test.profile-default_istio.io_release-1.18
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_default
+    rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_default
+        - doc.test.profile-default
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -527,24 +527,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_default,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_default_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-default_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.18_istio.io
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_demo_istio.io_release-1.18
+    name: doc.test.profile-demo_istio.io_release-1.18
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_demo
+    rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_demo
+        - doc.test.profile-demo
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -589,24 +589,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_demo,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_demo_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-demo_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.18_istio.io
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_none_istio.io_release-1.18
+    name: doc.test.profile-none_istio.io_release-1.18
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_none
+    rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_none
+        - doc.test.profile-none
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -651,24 +651,24 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_none,?($|\s.*))|((?m)^/test( | .*
-      )doc.test.profile_none_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*
+      )doc.test.profile-none_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.18_istio.io
     branches:
     - ^release-1.18$
     decorate: true
-    name: doc.test.profile_minimal_istio.io_release-1.18
+    name: doc.test.profile-minimal_istio.io_release-1.18
     path_alias: istio.io/istio.io
-    rerun_command: /test doc.test.profile_minimal
+    rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
       containers:
       - command:
         - entrypoint
         - prow/integ-suite-kind.sh
-        - doc.test.profile_minimal
+        - doc.test.profile-minimal
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -713,8 +713,8 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )doc.test.profile_minimal,?($|\s.*))|((?m)^/test( |
-      .* )doc.test.profile_minimal_istio.io_release-1.18,?($|\s.*))
+    trigger: ((?m)^/test( | .* )doc.test.profile-minimal,?($|\s.*))|((?m)^/test( |
+      .* )doc.test.profile-minimal_istio.io_release-1.18,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_release-1.18_istio.io

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
@@ -173,7 +173,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_pkg_dep_pkg_release-1.16_postsubmit
+    name: update-pkg-dep_pkg_release-1.16_postsubmit
     path_alias: istio.io/pkg
     spec:
       containers:
@@ -184,7 +184,7 @@ postsubmits:
         - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in
           $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_pkg_dep
+        - --modifier=update-pkg-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.17.gen.yaml
@@ -173,7 +173,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_pkg_dep_pkg_release-1.17_postsubmit
+    name: update-pkg-dep_pkg_release-1.17_postsubmit
     path_alias: istio.io/pkg
     spec:
       containers:
@@ -184,7 +184,7 @@ postsubmits:
         - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in
           $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_pkg_dep
+        - --modifier=update-pkg-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
@@ -173,7 +173,7 @@ postsubmits:
       org: istio
       path_alias: istio.io/test-infra
       repo: test-infra
-    name: update_pkg_dep_pkg_release-1.18_postsubmit
+    name: update-pkg-dep_pkg_release-1.18_postsubmit
     path_alias: istio.io/pkg
     spec:
       containers:
@@ -184,7 +184,7 @@ postsubmits:
         - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in
           $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
         - --labels=auto-merge,release-notes-none
-        - --modifier=update_pkg_dep
+        - --modifier=update-pkg-dep
         - --token-path=/etc/github-token/oauth
         - --git-exclude=^common/
         - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -508,10 +508,10 @@ presubmits:
     branches:
     - ^master$
     decorate: true
-    name: benchmark_check_tools
+    name: benchmark-check_tools
     optional: true
     path_alias: istio.io/tools
-    rerun_command: /test benchmark_check
+    rerun_command: /test benchmark-check
     run_if_changed: ^perf/benchmark/
     spec:
       containers:
@@ -547,7 +547,7 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-    trigger: ((?m)^/test( | .* )benchmark_check,?($|\s.*))|((?m)^/test( | .* )benchmark_check_tools,?($|\s.*))
+    trigger: ((?m)^/test( | .* )benchmark-check,?($|\s.*))|((?m)^/test( | .* )benchmark-check_tools,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_tools

--- a/prow/config/istio-private_jobs/api.yaml
+++ b/prow/config/istio-private_jobs/api.yaml
@@ -23,4 +23,4 @@ transforms:
     preset-enable-ssh: "true"
     preset-override-envoy: "true"
   job-type: [postsubmit]
-  job-denylist: [update_api_dep]
+  job-denylist: [update-api-dep]

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -278,7 +278,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.16-0b7dd749b128a1dcf3f1a1a0c930cbe686446eb4
-  name: update_api_dep_client_go
+  name: update-api-dep-client-go
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/api-1.17.yaml
+++ b/prow/config/jobs/api-1.17.yaml
@@ -287,7 +287,7 @@ jobs:
   - --token-path=/etc/github-token/oauth
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
   image: gcr.io/istio-testing/build-tools:release-1.17-9032e66ef91b6cccd5883fb89bb43af791050ba4
-  name: update_api_dep_client_go
+  name: update-api-dep-client-go
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -284,7 +284,7 @@ jobs:
   - --modifier=update_api_dep
   - --token-path=/etc/github-token/oauth
   - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  name: update_api_dep_client_go
+  name: update-api-dep-client-go
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -10,7 +10,7 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-  - name: update_api_dep_client_go
+  - name: update-api-dep-client-go
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh

--- a/prow/config/jobs/client-go-1.16.yaml
+++ b/prow/config/jobs/client-go-1.16.yaml
@@ -401,7 +401,7 @@ jobs:
   - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency in
     $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
-  - --modifier=update_client-go_dep
+  - --modifier=update-client-go-dep
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
@@ -409,7 +409,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.16-0b7dd749b128a1dcf3f1a1a0c930cbe686446eb4
-  name: update_client-go_dep
+  name: update-client-go-dep
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/client-go-1.17.yaml
+++ b/prow/config/jobs/client-go-1.17.yaml
@@ -420,12 +420,12 @@ jobs:
   - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency in
     $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
-  - --modifier=update_client-go_dep
+  - --modifier=update-client-go-dep
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
   image: gcr.io/istio-testing/build-tools:release-1.17-9032e66ef91b6cccd5883fb89bb43af791050ba4
-  name: update_client-go_dep
+  name: update-client-go-dep
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -417,11 +417,11 @@ jobs:
   - '--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency in
     $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
-  - --modifier=update_client-go_dep
+  - --modifier=update-client-go-dep
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  name: update_client-go_dep
+  name: update-client-go-dep
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -13,7 +13,7 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-  - name: update_client-go_dep
+  - name: update-client-go-dep
     types: [postsubmit]
     command:
     - ../test-infra/tools/automator/automator.sh
@@ -21,7 +21,7 @@ jobs:
     - --repo=istio
     - "--title=Automator: update istio/client-go@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH"
     - --labels=auto-merge,release-notes-none
-    - --modifier=update_client-go_dep
+    - --modifier=update-client-go-dep
     - --token-path=/etc/github-token/oauth
     - --git-exclude=^common/
     - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen

--- a/prow/config/jobs/istio.io-1.16.yaml
+++ b/prow/config/jobs/istio.io-1.16.yaml
@@ -282,12 +282,12 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_default
+  - doc.test.profile-default
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.16-0b7dd749b128a1dcf3f1a1a0c930cbe686446eb4
-  name: doc.test.profile_default
+  name: doc.test.profile-default
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -421,12 +421,12 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_demo
+  - doc.test.profile-demo
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.16-0b7dd749b128a1dcf3f1a1a0c930cbe686446eb4
-  name: doc.test.profile_demo
+  name: doc.test.profile-demo
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -560,12 +560,12 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_none
+  - doc.test.profile-none
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.16-0b7dd749b128a1dcf3f1a1a0c930cbe686446eb4
-  name: doc.test.profile_none
+  name: doc.test.profile-none
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/config/jobs/istio.io-1.17.yaml
+++ b/prow/config/jobs/istio.io-1.17.yaml
@@ -294,9 +294,9 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_default
+  - doc.test.profile-default
   image: gcr.io/istio-testing/build-tools:release-1.17-9032e66ef91b6cccd5883fb89bb43af791050ba4
-  name: doc.test.profile_default
+  name: doc.test.profile-default
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -440,9 +440,9 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_demo
+  - doc.test.profile-demo
   image: gcr.io/istio-testing/build-tools:release-1.17-9032e66ef91b6cccd5883fb89bb43af791050ba4
-  name: doc.test.profile_demo
+  name: doc.test.profile-demo
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -586,9 +586,9 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_none
+  - doc.test.profile-none
   image: gcr.io/istio-testing/build-tools:release-1.17-9032e66ef91b6cccd5883fb89bb43af791050ba4
-  name: doc.test.profile_none
+  name: doc.test.profile-none
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -306,8 +306,8 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_default
-  name: doc.test.profile_default
+  - doc.test.profile-default
+  name: doc.test.profile-default
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -459,8 +459,8 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_demo
-  name: doc.test.profile_demo
+  - doc.test.profile-demo
+  name: doc.test.profile-demo
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -611,8 +611,8 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_none
-  name: doc.test.profile_none
+  - doc.test.profile-none
+  name: doc.test.profile-none
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -763,8 +763,8 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
-  - doc.test.profile_minimal
-  name: doc.test.profile_minimal
+  - doc.test.profile-minimal
+  name: doc.test.profile-minimal
   node_selector:
     testing: test-pool
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -10,24 +10,24 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-  - name: doc.test.profile_default
-    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_default]
+  - name: doc.test.profile-default
+    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-default]
     requirements: [kind]
     resources: 6Gi
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 
-  - name: doc.test.profile_demo
-    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_demo]
+  - name: doc.test.profile-demo
+    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-demo]
     requirements: [kind]
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 
-  - name: doc.test.profile_none
-    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_none]
+  - name: doc.test.profile-none
+    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-none]
     requirements: [kind]
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 
-  - name: doc.test.profile_minimal
-    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile_minimal]
+  - name: doc.test.profile-minimal
+    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-minimal]
     requirements: [kind]
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 

--- a/prow/config/jobs/pkg-1.16.yaml
+++ b/prow/config/jobs/pkg-1.16.yaml
@@ -529,7 +529,7 @@ jobs:
   - --repo=istio
   - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
-  - --modifier=update_pkg_dep
+  - --modifier=update-pkg-dep
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
@@ -537,7 +537,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   image: gcr.io/istio-testing/build-tools:release-1.16-0b7dd749b128a1dcf3f1a1a0c930cbe686446eb4
-  name: update_pkg_dep
+  name: update-pkg-dep
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/pkg-1.17.yaml
+++ b/prow/config/jobs/pkg-1.17.yaml
@@ -555,12 +555,12 @@ jobs:
   - --repo=istio
   - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
-  - --modifier=update_pkg_dep
+  - --modifier=update-pkg-dep
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
   image: gcr.io/istio-testing/build-tools:release-1.17-9032e66ef91b6cccd5883fb89bb43af791050ba4
-  name: update_pkg_dep
+  name: update-pkg-dep
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -551,11 +551,11 @@ jobs:
   - --repo=istio
   - '--title=Automator: update istio/pkg@$AUTOMATOR_SRC_BRANCH dependency in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH'
   - --labels=auto-merge,release-notes-none
-  - --modifier=update_pkg_dep
+  - --modifier=update-pkg-dep
   - --token-path=/etc/github-token/oauth
   - --git-exclude=^common/
   - --cmd=go get istio.io/pkg@$AUTOMATOR_SHA && go mod tidy && make clean gen
-  name: update_pkg_dep
+  name: update-pkg-dep
   node_selector:
     testing: test-pool
   repos:

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -16,7 +16,7 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-  - name: benchmark_check
+  - name: benchmark-check
     service_account_name: prowjob-advanced-sa
     disable_release_branching: true
     regex: '^perf/benchmark/'

--- a/tools/prowgen/pkg/generate.go
+++ b/tools/prowgen/pkg/generate.go
@@ -159,6 +159,13 @@ func validateJobsConfig(fileName string, jobsConfig spec.JobsConfig) error {
 	}
 
 	for _, job := range jobsConfig.Jobs {
+		if jobsConfig.Org == "istio" || jobsConfig.Org == "istio-private" {
+			// Some other orgs may have other naming conventions, but for Istio we use _ as divider between job
+			// name, repo, and type. So exclude it from the name.
+			if strings.Contains(job.Name, "_") {
+				err = multierror.Append(err, fmt.Errorf("%s: job may not contain '_' %v", fileName, job.Name))
+			}
+		}
 		if job.Image == "" {
 			err = multierror.Append(err, fmt.Errorf("%s: image must be set for job %v", fileName, job.Name))
 		}


### PR DESCRIPTION
This is to enforce consistency in job names. Underscore is used as a
seperator for auto-generated suffixes, so using it in the base name is
problematic.
