### PR TITLE
prow: add highlighter config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -68,8 +68,8 @@ deck:
           highlight_regexes:
             - "timed out"
             - "ERROR:"
-            - "(FAIL|Failure \[)\b"
-            - "panic\b"
+            - "(FAIL|Failure \\[)\\b"
+            - "panic\\b"
             - "SUSPICIOUS:"
       required_files:
       - build-log.txt

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -64,6 +64,13 @@ deck:
       - podinfo.json
     - lens:
         name: buildlog
+        config:
+          highlight_regexes:
+            - "timed out"
+            - "ERROR:"
+            - "(FAIL|Failure \[)\b"
+            - "panic\b"
+            - "SUSPICIOUS:"
       required_files:
       - build-log.txt
     - lens:


### PR DESCRIPTION
Motivation: we currently use `FAIL:` in logs to trigger the highlight,
when the line did *not* cause a failure. This allows us to highlight
without faking log lines. It may also be useful for future things we
want to add, now that we have the basis for it.

This should be the defaults + the SUSPICIOUS part. See
https://github.com/kubernetes/test-infra/blob/e7ccf79861d3c53dfaa6c784c0c8537922c4c0cc/prow/spyglass/lenses/buildlog/lens.go#L95
for the defaults.

Note this overrides the defaults, so we need to include the default
parts.
