### PR TITLE
jobs: disable mounting service account token

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
@@ -14,6 +14,7 @@ postsubmits:
     name: build_api_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -57,6 +58,7 @@ postsubmits:
     name: gencheck_api_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -103,6 +105,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -150,6 +153,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.16.gen.yaml
@@ -14,6 +14,7 @@ postsubmits:
     name: build_api_release-1.16_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -57,6 +58,7 @@ postsubmits:
     name: gencheck_api_release-1.16_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -106,6 +108,7 @@ postsubmits:
     name: update-api-dep-client-go_api_release-1.16_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.17.gen.yaml
@@ -14,6 +14,7 @@ postsubmits:
     name: build_api_release-1.17_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -57,6 +58,7 @@ postsubmits:
     name: gencheck_api_release-1.17_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -106,6 +108,7 @@ postsubmits:
     name: update-api-dep-client-go_api_release-1.17_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
@@ -14,6 +14,7 @@ postsubmits:
     name: build_api_release-1.18_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -57,6 +58,7 @@ postsubmits:
     name: gencheck_api_release-1.18_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -106,6 +108,7 @@ postsubmits:
     name: update-api-dep-client-go_api_release-1.18_postsubmit_pri
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/envoy/istio-private.envoy.master.gen.yaml
@@ -15,6 +15,7 @@ presubmits:
     path_alias: istio.io/envoy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./ci/do_ci.sh
@@ -67,6 +68,7 @@ presubmits:
     path_alias: istio.io/envoy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./ci/do_ci.sh
