### PR TITLE
Setup job configuration to allow reading GCP secrets directly

### DIFF
--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -239,7 +239,7 @@ func TestJobs(t *testing.T) {
 		}
 
 		if j.Type == Presubmit {
-			return fmt.Errorf("jobs with secrets must cannot be presubmits")
+			return fmt.Errorf("jobs with secrets cannot be presubmits")
 		}
 		if !hasEntrypoint {
 			return fmt.Errorf("jobs with secrets must use entrypoint")

--- a/tools/prowgen/pkg/decorator/requirement.go
+++ b/tools/prowgen/pkg/decorator/requirement.go
@@ -80,7 +80,7 @@ func applySecrets(job *config.JobBase, presets []spec.RequirementPreset) {
 	}
 	if len(job.Spec.Containers) != 1 {
 		// We could support more but it may expand permissions, just keep it safe for now
-		log.Fatalf("secrets only works with 1 container")
+		log.Fatalf("secrets only work with 1 container")
 	}
 	job.Spec.Containers[0].Env = append(job.Spec.Containers[0].Env, v1.EnvVar{
 		Name:  "GCP_SECRETS",

--- a/tools/prowgen/pkg/spec/spec.go
+++ b/tools/prowgen/pkg/spec/spec.go
@@ -144,6 +144,7 @@ type RequirementPreset struct {
 	VolumeMounts []v1.VolumeMount  `json:"volumeMounts,omitempty"`
 	Args         []string          `json:"args,omitempty"`
 	Cron         string            `json:"cron,omitempty"`
+	Secrets      []Secret          `json:"secrets,omitempty"`
 	PodSpec      *v1.PodSpec       `json:"podSpec,omitempty"` // Use this field to add extra PodSpec fields except containers and metadata
 }
 
@@ -154,4 +155,10 @@ func (r *RequirementPreset) DeepCopy() RequirementPreset {
 		log.Fatalf("Failed to unmarshal RequirementPreset: %v", err)
 	}
 	return newRequirementPreset
+}
+
+type Secret struct {
+	Name    string `json:"secret,omitempty"`
+	Project string `json:"project,omitempty"`
+	Env     string `json:"env,omitempty"`
 }

--- a/tools/prowgen/pkg/testdata/.base.yaml
+++ b/tools/prowgen/pkg/testdata/.base.yaml
@@ -105,3 +105,8 @@ requirement_presets:
     - "common"
     - "args"
     - "that are reusable"
+  secrets:
+    secrets:
+      - secret: test-name
+        project: test-proj
+        env: TEST_SECRET

--- a/tools/prowgen/pkg/testdata/simple.gen.yaml
+++ b/tools/prowgen/pkg/testdata/simple.gen.yaml
@@ -530,3 +530,45 @@ presubmits:
         name: build-cache
     trigger: ((?m)^/test( | .* )multi-arch-param-arm64,?($|\s.*))|((?m)^/test( | .*
       )multi-arch-param-arm64_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: gerrit.istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: secret_istio
+    rerun_command: /test secret
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - prow/command.sh
+        env:
+        - name: key
+          value: value
+        - name: GCP_SECRETS
+          value: '[{"secret":"test-name","project":"test-proj","env":"TEST_SECRET"}]'
+        image: test
+        name: ""
+        resources:
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )secret,?($|\s.*))|((?m)^/test( | .* )secret_istio,?($|\s.*))

--- a/tools/prowgen/pkg/testdata/simple.yaml
+++ b/tools/prowgen/pkg/testdata/simple.yaml
@@ -64,6 +64,12 @@ jobs:
     command: [prow/command.sh, $(params.arch)]
     image: test
 
+  - name: secret
+    types: [presubmit]
+    requirements: [secrets]
+    command: [prow/command.sh]
+    image: test
+
 requirements: [gocache]
 
 resources_presets:


### PR DESCRIPTION
Pairs with https://github.com/istio/tools/pull/2526, see that PR for
more context.

This adds a new preset type of secrets that will be fetched at job
startup. Currently, no jobs use this - but the `github` and `release`
presets will be migrated to this, eventually.
