### PR TITLE
Terraform: better document GCS buckets and cleanup empty ones

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -70,3 +70,40 @@ gcp
 aws
 └── project-0
 ```
+
+## GCS Buckets
+
+Below catalogs all of the GCS buckets in one
+
+| Bucket                                         | Project                  | Importance | Notes                                                                                          |
+|------------------------------------------------|--------------------------|------------|------------------------------------------------------------------------------------------------|
+| artifacts.istio-release.appspot.com            | istio-release            | Critical   | gcr.io/istio-release                                                                           |
+| istio-release                                  | istio-io                 | Critical   | Production GCS artifacts of our releases                                                       |
+| artifacts.istio-testing.appspot.com            | istio-testing            | Important  | gcr.io/istio-testing                                                                           |
+| istio-build                                    | istio-testing            | Important  | Holds release artifacts for proxy, ztunnel, etc                                                |
+| istio-prow                                     | istio-testing            | Important  | Stores all our test artifacts and results                                                      |
+| istio-testgrid                                 | istio-testing            | Important  | Used by testgrid                                                                               |
+| artifacts.istio-prerelease-testing.appspot.com | istio-prerelease-testing | Important  | gcr.io/istio-prerelease-testing                                                                |
+| artifacts.istio-prow-build.appspot.com         | istio-prow-build         | Important  | gcr.io/istio-prow-build                                                                        |
+| istio-private-build                            | istio-prow-build         | Important  | Private builds for proxy. Mirrors "istio-artifacts"                                            |
+| istio-private-prerelease                       | istio-prow-build         | Important  | Private release-builder, mirrors istio-prerelease                                              |
+| istio-prerelease                               | istio-io                 | Important  | Release builder publishes artifacts here before they are official released                     |
+| istio-release-pipeline-data                    | istio-release            | Legacy     |                                                                                                |
+| e2e-testing-log                                | istio-testing            | Legacy     |                                                                                                |
+| istio-circleci                                 | istio-testing            | Legacy     |                                                                                                |
+| istio-code-coverage                            | istio-testing            | Legacy     |                                                                                                |
+| istio-flakes                                   | istio-testing            | Legacy     |                                                                                                |
+| istio-gists                                    | istio-testing            | Legacy     |                                                                                                |
+| istio-logs                                     | istio-testing            | Legacy     |                                                                                                |
+| istio-presubmit-release-pipeline-data          | istio-testing            | Legacy     |                                                                                                |
+| istio-stats                                    | istio-testing            | Legacy     | This was a oneoff upload                                                                       |
+| istio-testing_cloudbuild                       | istio-testing            | Legacy     |                                                                                                |
+| istio-tools                                    | istio-testing            | Legacy     |                                                                                                |
+| fortio-data                                    | istio-io                 | Legacy     | Old fortio data                                                                                |
+| artifacts.istio-io.appspot.com                 | istio-io                 | Legacy     | gcr.io/istio-io; only used for old artifacts                                                   |
+| istio-io_cloudbuild                            | istio-io                 | Legacy     |                                                                                                |
+| istio-artifacts                                | istio-testing            | Legacy?    | I believe formerly we used this for part of proxy release, now istio-build is used exclusively |
+| istio-build-deps                               | istio-testing            | Legacy?    |                                                                                                |
+| us.artifacts.istio-testing.appspot.com         | istio-testing            | Legacy?    | I am not sure what this is. Its part of GCR somehow                                            |
+| istio-snippets                                 | istio-testing            | Legacy?    | Looks like it may have been used for istio.io tests, but likely not anymore                    |
+| istio-private-artifacts                        | istio-prow-build         | Legacy?    | Private builds for proxy. Mirrors "istio-artifacts"                                            |

--- a/infra/gcp/istio-testing/storage.tf
+++ b/infra/gcp/istio-testing/storage.tf
@@ -5,14 +5,6 @@ resource "google_storage_bucket" "artifacts_istio_testing_appspot_com" {
   project       = "istio-testing"
   storage_class = "STANDARD"
 }
-resource "google_storage_bucket" "dataflow_staging_us_central1_450874614208" {
-  force_destroy            = false
-  location                 = "US-CENTRAL1"
-  name                     = "dataflow-staging-us-central1-450874614208"
-  project                  = "istio-testing"
-  public_access_prevention = "inherited"
-  storage_class            = "STANDARD"
-}
 resource "google_storage_bucket" "e2e_testing_log" {
   force_destroy = false
   location      = "US"
@@ -82,15 +74,6 @@ resource "google_storage_bucket" "istio_logs" {
   project       = "istio-testing"
   storage_class = "MULTI_REGIONAL"
 }
-resource "google_storage_bucket" "istio_presubmit_prerelease" {
-  force_destroy               = false
-  location                    = "US"
-  name                        = "istio-presubmit-prerelease"
-  project                     = "istio-testing"
-  public_access_prevention    = "inherited"
-  storage_class               = "MULTI_REGIONAL"
-  uniform_bucket_level_access = true
-}
 resource "google_storage_bucket" "istio_presubmit_release_pipeline_data" {
   force_destroy               = false
   location                    = "US"
@@ -124,13 +107,6 @@ resource "google_storage_bucket" "istio_testgrid" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
-resource "google_storage_bucket" "istio_testing_appspot_com" {
-  force_destroy = false
-  location      = "US"
-  name          = "istio-testing.appspot.com"
-  project       = "istio-testing"
-  storage_class = "STANDARD"
-}
 resource "google_storage_bucket" "istio_testing_cloudbuild" {
   force_destroy = false
   location      = "US"
@@ -145,54 +121,12 @@ resource "google_storage_bucket" "istio_tools" {
   project       = "istio-testing"
   storage_class = "MULTI_REGIONAL"
 }
-resource "google_storage_bucket" "staging_istio_testing_appspot_com" {
-  force_destroy = false
-
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    condition {
-      age        = 15
-      with_state = "ANY"
-    }
-  }
-
-  location      = "US"
-  name          = "staging.istio-testing.appspot.com"
-  project       = "istio-testing"
-  storage_class = "STANDARD"
-}
 resource "google_storage_bucket" "us_artifacts_istio_testing_appspot_com" {
   force_destroy = false
   location      = "US"
   name          = "us.artifacts.istio-testing.appspot.com"
   project       = "istio-testing"
   storage_class = "STANDARD"
-}
-resource "google_storage_bucket" "vm_config_istio_testing_appspot_com" {
-  force_destroy = false
-  location      = "US"
-  name          = "vm-config.istio-testing.appspot.com"
-  project       = "istio-testing"
-  storage_class = "STANDARD"
-}
-resource "google_storage_bucket" "vm_containers_istio_testing_appspot_com" {
-  force_destroy = false
-  location      = "US"
-  name          = "vm-containers.istio-testing.appspot.com"
-  project       = "istio-testing"
-  storage_class = "STANDARD"
-}
-resource "google_storage_bucket" "istio_policybot" {
-  force_destroy               = false
-  location                    = "US-WEST1"
-  name                        = "istio-policybot"
-  project                     = "istio-testing"
-  public_access_prevention    = "inherited"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = true
 }
 resource "google_storage_bucket" "istio_snippets" {
   force_destroy            = false


### PR DESCRIPTION
These buckets are unused and empty so have been removed. Also add a
table so we can have a single place to reference for all the storage
going on in the project. Currently with it spread everywhere its hard to
grok.