@@ -119,6 +121,7 @@ presubmits:
     path_alias: istio.io/envoy
     rerun_command: /test test-release
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./ci/do_ci.sh

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -332,6 +338,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -397,6 +404,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -440,6 +448,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -484,6 +493,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -548,6 +558,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -612,6 +623,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -676,6 +688,7 @@ presubmits:
     rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -740,6 +753,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_release-1.16_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_release-1.16_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -337,6 +343,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -380,6 +387,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -424,6 +432,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -488,6 +497,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -552,6 +562,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -616,6 +627,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_release-1.17_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_release-1.17_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -337,6 +343,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -380,6 +387,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -424,6 +432,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -488,6 +497,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -552,6 +562,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -616,6 +627,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_release-1.18_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_release-1.18_postsubmit_pri
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -332,6 +338,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -397,6 +404,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -440,6 +448,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -484,6 +493,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -548,6 +558,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -612,6 +623,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -676,6 +688,7 @@ presubmits:
     rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -740,6 +753,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -73,6 +74,7 @@ postsubmits:
     name: unit-tests_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -125,6 +127,7 @@ postsubmits:
     name: integ-telemetry_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -192,6 +195,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -261,6 +265,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -334,6 +339,7 @@ postsubmits:
     name: integ-distroless_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -403,6 +409,7 @@ postsubmits:
     name: integ-ipv6_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -474,6 +481,7 @@ postsubmits:
     name: integ-ds_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -545,6 +553,7 @@ postsubmits:
     name: integ-operator-controller_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -612,6 +621,7 @@ postsubmits:
     name: integ-pilot_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -679,6 +689,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -748,6 +759,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -817,6 +829,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -890,6 +903,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -963,6 +977,7 @@ postsubmits:
     name: integ-security_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1030,6 +1045,7 @@ postsubmits:
     name: integ-security-multicluster_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1099,6 +1115,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1172,6 +1189,7 @@ postsubmits:
     name: integ-ambient_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1243,6 +1261,7 @@ postsubmits:
     name: integ-helm_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1312,6 +1331,7 @@ postsubmits:
     name: integ-k8s-121_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1387,6 +1407,7 @@ postsubmits:
     name: integ-k8s-122_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1462,6 +1483,7 @@ postsubmits:
     name: integ-k8s-123_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1535,6 +1557,7 @@ postsubmits:
     name: integ-k8s-124_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1608,6 +1631,7 @@ postsubmits:
     name: integ-k8s-125_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1681,6 +1705,7 @@ postsubmits:
     name: integ-k8s-126_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1754,6 +1779,7 @@ postsubmits:
     name: integ-k8s-128_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1829,6 +1855,7 @@ postsubmits:
     name: integ-cni_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1902,6 +1929,7 @@ postsubmits:
     name: integ-assertion_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1970,6 +1998,7 @@ postsubmits:
     name: unit-tests-arm64_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2026,6 +2055,7 @@ postsubmits:
     name: integ-basic-arm64_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2102,6 +2132,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2157,6 +2188,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2212,6 +2244,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2263,6 +2296,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2335,6 +2369,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2405,6 +2440,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2477,6 +2513,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2554,6 +2591,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2626,6 +2664,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2700,6 +2739,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2774,6 +2814,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2845,6 +2886,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2915,6 +2957,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2988,6 +3031,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3065,6 +3109,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3142,6 +3187,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3212,6 +3258,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3285,6 +3332,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3362,6 +3410,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3436,6 +3485,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3509,6 +3559,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3581,6 +3632,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3632,6 +3684,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3682,6 +3735,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3734,6 +3788,7 @@ presubmits:
     rerun_command: /test bookinfo-build
     run_if_changed: ^samples/bookinfo/src/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3789,6 +3844,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3848,6 +3904,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.16.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -73,6 +74,7 @@ postsubmits:
     name: unit-tests_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -125,6 +127,7 @@ postsubmits:
     name: integ-telemetry_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -192,6 +195,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -261,6 +265,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -334,6 +339,7 @@ postsubmits:
     name: integ-distroless_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -403,6 +409,7 @@ postsubmits:
     name: integ-ipv6_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -474,6 +481,7 @@ postsubmits:
     name: integ-ds_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -545,6 +553,7 @@ postsubmits:
     name: integ-operator-controller_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -612,6 +621,7 @@ postsubmits:
     name: integ-pilot_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -679,6 +689,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -748,6 +759,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -817,6 +829,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -890,6 +903,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -963,6 +977,7 @@ postsubmits:
     name: integ-security_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1030,6 +1045,7 @@ postsubmits:
     name: integ-security-multicluster_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1099,6 +1115,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1172,6 +1189,7 @@ postsubmits:
     name: integ-helm_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1241,6 +1259,7 @@ postsubmits:
     name: integ-k8s-116_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1316,6 +1335,7 @@ postsubmits:
     name: integ-k8s-117_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1391,6 +1411,7 @@ postsubmits:
     name: integ-k8s-118_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1466,6 +1487,7 @@ postsubmits:
     name: integ-k8s-119_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1541,6 +1563,7 @@ postsubmits:
     name: integ-k8s-120_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1616,6 +1639,7 @@ postsubmits:
     name: integ-k8s-121_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1691,6 +1715,7 @@ postsubmits:
     name: integ-k8s-122_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1766,6 +1791,7 @@ postsubmits:
     name: integ-k8s-123_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1843,6 +1869,7 @@ postsubmits:
         report: false
     skip_report: true
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1916,6 +1943,7 @@ postsubmits:
     name: integ-cni_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1989,6 +2017,7 @@ postsubmits:
     name: integ-assertion_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2057,6 +2086,7 @@ postsubmits:
     name: unit-tests-arm64_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2113,6 +2143,7 @@ postsubmits:
     name: integ-basic-arm64_istio_release-1.16_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2189,6 +2220,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2244,6 +2276,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2300,6 +2333,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2351,6 +2385,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2423,6 +2458,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2493,6 +2529,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2565,6 +2602,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2642,6 +2680,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2714,6 +2753,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2788,6 +2828,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2862,6 +2903,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2933,6 +2975,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3003,6 +3046,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3076,6 +3120,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3153,6 +3198,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3230,6 +3276,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3300,6 +3347,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3373,6 +3421,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3450,6 +3499,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3523,6 +3573,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3595,6 +3646,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3646,6 +3698,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3696,6 +3749,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3746,6 +3800,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3805,6 +3860,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.17.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -73,6 +74,7 @@ postsubmits:
     name: unit-tests_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -125,6 +127,7 @@ postsubmits:
     name: integ-telemetry_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -192,6 +195,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -261,6 +265,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -334,6 +339,7 @@ postsubmits:
     name: integ-distroless_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -403,6 +409,7 @@ postsubmits:
     name: integ-ipv6_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -474,6 +481,7 @@ postsubmits:
     name: integ-ds_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -545,6 +553,7 @@ postsubmits:
     name: integ-operator-controller_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -612,6 +621,7 @@ postsubmits:
     name: integ-pilot_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -679,6 +689,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -748,6 +759,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -817,6 +829,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -890,6 +903,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -963,6 +977,7 @@ postsubmits:
     name: integ-security_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1030,6 +1045,7 @@ postsubmits:
     name: integ-security-multicluster_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1099,6 +1115,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1172,6 +1189,7 @@ postsubmits:
     name: integ-helm_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1241,6 +1259,7 @@ postsubmits:
     name: integ-k8s-116_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1316,6 +1335,7 @@ postsubmits:
     name: integ-k8s-117_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1391,6 +1411,7 @@ postsubmits:
     name: integ-k8s-118_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1466,6 +1487,7 @@ postsubmits:
     name: integ-k8s-119_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1541,6 +1563,7 @@ postsubmits:
     name: integ-k8s-120_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1616,6 +1639,7 @@ postsubmits:
     name: integ-k8s-121_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1691,6 +1715,7 @@ postsubmits:
     name: integ-k8s-122_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1766,6 +1791,7 @@ postsubmits:
     name: integ-k8s-123_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1839,6 +1865,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1912,6 +1939,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1985,6 +2013,7 @@ postsubmits:
     name: integ-cni_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2058,6 +2087,7 @@ postsubmits:
     name: integ-assertion_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2126,6 +2156,7 @@ postsubmits:
     name: unit-tests-arm64_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2182,6 +2213,7 @@ postsubmits:
     name: integ-basic-arm64_istio_release-1.17_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2258,6 +2290,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2313,6 +2346,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2369,6 +2403,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2420,6 +2455,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2492,6 +2528,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2562,6 +2599,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2634,6 +2672,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2711,6 +2750,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2783,6 +2823,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2857,6 +2898,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2931,6 +2973,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3002,6 +3045,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3072,6 +3116,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3145,6 +3190,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3222,6 +3268,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3299,6 +3346,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3369,6 +3417,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3442,6 +3491,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3519,6 +3569,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3592,6 +3643,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3664,6 +3716,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3715,6 +3768,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3765,6 +3819,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3815,6 +3870,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3874,6 +3930,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.18.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -73,6 +74,7 @@ postsubmits:
     name: unit-tests_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -125,6 +127,7 @@ postsubmits:
     name: integ-telemetry_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -192,6 +195,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -261,6 +265,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -334,6 +339,7 @@ postsubmits:
     name: integ-distroless_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -403,6 +409,7 @@ postsubmits:
     name: integ-ipv6_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -474,6 +481,7 @@ postsubmits:
     name: integ-ds_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -545,6 +553,7 @@ postsubmits:
     name: integ-operator-controller_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -612,6 +621,7 @@ postsubmits:
     name: integ-pilot_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -679,6 +689,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -748,6 +759,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -817,6 +829,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -890,6 +903,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -963,6 +977,7 @@ postsubmits:
     name: integ-security_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1030,6 +1045,7 @@ postsubmits:
     name: integ-security-multicluster_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1099,6 +1115,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1172,6 +1189,7 @@ postsubmits:
     name: integ-ambient_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1243,6 +1261,7 @@ postsubmits:
     name: integ-helm_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1312,6 +1331,7 @@ postsubmits:
     name: integ-k8s-120_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1387,6 +1407,7 @@ postsubmits:
     name: integ-k8s-121_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1462,6 +1483,7 @@ postsubmits:
     name: integ-k8s-122_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1537,6 +1559,7 @@ postsubmits:
     name: integ-k8s-123_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1610,6 +1633,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1683,6 +1707,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1756,6 +1781,7 @@ postsubmits:
     name: integ-k8s-126_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1829,6 +1855,7 @@ postsubmits:
     name: integ-cni_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1902,6 +1929,7 @@ postsubmits:
     name: integ-assertion_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1970,6 +1998,7 @@ postsubmits:
     name: unit-tests-arm64_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2026,6 +2055,7 @@ postsubmits:
     name: integ-basic-arm64_istio_release-1.18_postsubmit_pri
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2102,6 +2132,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2157,6 +2188,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2213,6 +2245,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2264,6 +2297,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2336,6 +2370,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2406,6 +2441,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2478,6 +2514,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2555,6 +2592,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2627,6 +2665,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2701,6 +2740,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2775,6 +2815,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2846,6 +2887,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2916,6 +2958,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2989,6 +3032,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3066,6 +3110,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3143,6 +3188,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3213,6 +3259,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3286,6 +3333,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3363,6 +3411,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3437,6 +3486,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3510,6 +3560,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3582,6 +3633,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3633,6 +3685,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3683,6 +3736,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3733,6 +3787,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3792,6 +3847,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -75,6 +76,7 @@ postsubmits:
     name: release-centos_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -130,6 +132,7 @@ postsubmits:
     name: release-arm64_proxy_postsubmit_master_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -200,6 +203,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -252,6 +256,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -304,6 +309,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -356,6 +362,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -408,6 +415,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -460,6 +468,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -517,6 +526,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.16.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_proxy_release-1.16_postsubmit_release-1.16_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -75,6 +76,7 @@ postsubmits:
     name: release-centos_proxy_release-1.16_postsubmit_release-1.16_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -130,6 +132,7 @@ postsubmits:
     name: release-arm64_proxy_release-1.16_postsubmit_release-1.16_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -200,6 +203,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -252,6 +256,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -304,6 +309,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -356,6 +362,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -408,6 +415,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -460,6 +468,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -517,6 +526,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.17.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_proxy_release-1.17_postsubmit_release-1.17_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -75,6 +76,7 @@ postsubmits:
     name: release-centos_proxy_release-1.17_postsubmit_release-1.17_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -130,6 +132,7 @@ postsubmits:
     name: release-arm64_proxy_release-1.17_postsubmit_release-1.17_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -200,6 +203,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -252,6 +256,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -304,6 +309,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -356,6 +362,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -408,6 +415,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -460,6 +468,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -517,6 +526,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
