### PR TITLE
Revert "make test-arm optional"

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -510,7 +510,7 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )check-wasm,?($|\s.*))|((?m)^/test( | .* )check-wasm_proxy,?($|\s.*))
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -524,10 +524,7 @@ presubmits:
       preset-enable-netrc: "true"
     name: test-arm-arm64_proxy_master_priv
     path_alias: istio.io/proxy
-    reporter_config:
-      slack: {}
     rerun_command: /test test-arm-arm64
-    skip_report: true
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -471,7 +471,7 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy,?($|\s.*))
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
     branches:
@@ -482,10 +482,7 @@ presubmits:
       timeout: 6h0m0s
     name: test-arm-arm64_proxy
     path_alias: istio.io/proxy
-    reporter_config:
-      slack: {}
     rerun_command: /test test-arm-arm64
-    skip_report: true
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -281,7 +281,7 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )test-tsan,?($|\s.*))|((?m)^/test( | .* )test-tsan_proxy,?($|\s.*))
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_proxy
     branches:
@@ -292,10 +292,7 @@ presubmits:
       timeout: 6h0m0s
     name: test-arm-arm64_proxy_exp
     path_alias: istio.io/proxy
-    reporter_config:
-      slack: {}
     rerun_command: /test test-arm-arm64
-    skip_report: true
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -35,9 +35,6 @@ jobs:
   timeout: 6h
   # TODO: get build-pool for arm
   resources: arm
-  modifiers:
-  - presubmit_skipped
-  - hidden
   node_selector:
     testing: test-pool
 


### PR DESCRIPTION
Reverts istio/test-infra#4771

see: https://github.com/istio/proxy/pull/4731#issuecomment-1599789722

cc @kyessenov can we revert this?