@@ -15,6 +15,7 @@ postsubmits:
     name: release_proxy_release-1.18_postsubmit_release-1.18_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -75,6 +76,7 @@ postsubmits:
     name: release-centos_proxy_release-1.18_postsubmit_release-1.18_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -130,6 +132,7 @@ postsubmits:
     name: release-arm64_proxy_release-1.18_postsubmit_release-1.18_priv
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -200,6 +203,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -252,6 +256,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -304,6 +309,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -356,6 +362,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -408,6 +415,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -460,6 +468,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -517,6 +526,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     name: lint_release-builder_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -55,6 +56,7 @@ postsubmits:
     name: test_release-builder_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -97,6 +99,7 @@ postsubmits:
     name: gencheck_release-builder_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -143,6 +146,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -235,6 +239,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -325,6 +331,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -370,6 +377,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     name: lint_release-builder_release-1.16_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -55,6 +56,7 @@ postsubmits:
     name: test_release-builder_release-1.16_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -97,6 +99,7 @@ postsubmits:
     name: gencheck_release-builder_release-1.16_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -143,6 +146,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -235,6 +239,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -325,6 +331,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -370,6 +377,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     name: lint_release-builder_release-1.17_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -55,6 +56,7 @@ postsubmits:
     name: test_release-builder_release-1.17_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -97,6 +99,7 @@ postsubmits:
     name: gencheck_release-builder_release-1.17_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -143,6 +146,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -235,6 +239,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -325,6 +331,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -370,6 +377,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     name: lint_release-builder_release-1.18_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -55,6 +56,7 @@ postsubmits:
     name: test_release-builder_release-1.18_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -97,6 +99,7 @@ postsubmits:
     name: gencheck_release-builder_release-1.18_postsubmit_pri
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -143,6 +146,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -235,6 +239,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -325,6 +331,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -370,6 +377,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_api_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_api_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -96,6 +98,7 @@ postsubmits:
     name: update-api-dep-client-go_api_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -153,6 +156,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -194,6 +198,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -245,6 +250,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_api_release-1.16_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_api_release-1.16_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -96,6 +98,7 @@ postsubmits:
     name: update-api-dep-client-go_api_release-1.16_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -151,6 +154,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -192,6 +196,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -243,6 +248,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_api_release-1.17_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_api_release-1.17_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -96,6 +98,7 @@ postsubmits:
     name: update-api-dep-client-go_api_release-1.17_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -151,6 +154,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -192,6 +196,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -243,6 +248,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_api_release-1.18_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_api_release-1.18_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -96,6 +98,7 @@ postsubmits:
     name: update-api-dep-client-go_api_release-1.18_postsubmit
     path_alias: istio.io/api
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -151,6 +154,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -192,6 +196,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -243,6 +248,7 @@ presubmits:
     path_alias: istio.io/api
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_bots_postsubmit
     path_alias: istio.io/bots
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_bots_postsubmit
     path_alias: istio.io/bots
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_bots_postsubmit
     path_alias: istio.io/bots
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_bots_postsubmit
     path_alias: istio.io/bots
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -172,6 +176,7 @@ postsubmits:
     path_alias: istio.io/bots
     run_if_changed: ^policybot/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -257,6 +262,7 @@ presubmits:
     path_alias: istio.io/bots
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -298,6 +304,7 @@ presubmits:
     path_alias: istio.io/bots
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -339,6 +346,7 @@ presubmits:
     path_alias: istio.io/bots
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -380,6 +388,7 @@ presubmits:
     path_alias: istio.io/bots
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_client-go_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_client-go_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: gencheck_client-go_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -136,6 +139,7 @@ postsubmits:
     name: update-client-go-dep_client-go_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -195,6 +199,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -236,6 +241,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -277,6 +283,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_client-go_release-1.16_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_client-go_release-1.16_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: gencheck_client-go_release-1.16_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -136,6 +139,7 @@ postsubmits:
     name: update-client-go-dep_client-go_release-1.16_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -193,6 +197,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -234,6 +239,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -275,6 +281,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_client-go_release-1.17_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_client-go_release-1.17_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: gencheck_client-go_release-1.17_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -136,6 +139,7 @@ postsubmits:
     name: update-client-go-dep_client-go_release-1.17_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -193,6 +197,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -234,6 +239,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -275,6 +281,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_client-go_release-1.18_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_client-go_release-1.18_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: gencheck_client-go_release-1.18_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -136,6 +139,7 @@ postsubmits:
     name: update-client-go-dep_client-go_release-1.18_postsubmit
     path_alias: istio.io/client-go
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -193,6 +197,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -234,6 +239,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -275,6 +281,7 @@ presubmits:
     path_alias: istio.io/client-go
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_common-files_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -56,6 +57,7 @@ postsubmits:
     name: update-common-mainonly_common-files_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -116,6 +118,7 @@ postsubmits:
     name: update-common_common-files_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -176,6 +179,7 @@ postsubmits:
     name: update-common-istio.io_common-files_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -236,6 +240,7 @@ postsubmits:
     name: update-build-tools-image_common-files_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -297,6 +302,7 @@ presubmits:
     path_alias: istio.io/common-files
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_common-files_release-1.16_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -56,6 +57,7 @@ postsubmits:
     name: update-common_common-files_release-1.16_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -114,6 +116,7 @@ postsubmits:
     name: update-common-istio.io_common-files_release-1.16_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -172,6 +175,7 @@ postsubmits:
     name: update-build-tools-image_common-files_release-1.16_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -231,6 +235,7 @@ presubmits:
     path_alias: istio.io/common-files
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_common-files_release-1.17_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -56,6 +57,7 @@ postsubmits:
     name: update-common_common-files_release-1.17_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -114,6 +116,7 @@ postsubmits:
     name: update-common-istio.io_common-files_release-1.17_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -172,6 +175,7 @@ postsubmits:
     name: update-build-tools-image_common-files_release-1.17_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -231,6 +235,7 @@ presubmits:
     path_alias: istio.io/common-files
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_common-files_release-1.18_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -56,6 +57,7 @@ postsubmits:
     name: update-common_common-files_release-1.18_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -114,6 +116,7 @@ postsubmits:
     name: update-common-istio.io_common-files_release-1.18_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -172,6 +175,7 @@ postsubmits:
     name: update-build-tools-image_common-files_release-1.18_postsubmit
     path_alias: istio.io/common-files
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -231,6 +235,7 @@ presubmits:
     path_alias: istio.io/common-files
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_community_postsubmit
     path_alias: istio.io/community
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/community-lint.sh
@@ -50,6 +51,7 @@ postsubmits:
     name: test_community_postsubmit
     path_alias: istio.io/community
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     name: sync-org_community_postsubmit
     path_alias: istio.io/community
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - sh
@@ -140,6 +143,7 @@ presubmits:
     path_alias: istio.io/community
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/community-lint.sh
@@ -180,6 +184,7 @@ presubmits:
     path_alias: istio.io/community
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
@@ -21,6 +21,7 @@ presubmits:
     path_alias: istio.io/enhancements
     rerun_command: /test validate-features
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/scripts/validate_schema.sh

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.16.gen.yaml
@@ -21,6 +21,7 @@ presubmits:
     path_alias: istio.io/enhancements
     rerun_command: /test validate-features
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/scripts/validate_schema.sh

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.17.gen.yaml
@@ -21,6 +21,7 @@ presubmits:
     path_alias: istio.io/enhancements
     rerun_command: /test validate-features
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/scripts/validate_schema.sh

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.18.gen.yaml
@@ -21,6 +21,7 @@ presubmits:
     path_alias: istio.io/enhancements
     rerun_command: /test validate-features
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/scripts/validate_schema.sh

--- a/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/envoy/istio.envoy.master.gen.yaml
@@ -13,6 +13,7 @@ presubmits:
     path_alias: istio.io/envoy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./ci/do_ci.sh
@@ -63,6 +64,7 @@ presubmits:
     path_alias: istio.io/envoy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./ci/do_ci.sh
@@ -113,6 +115,7 @@ presubmits:
     path_alias: istio.io/envoy
     rerun_command: /test test-release
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./ci/do_ci.sh

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -17,6 +17,7 @@ periodics:
     repo: test-infra
   name: update-ref-docs_istio.io_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -78,6 +79,7 @@ periodics:
     repo: test-infra
   name: update-istio-ref_istio.io_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -133,6 +135,7 @@ postsubmits:
     name: lint_istio.io_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -173,6 +176,7 @@ postsubmits:
     name: gencheck_istio.io_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -214,6 +218,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -274,6 +279,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -334,6 +340,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -394,6 +401,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -454,6 +462,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -517,6 +526,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -558,6 +568,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -600,6 +611,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -662,6 +674,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -724,6 +737,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -786,6 +800,7 @@ presubmits:
     rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -848,6 +863,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -917,6 +933,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test update-ref-docs-dry-run
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_release-1.16_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_release-1.16_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -335,6 +341,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -376,6 +383,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -418,6 +426,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -480,6 +489,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -542,6 +552,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -604,6 +615,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -673,6 +685,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test update-ref-docs-dry-run
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_release-1.17_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_release-1.17_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -335,6 +341,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -376,6 +383,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -418,6 +426,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -480,6 +489,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -542,6 +552,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -604,6 +615,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -673,6 +685,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test update-ref-docs-dry-run
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: lint_istio.io_release-1.18_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: gencheck_istio.io_release-1.18_postsubmit
     path_alias: istio.io/istio.io
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -92,6 +94,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -152,6 +155,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -212,6 +216,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -272,6 +277,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -332,6 +338,7 @@ postsubmits:
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -395,6 +402,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -436,6 +444,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -478,6 +487,7 @@ presubmits:
     rerun_command: /test doc.test.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -540,6 +550,7 @@ presubmits:
     rerun_command: /test doc.test.profile-demo
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -602,6 +613,7 @@ presubmits:
     rerun_command: /test doc.test.profile-none
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -664,6 +676,7 @@ presubmits:
     rerun_command: /test doc.test.profile-minimal
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -726,6 +739,7 @@ presubmits:
     rerun_command: /test doc.test.multicluster
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -795,6 +809,7 @@ presubmits:
     path_alias: istio.io/istio.io
     rerun_command: /test update-ref-docs-dry-run
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh

--- a/prow/cluster/jobs/istio/istio/istio.istio.experimental-ambient.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.experimental-ambient.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: integ-ambient_istio_experimental-ambient_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -78,6 +79,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: istio
   name: integ-security-fuzz_istio_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -82,6 +83,7 @@ periodics:
     repo: test-infra
   name: update-go-control-plane_istio_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -147,6 +149,7 @@ periodics:
   interval: 24h
   name: update-ztunnel_istio_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -206,6 +209,7 @@ postsubmits:
     name: unit-tests_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -254,6 +258,7 @@ postsubmits:
     name: unit-tests-arm64_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -306,6 +311,7 @@ postsubmits:
     name: release_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -353,6 +359,7 @@ postsubmits:
     name: benchmark-report_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -398,6 +405,7 @@ postsubmits:
     name: integ-telemetry_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -460,6 +468,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -524,6 +533,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -592,6 +602,7 @@ postsubmits:
     name: integ-distroless_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -656,6 +667,7 @@ postsubmits:
     name: integ-ipv6_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -722,6 +734,7 @@ postsubmits:
     name: integ-ds_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -789,6 +802,7 @@ postsubmits:
     name: integ-basic-arm64_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -856,6 +870,7 @@ postsubmits:
     name: integ-operator-controller_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -918,6 +933,7 @@ postsubmits:
     name: integ-pilot_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -980,6 +996,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1044,6 +1061,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1108,6 +1126,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1176,6 +1195,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1244,6 +1264,7 @@ postsubmits:
     name: integ-security_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1306,6 +1327,7 @@ postsubmits:
     name: integ-security-multicluster_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1370,6 +1392,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1438,6 +1461,7 @@ postsubmits:
     name: integ-ambient_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1504,6 +1528,7 @@ postsubmits:
     name: integ-helm_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1568,6 +1593,7 @@ postsubmits:
     name: integ-k8s-121_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1638,6 +1664,7 @@ postsubmits:
     name: integ-k8s-122_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1708,6 +1735,7 @@ postsubmits:
     name: integ-k8s-123_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1776,6 +1804,7 @@ postsubmits:
     name: integ-k8s-124_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1844,6 +1873,7 @@ postsubmits:
     name: integ-k8s-125_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1912,6 +1942,7 @@ postsubmits:
     name: integ-k8s-126_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1980,6 +2011,7 @@ postsubmits:
     name: integ-k8s-128_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2050,6 +2082,7 @@ postsubmits:
     name: integ-cni_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2118,6 +2151,7 @@ postsubmits:
     name: integ-assertion_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2188,6 +2222,7 @@ postsubmits:
     path_alias: istio.io/istio
     run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2286,6 +2321,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2335,6 +2371,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2388,6 +2425,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2436,6 +2474,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2480,6 +2519,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2545,6 +2585,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2608,6 +2649,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2673,6 +2715,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2743,6 +2786,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2808,6 +2852,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2875,6 +2920,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2943,6 +2989,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3011,6 +3058,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3075,6 +3123,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3138,6 +3187,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3204,6 +3254,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3274,6 +3325,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3344,6 +3396,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3407,6 +3460,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3473,6 +3527,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3543,6 +3598,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3610,6 +3666,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3676,6 +3733,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3741,6 +3799,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3785,6 +3844,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3828,6 +3888,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3881,6 +3942,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh
@@ -3932,6 +3994,7 @@ presubmits:
     rerun_command: /test bookinfo-build
     run_if_changed: ^samples/bookinfo/src/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: istio
   name: integ-security-fuzz_istio_release-1.16_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -77,6 +78,7 @@ postsubmits:
     name: unit-tests_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -125,6 +127,7 @@ postsubmits:
     name: unit-tests-arm64_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -177,6 +180,7 @@ postsubmits:
     name: release_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -224,6 +228,7 @@ postsubmits:
     name: benchmark-report_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -269,6 +274,7 @@ postsubmits:
     name: integ-telemetry_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -331,6 +337,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -395,6 +402,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -463,6 +471,7 @@ postsubmits:
     name: integ-distroless_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -527,6 +536,7 @@ postsubmits:
     name: integ-ipv6_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -593,6 +603,7 @@ postsubmits:
     name: integ-ds_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -660,6 +671,7 @@ postsubmits:
     name: integ-basic-arm64_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -727,6 +739,7 @@ postsubmits:
     name: integ-operator-controller_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -789,6 +802,7 @@ postsubmits:
     name: integ-pilot_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -851,6 +865,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -915,6 +930,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -979,6 +995,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1047,6 +1064,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1115,6 +1133,7 @@ postsubmits:
     name: integ-security_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1177,6 +1196,7 @@ postsubmits:
     name: integ-security-multicluster_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1241,6 +1261,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1309,6 +1330,7 @@ postsubmits:
     name: integ-helm_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1373,6 +1395,7 @@ postsubmits:
     name: integ-k8s-116_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1443,6 +1466,7 @@ postsubmits:
     name: integ-k8s-117_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1513,6 +1537,7 @@ postsubmits:
     name: integ-k8s-118_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1583,6 +1608,7 @@ postsubmits:
     name: integ-k8s-119_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1653,6 +1679,7 @@ postsubmits:
     name: integ-k8s-120_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1723,6 +1750,7 @@ postsubmits:
     name: integ-k8s-121_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1793,6 +1821,7 @@ postsubmits:
     name: integ-k8s-122_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1863,6 +1892,7 @@ postsubmits:
     name: integ-k8s-123_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1935,6 +1965,7 @@ postsubmits:
         report: false
     skip_report: true
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2003,6 +2034,7 @@ postsubmits:
     name: integ-cni_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2071,6 +2103,7 @@ postsubmits:
     name: integ-assertion_istio_release-1.16_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2141,6 +2174,7 @@ postsubmits:
     path_alias: istio.io/istio
     run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2239,6 +2273,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2288,6 +2323,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2341,6 +2377,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2390,6 +2427,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2434,6 +2472,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2499,6 +2538,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2562,6 +2602,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2627,6 +2668,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2697,6 +2739,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2762,6 +2805,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2829,6 +2873,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2897,6 +2942,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2965,6 +3011,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3029,6 +3076,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3092,6 +3140,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3158,6 +3207,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3228,6 +3278,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3298,6 +3349,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3361,6 +3413,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3427,6 +3480,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3497,6 +3551,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3563,6 +3618,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3628,6 +3684,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3672,6 +3729,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3715,6 +3773,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3768,6 +3827,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: istio
   name: integ-security-fuzz_istio_release-1.17_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -77,6 +78,7 @@ postsubmits:
     name: unit-tests_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -125,6 +127,7 @@ postsubmits:
     name: unit-tests-arm64_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -177,6 +180,7 @@ postsubmits:
     name: release_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -224,6 +228,7 @@ postsubmits:
     name: benchmark-report_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -269,6 +274,7 @@ postsubmits:
     name: integ-telemetry_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -331,6 +337,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -395,6 +402,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -463,6 +471,7 @@ postsubmits:
     name: integ-distroless_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -527,6 +536,7 @@ postsubmits:
     name: integ-ipv6_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -593,6 +603,7 @@ postsubmits:
     name: integ-ds_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -660,6 +671,7 @@ postsubmits:
     name: integ-basic-arm64_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -727,6 +739,7 @@ postsubmits:
     name: integ-operator-controller_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -789,6 +802,7 @@ postsubmits:
     name: integ-pilot_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -851,6 +865,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -915,6 +930,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -979,6 +995,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1047,6 +1064,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1115,6 +1133,7 @@ postsubmits:
     name: integ-security_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1177,6 +1196,7 @@ postsubmits:
     name: integ-security-multicluster_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1241,6 +1261,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1309,6 +1330,7 @@ postsubmits:
     name: integ-helm_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1373,6 +1395,7 @@ postsubmits:
     name: integ-k8s-116_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1443,6 +1466,7 @@ postsubmits:
     name: integ-k8s-117_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1513,6 +1537,7 @@ postsubmits:
     name: integ-k8s-118_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1583,6 +1608,7 @@ postsubmits:
     name: integ-k8s-119_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1653,6 +1679,7 @@ postsubmits:
     name: integ-k8s-120_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1723,6 +1750,7 @@ postsubmits:
     name: integ-k8s-121_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1793,6 +1821,7 @@ postsubmits:
     name: integ-k8s-122_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1863,6 +1892,7 @@ postsubmits:
     name: integ-k8s-123_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1931,6 +1961,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1999,6 +2030,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2067,6 +2099,7 @@ postsubmits:
     name: integ-cni_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2135,6 +2168,7 @@ postsubmits:
     name: integ-assertion_istio_release-1.17_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2205,6 +2239,7 @@ postsubmits:
     path_alias: istio.io/istio
     run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2303,6 +2338,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2352,6 +2388,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2405,6 +2442,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2454,6 +2492,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2498,6 +2537,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2563,6 +2603,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2626,6 +2667,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2691,6 +2733,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2761,6 +2804,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2826,6 +2870,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2893,6 +2938,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2961,6 +3007,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3029,6 +3076,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3093,6 +3141,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3156,6 +3205,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3222,6 +3272,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3292,6 +3343,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3362,6 +3414,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3425,6 +3478,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3491,6 +3545,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3561,6 +3616,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3627,6 +3683,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3692,6 +3749,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3736,6 +3794,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3779,6 +3838,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3832,6 +3892,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: istio
   name: integ-security-fuzz_istio_release-1.18_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -82,6 +83,7 @@ periodics:
   interval: 24h
   name: update-ztunnel_istio_release-1.18_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -139,6 +141,7 @@ postsubmits:
     name: unit-tests_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -187,6 +190,7 @@ postsubmits:
     name: unit-tests-arm64_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -239,6 +243,7 @@ postsubmits:
     name: release_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -286,6 +291,7 @@ postsubmits:
     name: benchmark-report_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -331,6 +337,7 @@ postsubmits:
     name: integ-telemetry_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -393,6 +400,7 @@ postsubmits:
     name: integ-telemetry-mc_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -457,6 +465,7 @@ postsubmits:
     name: integ-telemetry-istiodremote_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -525,6 +534,7 @@ postsubmits:
     name: integ-distroless_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -589,6 +599,7 @@ postsubmits:
     name: integ-ipv6_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -655,6 +666,7 @@ postsubmits:
     name: integ-ds_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -722,6 +734,7 @@ postsubmits:
     name: integ-basic-arm64_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -789,6 +802,7 @@ postsubmits:
     name: integ-operator-controller_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -851,6 +865,7 @@ postsubmits:
     name: integ-pilot_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -913,6 +928,7 @@ postsubmits:
     name: integ-pilot-cpp_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -977,6 +993,7 @@ postsubmits:
     name: integ-pilot-multicluster_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1041,6 +1058,7 @@ postsubmits:
     name: integ-pilot-istiodremote_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1109,6 +1127,7 @@ postsubmits:
     name: integ-pilot-istiodremote-mc_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1177,6 +1196,7 @@ postsubmits:
     name: integ-security_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1239,6 +1259,7 @@ postsubmits:
     name: integ-security-multicluster_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1303,6 +1324,7 @@ postsubmits:
     name: integ-security-istiodremote_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1371,6 +1393,7 @@ postsubmits:
     name: integ-ambient_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1437,6 +1460,7 @@ postsubmits:
     name: integ-helm_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1501,6 +1525,7 @@ postsubmits:
     name: integ-k8s-120_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1571,6 +1596,7 @@ postsubmits:
     name: integ-k8s-121_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1641,6 +1667,7 @@ postsubmits:
     name: integ-k8s-122_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1711,6 +1738,7 @@ postsubmits:
     name: integ-k8s-123_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1779,6 +1807,7 @@ postsubmits:
     name: integ-k8s-124_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1847,6 +1876,7 @@ postsubmits:
     name: integ-k8s-125_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1915,6 +1945,7 @@ postsubmits:
     name: integ-k8s-126_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1983,6 +2014,7 @@ postsubmits:
     name: integ-cni_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2051,6 +2083,7 @@ postsubmits:
     name: integ-assertion_istio_release-1.18_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2121,6 +2154,7 @@ postsubmits:
     path_alias: istio.io/istio
     run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2219,6 +2253,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2268,6 +2303,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2321,6 +2357,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2370,6 +2407,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2414,6 +2452,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2479,6 +2518,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2542,6 +2582,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2607,6 +2648,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2677,6 +2719,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2742,6 +2785,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2809,6 +2853,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2877,6 +2922,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -2945,6 +2991,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3009,6 +3056,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3072,6 +3120,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3138,6 +3187,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3208,6 +3258,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3278,6 +3329,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3341,6 +3393,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3407,6 +3460,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3477,6 +3531,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3544,6 +3599,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3610,6 +3666,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -3675,6 +3732,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3719,6 +3777,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3762,6 +3821,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -3815,6 +3875,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-notes
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/check_release_notes.sh

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -11,6 +11,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -60,6 +61,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test unit-tests-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -113,6 +115,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -161,6 +164,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test benchmark
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -205,6 +209,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-cni
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -270,6 +275,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -333,6 +339,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -398,6 +405,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-telemetry-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -468,6 +476,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-distroless
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -533,6 +542,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ipv6
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -600,6 +610,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ds
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -668,6 +679,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-basic-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -736,6 +748,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-operator-controller
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -800,6 +813,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -863,6 +877,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -929,6 +944,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -999,6 +1015,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-pilot-istiodremote-mc
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1069,6 +1086,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1132,6 +1150,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-multicluster
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1198,6 +1217,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-security-istiodremote
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1268,6 +1288,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1335,6 +1356,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1401,6 +1423,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test integ-assertion
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -1466,6 +1489,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test analyze-tests
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -1510,6 +1534,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -1553,6 +1578,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -1598,6 +1624,7 @@ presubmits:
     rerun_command: /test bookinfo-build
     run_if_changed: ^samples/bookinfo/src/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_pkg_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_pkg_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_pkg_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_pkg_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -173,6 +177,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -214,6 +219,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -255,6 +261,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -296,6 +303,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_pkg_release-1.16_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_pkg_release-1.16_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_pkg_release-1.16_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_pkg_release-1.16_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -176,6 +180,7 @@ postsubmits:
     name: update-pkg-dep_pkg_release-1.16_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -232,6 +237,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -273,6 +279,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -314,6 +321,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -355,6 +363,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_pkg_release-1.17_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_pkg_release-1.17_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_pkg_release-1.17_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_pkg_release-1.17_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -176,6 +180,7 @@ postsubmits:
     name: update-pkg-dep_pkg_release-1.17_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -232,6 +237,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -273,6 +279,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -314,6 +321,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -355,6 +363,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_pkg_release-1.18_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_pkg_release-1.18_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_pkg_release-1.18_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_pkg_release-1.18_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -176,6 +180,7 @@ postsubmits:
     name: update-pkg-dep_pkg_release-1.18_postsubmit
     path_alias: istio.io/pkg
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -232,6 +237,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -273,6 +279,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -314,6 +321,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -355,6 +363,7 @@ presubmits:
     path_alias: istio.io/pkg
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -19,6 +19,7 @@ periodics:
   interval: 24h
   name: update-proxy_proxy_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -80,6 +81,7 @@ periodics:
     repo: test-infra
   name: update-go-control-plane_proxy_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -138,6 +140,7 @@ postsubmits:
     name: release_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -186,6 +189,7 @@ postsubmits:
     name: release-arm64_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -239,6 +243,7 @@ postsubmits:
     name: release-centos_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -286,6 +291,7 @@ postsubmits:
     name: update-istio_proxy_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -345,6 +351,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -388,6 +395,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -431,6 +439,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -474,6 +483,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -518,6 +528,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -567,6 +578,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -610,6 +622,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
@@ -19,6 +19,7 @@ periodics:
   interval: 24h
   name: update-proxy_proxy_release-1.16_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -75,6 +76,7 @@ postsubmits:
     name: release_proxy_release-1.16_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -123,6 +125,7 @@ postsubmits:
     name: release-arm64_proxy_release-1.16_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -176,6 +179,7 @@ postsubmits:
     name: release-centos_proxy_release-1.16_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -223,6 +227,7 @@ postsubmits:
     name: update-istio_proxy_release-1.16_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -323,6 +329,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -366,6 +373,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -409,6 +417,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -453,6 +462,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -502,6 +512,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -545,6 +556,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
@@ -19,6 +19,7 @@ periodics:
   interval: 24h
   name: update-proxy_proxy_release-1.17_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -75,6 +76,7 @@ postsubmits:
     name: release_proxy_release-1.17_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -123,6 +125,7 @@ postsubmits:
     name: release-arm64_proxy_release-1.17_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -176,6 +179,7 @@ postsubmits:
     name: release-centos_proxy_release-1.17_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -223,6 +227,7 @@ postsubmits:
     name: update-istio_proxy_release-1.17_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -323,6 +329,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -366,6 +373,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -409,6 +417,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -453,6 +462,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -502,6 +512,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -545,6 +556,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -19,6 +19,7 @@ periodics:
   interval: 24h
   name: update-proxy_proxy_release-1.18_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ../test-infra/tools/automator/automator.sh
@@ -75,6 +76,7 @@ postsubmits:
     name: release_proxy_release-1.18_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -123,6 +125,7 @@ postsubmits:
     name: release-arm64_proxy_release-1.18_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -176,6 +179,7 @@ postsubmits:
     name: release-centos_proxy_release-1.18_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -223,6 +227,7 @@ postsubmits:
     name: update-istio_proxy_release-1.18_postsubmit
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ../test-infra/tools/automator/automator.sh
@@ -280,6 +285,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -323,6 +329,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -366,6 +373,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -409,6 +417,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -453,6 +462,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -502,6 +512,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -545,6 +556,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -13,6 +13,7 @@ postsubmits:
     name: release_proxy_postsubmit_exp
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -61,6 +62,7 @@ postsubmits:
     name: release-arm64_proxy_postsubmit_exp
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -114,6 +116,7 @@ postsubmits:
     name: release-centos_proxy_postsubmit_exp
     path_alias: istio.io/proxy
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-postsubmit-centos.sh
@@ -158,6 +161,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit.sh
@@ -201,6 +205,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-asan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-asan.sh
@@ -244,6 +249,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test test-tsan
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-tsan.sh
@@ -287,6 +293,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -331,6 +338,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-test-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-release.sh
@@ -380,6 +388,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test release-centos-test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - ./prow/proxy-presubmit-centos-release.sh
@@ -423,6 +432,7 @@ presubmits:
     path_alias: istio.io/proxy
     rerun_command: /test check-wasm
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: release-builder
   name: build-base-images_release-builder_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -106,6 +107,7 @@ postsubmits:
     name: lint_release-builder_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -146,6 +148,7 @@ postsubmits:
     name: test_release-builder_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -186,6 +189,7 @@ postsubmits:
     name: gencheck_release-builder_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -227,6 +231,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -273,6 +278,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -354,6 +360,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -436,6 +443,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -477,6 +485,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -518,6 +527,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -560,6 +570,7 @@ presubmits:
     rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -608,6 +619,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh
@@ -650,6 +662,7 @@ presubmits:
     rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/publish-warning.sh

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: release-builder
   name: build-base-images_release-builder_release-1.16_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -106,6 +107,7 @@ postsubmits:
     name: lint_release-builder_release-1.16_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -146,6 +148,7 @@ postsubmits:
     name: test_release-builder_release-1.16_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -186,6 +189,7 @@ postsubmits:
     name: gencheck_release-builder_release-1.16_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -227,6 +231,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -273,6 +278,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -354,6 +360,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -436,6 +443,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -477,6 +485,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -518,6 +527,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -560,6 +570,7 @@ presubmits:
     rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -608,6 +619,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh
@@ -650,6 +662,7 @@ presubmits:
     rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/publish-warning.sh

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: release-builder
   name: build-base-images_release-builder_release-1.17_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -106,6 +107,7 @@ postsubmits:
     name: lint_release-builder_release-1.17_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -146,6 +148,7 @@ postsubmits:
     name: test_release-builder_release-1.17_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -186,6 +189,7 @@ postsubmits:
     name: gencheck_release-builder_release-1.17_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -227,6 +231,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -273,6 +278,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -354,6 +360,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -436,6 +443,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -477,6 +485,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -518,6 +527,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -560,6 +570,7 @@ presubmits:
     rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -608,6 +619,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh
@@ -650,6 +662,7 @@ presubmits:
     rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/publish-warning.sh

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: release-builder
   name: build-base-images_release-builder_release-1.18_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - entrypoint
@@ -106,6 +107,7 @@ postsubmits:
     name: lint_release-builder_release-1.18_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -146,6 +148,7 @@ postsubmits:
     name: test_release-builder_release-1.18_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -186,6 +189,7 @@ postsubmits:
     name: gencheck_release-builder_release-1.18_postsubmit
     path_alias: istio.io/release-builder
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -227,6 +231,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -273,6 +278,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -354,6 +360,7 @@ postsubmits:
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -436,6 +443,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -477,6 +485,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -518,6 +527,7 @@ presubmits:
     path_alias: istio.io/release-builder
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -560,6 +570,7 @@ presubmits:
     rerun_command: /test dry-run
     run_if_changed: \.go$|\.sh$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -608,6 +619,7 @@ presubmits:
     rerun_command: /test build-warning
     run_if_changed: ^release/trigger-build$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/build-warning.sh
@@ -650,6 +662,7 @@ presubmits:
     rerun_command: /test publish-warning
     run_if_changed: ^release/trigger-publish$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - release/publish-warning.sh

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -13,6 +13,7 @@ periodics:
     repo: test-infra
   name: bump-k8s-prow-images_test-infra_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - ./tools/automator/automator.sh
@@ -75,6 +76,7 @@ postsubmits:
     name: lint_test-infra_postsubmit
     path_alias: istio.io/test-infra
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -115,6 +117,7 @@ postsubmits:
     name: test_test-infra_postsubmit
     path_alias: istio.io/test-infra
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -155,6 +158,7 @@ postsubmits:
     name: gencheck_test-infra_postsubmit
     path_alias: istio.io/test-infra
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -198,6 +202,7 @@ postsubmits:
     path_alias: istio.io/test-infra
     run_if_changed: ^docker/prowbazel/Makefile$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -250,6 +255,7 @@ postsubmits:
     path_alias: istio.io/test-infra
     run_if_changed: ^authentikos/Makefile$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -301,6 +307,7 @@ postsubmits:
     path_alias: istio.io/test-infra
     run_if_changed: ^tools/prowgen/.*$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -352,6 +359,7 @@ postsubmits:
     path_alias: istio.io/test-infra
     run_if_changed: ^tools/prowtrans/.*$
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -402,6 +410,7 @@ presubmits:
     path_alias: istio.io/test-infra
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -443,6 +452,7 @@ presubmits:
     path_alias: istio.io/test-infra
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -484,6 +494,7 @@ presubmits:
     path_alias: istio.io/test-infra
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_tools_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_tools_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_tools_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_tools_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -181,6 +185,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -245,6 +250,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -298,6 +304,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -348,6 +355,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -389,6 +397,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -430,6 +439,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -471,6 +481,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -514,6 +525,7 @@ presubmits:
     rerun_command: /test benchmark-check
     run_if_changed: ^perf/benchmark/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -559,6 +571,7 @@ presubmits:
     rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -608,6 +621,7 @@ presubmits:
     rerun_command: /test containers-test-arm64
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.16.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_tools_release-1.16_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_tools_release-1.16_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_tools_release-1.16_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_tools_release-1.16_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -181,6 +185,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -243,6 +248,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -296,6 +302,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -346,6 +353,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -387,6 +395,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -428,6 +437,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -469,6 +479,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -511,6 +522,7 @@ presubmits:
     rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -560,6 +572,7 @@ presubmits:
     rerun_command: /test containers-test-arm64
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.17.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_tools_release-1.17_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_tools_release-1.17_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_tools_release-1.17_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_tools_release-1.17_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -181,6 +185,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -243,6 +248,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -296,6 +302,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -346,6 +353,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -387,6 +395,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -428,6 +437,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -469,6 +479,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -511,6 +522,7 @@ presubmits:
     rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -560,6 +572,7 @@ presubmits:
     rerun_command: /test containers-test-arm64
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: build_tools_release-1.18_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -51,6 +52,7 @@ postsubmits:
     name: lint_tools_release-1.18_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -91,6 +93,7 @@ postsubmits:
     name: test_tools_release-1.18_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -131,6 +134,7 @@ postsubmits:
     name: gencheck_tools_release-1.18_postsubmit
     path_alias: istio.io/tools
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -181,6 +185,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -243,6 +248,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -296,6 +302,7 @@ postsubmits:
     path_alias: istio.io/tools
     run_if_changed: ^perf_dashboard/
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -346,6 +353,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test build
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -387,6 +395,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test lint
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -428,6 +437,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -469,6 +479,7 @@ presubmits:
     path_alias: istio.io/tools
     rerun_command: /test gencheck
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -511,6 +522,7 @@ presubmits:
     rerun_command: /test containers-test
     run_if_changed: docker/.+|cmd/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint
@@ -560,6 +572,7 @@ presubmits:
     rerun_command: /test containers-test-arm64
     run_if_changed: docker/.+|cmd/.+|pkg/.+
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - entrypoint

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: test_ztunnel_postsubmit
     path_alias: istio.io/ztunnel
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -54,6 +55,7 @@ postsubmits:
     name: release_ztunnel_postsubmit
     path_alias: istio.io/ztunnel
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -99,6 +101,7 @@ postsubmits:
     name: release-arm64_ztunnel_postsubmit
     path_alias: istio.io/ztunnel
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -150,6 +153,7 @@ presubmits:
     path_alias: istio.io/ztunnel
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.18.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: test_ztunnel_release-1.18_postsubmit
     path_alias: istio.io/ztunnel
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -54,6 +55,7 @@ postsubmits:
     name: release_ztunnel_release-1.18_postsubmit
     path_alias: istio.io/ztunnel
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -99,6 +101,7 @@ postsubmits:
     name: release-arm64_ztunnel_release-1.18_postsubmit
     path_alias: istio.io/ztunnel
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make
@@ -150,6 +153,7 @@ presubmits:
     path_alias: istio.io/ztunnel
     rerun_command: /test test
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - make

--- a/tools/prowgen/pkg/generate.go
+++ b/tools/prowgen/pkg/generate.go
@@ -445,12 +445,18 @@ func (cli *Client) createJobBase(baseConfig spec.BaseConfig, jobConfig spec.Jobs
 	}
 
 	yes := true
+	no := false
 	jb := config.JobBase{
 		Name:           name,
 		MaxConcurrency: job.MaxConcurrency,
 		Spec: &v1.PodSpec{
 			Containers:   createContainer(jobConfig, job, resources),
 			NodeSelector: job.NodeSelector,
+			// Disable mounting the service account token. None of our jobs should ever be connecting to the API server.
+			// We do use service accounts, but only for GKE workload identity which doesn't require this.
+			// Aside from security concerns, this also triggers https://github.com/kubernetes/kubernetes/issues/99884 which
+			// ends up with `kubectl` being confused about which namespace it should be.
+			AutomountServiceAccountToken: &no,
 		},
 		UtilityConfig: config.UtilityConfig{
 			Decorate:  &yes,

--- a/tools/prowgen/pkg/testdata/matrix.gen.yaml
+++ b/tools/prowgen/pkg/testdata/matrix.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: test-kind-arg1-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -73,6 +74,7 @@ postsubmits:
     name: test-gcp-arg1-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -115,6 +117,7 @@ postsubmits:
     name: test-kind-arg1-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -177,6 +180,7 @@ postsubmits:
     name: test-gcp-arg1-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -219,6 +223,7 @@ postsubmits:
     name: test-kind-arg2-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -281,6 +286,7 @@ postsubmits:
     name: test-gcp-arg2-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -323,6 +329,7 @@ postsubmits:
     name: test-kind-arg2-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -385,6 +392,7 @@ postsubmits:
     name: test-gcp-arg2-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -427,6 +435,7 @@ postsubmits:
     name: test-kind-arg3-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -489,6 +498,7 @@ postsubmits:
     name: test-gcp-arg3-val1_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -531,6 +541,7 @@ postsubmits:
     name: test-kind-arg3-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -593,6 +604,7 @@ postsubmits:
     name: test-gcp-arg3-val2_istio_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -637,6 +649,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-kind-arg1-val1
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -700,6 +713,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-gcp-arg1-val1
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -743,6 +757,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-kind-arg1-val2
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -806,6 +821,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-gcp-arg1-val2
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -849,6 +865,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-kind-arg2-val1
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -912,6 +929,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-gcp-arg2-val1
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -955,6 +973,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-kind-arg2-val2
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -1018,6 +1037,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-gcp-arg2-val2
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -1061,6 +1081,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-kind-arg3-val1
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -1124,6 +1145,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-gcp-arg3-val1
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -1167,6 +1189,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-kind-arg3-val2
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -1230,6 +1253,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-gcp-arg3-val2
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh

--- a/tools/prowgen/pkg/testdata/params.gen.yaml
+++ b/tools/prowgen/pkg/testdata/params.gen.yaml
@@ -11,6 +11,7 @@ postsubmits:
     name: test-params-job1_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - --key1=val1
@@ -54,6 +55,7 @@ postsubmits:
     name: test-params-job2_istio_release-1.10_postsubmit
     path_alias: istio.io/istio
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - --key1=val1
@@ -97,6 +99,7 @@ presubmits:
     path_alias: istio.io/istio
     rerun_command: /test test-params-job1
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - --key1=val1

--- a/tools/prowgen/pkg/testdata/simple.gen.yaml
+++ b/tools/prowgen/pkg/testdata/simple.gen.yaml
@@ -15,6 +15,7 @@ periodics:
     repo: istio
   name: periodic-job_istio_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - args:
       - common
@@ -68,6 +69,7 @@ periodics:
     repo: istio
   name: presubmit-skipped_istio_periodic
   spec:
+    automountServiceAccountToken: false
     containers:
     - command:
       - prow/command.sh
@@ -112,6 +114,7 @@ postsubmits:
     name: test_istio_postsubmit
     run_if_changed: foo.*
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -153,6 +156,7 @@ presubmits:
     rerun_command: /test test
     run_if_changed: foo.*
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -198,6 +202,7 @@ presubmits:
     name: presubmit-kind_istio
     rerun_command: /test presubmit-kind
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/istio-lint.sh
@@ -264,6 +269,7 @@ presubmits:
     name: custom-node-selector_istio
     rerun_command: /test custom-node-selector
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - common
@@ -314,6 +320,7 @@ presubmits:
     name: presubmit-skipped_istio
     rerun_command: /test presubmit-skipped
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -357,6 +364,7 @@ presubmits:
     name: multi-arch_istio
     rerun_command: /test multi-arch
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -397,6 +405,7 @@ presubmits:
     name: multi-arch-arm64_istio
     rerun_command: /test multi-arch-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -441,6 +450,7 @@ presubmits:
     name: multi-arch-param_istio
     rerun_command: /test multi-arch-param
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh
@@ -482,6 +492,7 @@ presubmits:
     name: multi-arch-param-arm64_istio
     rerun_command: /test multi-arch-param-arm64
     spec:
+      automountServiceAccountToken: false
       containers:
       - command:
         - prow/command.sh


### PR DESCRIPTION
This fixes policybot deployment, and perhaps other previously unknown-cause bugs