### PR TITLE
terraform: add initial scoped service accounts

### DIFF
--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -24,3 +24,17 @@ resource "google_service_account" "prow_internal_storage" {
   display_name = "Prow Internal Storage"
   project      = "istio-prow-build"
 }
+
+module "workload_identity_service_accounts" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "prowjob-release"
+  description       = "Service account used for prow release jobs. Highly privileged."
+  cluster_namespace = local.pod_namespace
+  project_roles = [
+    {
+      role      = "roles/secretmanager.secretAccessor"
+      # TODO: create real secrets and reference these, this is just a starter to get things tested
+      condition = "resource.name.startsWith('projects/${local.project_number}/secrets/test-secret')"
+  }]
+}

--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -41,8 +41,8 @@ module "prowjob_release_account" {
 module "prowjob_rbe_account" {
   source            = "../modules/workload-identity-service-account"
   project_id        = local.project_id
-  name              = "prowjob-release"
-  description       = "Service account used for prow release jobs. Highly privileged."
+  name              = "prowjob-rbe"
+  description       = "Service account used for prow jobs requireing RBE access (istio/proxy)."
   cluster_namespace = local.pod_namespace
   project_roles = [
     { role = "roles/remotebuildexecution.actionCacheWriter", project = "istio-testing" },

--- a/infra/gcp/istio-prow-build/secrets.tf
+++ b/infra/gcp/istio-prow-build/secrets.tf
@@ -1,0 +1,34 @@
+# secrets.tf contains GCP managed secrets
+# This file just defines the secrets and their access; the actual secrets are managed manually:
+# gcloud --project <project> secrets versions add <secret> --data-file=<data>
+
+# This is just a test secret for testing
+resource "google_secret_manager_secret" "test_secret" {
+  project   = local.project_id
+  secret_id = "test-secret"
+  replication {
+    automatic = true
+  }
+}
+resource "google_secret_manager_secret" "test_secret2" {
+  project   = local.project_id
+  secret_id = "test-secret2"
+  replication {
+    automatic = true
+  }
+}
+
+data "google_iam_policy" "test_secret" {
+  binding {
+    role = "roles/secretmanager.secretAccessor"
+    members = [
+      "serviceAccount:${module.prowjob_release_account.email}",
+    ]
+  }
+}
+
+resource "google_secret_manager_secret_iam_policy" "test_secret" {
+  project     = google_secret_manager_secret.test_secret.project
+  secret_id   = google_secret_manager_secret.test_secret.secret_id
+  policy_data = data.google_iam_policy.test_secret.policy_data
+}

--- a/infra/gcp/modules/workload-identity-service-account/README.md
+++ b/infra/gcp/modules/workload-identity-service-account/README.md
@@ -1,0 +1,7 @@
+# `workload-identity-serviceaccount` terraform module
+
+This terraform module defines a GCP service account intended solely for use
+by pods running in GKE clusters in a given project, running as a given K8s
+service account in a given namespace.
+
+This is forked (mostly as-is) from https://github.com/kubernetes/k8s.io/blob/main/infra/gcp/terraform/modules/workload-identity-service-account/README.md.

--- a/infra/gcp/modules/workload-identity-service-account/README.md
+++ b/infra/gcp/modules/workload-identity-service-account/README.md
@@ -4,4 +4,4 @@ This terraform module defines a GCP service account intended solely for use
 by pods running in GKE clusters in a given project, running as a given K8s
 service account in a given namespace.
 
-This is forked (mostly as-is) from https://github.com/kubernetes/k8s.io/blob/main/infra/gcp/terraform/modules/workload-identity-service-account/README.md.
+This is forked (mostly as-is) from [Kubernetes](https://github.com/kubernetes/k8s.io/blob/main/infra/gcp/terraform/modules/workload-identity-service-account/README.md).

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -45,8 +45,8 @@ resource "google_service_account_iam_policy" "serviceaccount_iam" {
 }
 // optional: roles to grant the serviceaccount on the project
 resource "google_project_iam_member" "project_roles" {
-  for_each = toset(var.project_roles)
-  project  = var.project_id
-  role     = each.value
+  for_each = {for k, v in var.project_roles : k => v}
+  project  = coalesce(each.value.project, var.project_id)
+  role     = each.value.role
   member   = "serviceAccount:${google_service_account.serviceaccount.email}"
 }

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -21,7 +21,7 @@ limitations under the License.
 
 locals {
   description                 = var.description != "" ? var.description : var.name
-  display_name                 = var.display_name != "" ? var.display_name : var.name
+  display_name                = var.display_name != "" ? var.display_name : var.name
   cluster_project_id          = var.cluster_project_id != "" ? var.cluster_project_id : var.project_id
   cluster_serviceaccount_name = var.cluster_serviceaccount_name != "" ? var.cluster_serviceaccount_name : var.name
 }
@@ -30,15 +30,12 @@ resource "google_service_account" "serviceaccount" {
   project      = var.project_id
   account_id   = var.name
   display_name = local.display_name
-  description = local.description
+  description  = local.description
 }
 data "google_iam_policy" "workload_identity" {
   binding {
-    members = concat(["serviceAccount:${local.cluster_project_id}.svc.id.goog[${var.cluster_namespace}/${local.cluster_serviceaccount_name}]"],
-      var.additional_workload_identity_principals
-    )
-
-    role = "roles/iam.workloadIdentityUser"
+    members = ["serviceAccount:${local.cluster_project_id}.svc.id.goog[${var.cluster_namespace}/${local.cluster_serviceaccount_name}]"]
+    role    = "roles/iam.workloadIdentityUser"
   }
 }
 // authoritative binding, replaces any existing IAM policy on the service account

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// creates a service account in project_id with name and description
+// usable by pods in cluster_project_id
+// running in namespace cluster_namespace
+// running as cluster_serviceaccount_name
+
+locals {
+  description                 = var.description != "" ? var.description : var.name
+  display_name                 = var.display_name != "" ? var.display_name : var.name
+  cluster_project_id          = var.cluster_project_id != "" ? var.cluster_project_id : var.project_id
+  cluster_serviceaccount_name = var.cluster_serviceaccount_name != "" ? var.cluster_serviceaccount_name : var.name
+}
+
+resource "google_service_account" "serviceaccount" {
+  project      = var.project_id
+  account_id   = var.name
+  display_name = local.display_name
+  description = local.description
+}
+data "google_iam_policy" "workload_identity" {
+  binding {
+    members = concat(["serviceAccount:${local.cluster_project_id}.svc.id.goog[${var.cluster_namespace}/${local.cluster_serviceaccount_name}]"],
+      var.additional_workload_identity_principals
+    )
+
+    role = "roles/iam.workloadIdentityUser"
+  }
+}
+// authoritative binding, replaces any existing IAM policy on the service account
+resource "google_service_account_iam_policy" "serviceaccount_iam" {
+  service_account_id = google_service_account.serviceaccount.name
+  policy_data        = data.google_iam_policy.workload_identity.policy_data
+}
+// optional: roles to grant the serviceaccount on the project
+resource "google_project_iam_member" "project_roles" {
+  for_each = toset(var.project_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.serviceaccount.email}"
+}

--- a/infra/gcp/modules/workload-identity-service-account/outputs.tf
+++ b/infra/gcp/modules/workload-identity-service-account/outputs.tf
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "email" {
+  description = "The email of the serviceaccount that was created"
+  value       = google_service_account.serviceaccount.email
+}
+
+output "iam_policy" {
+  description = "The serviceaccount iam_policy"
+  value       = google_service_account_iam_policy.serviceaccount_iam.policy_data
+}

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -55,12 +55,9 @@ variable "cluster_namespace" {
 
 variable "project_roles" {
   description = "A list of roles to bind to the serviceaccount in its project, eg: [ \"roles/bigquery.user\" ]"
-  type        = list(string)
-  default     = []
-}
-
-variable "additional_workload_identity_principals" {
-  description = "A list of extra principals to grant WorkloadIdentityUser on the service account"
-  type        = list(string)
-  default     = []
+  type = list(object({
+    role = string
+    condition = string
+  }))
+  default = []
 }

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "project_id" {
+  description = "The id of the project hosting the serviceaccount, eg: my-awesome-project"
+  type        = string
+}
+
+variable "name" {
+  description = "The name of the serviceaccount, eg: my-awesome-sa"
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the service account, eg: My Awesome Service Account (default: name)"
+  type        = string
+  default     = ""
+}
+
+variable "display_name" {
+  description = "The display name of the service account"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_project_id" {
+  description = "The id of the project hosting clusters that will use the serviceaccount, eg: my-awesome-cluster-project (default: project_id)"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_serviceaccount_name" {
+  description = "The name of the kubernetes service account that will bind to the service account, eg: my-cluster-sa (default: name)"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_namespace" {
+  description = "The namespace of the kubernetes service account that will bind to the service account, eg: my-namespace"
+  type        = string
+}
+
+variable "project_roles" {
+  description = "A list of roles to bind to the serviceaccount in its project, eg: [ \"roles/bigquery.user\" ]"
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_workload_identity_principals" {
+  description = "A list of extra principals to grant WorkloadIdentityUser on the service account"
+  type        = list(string)
+  default     = []
+}

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -54,10 +54,10 @@ variable "cluster_namespace" {
 }
 
 variable "project_roles" {
-  description = "A list of roles to bind to the serviceaccount in its project, eg: [ \"roles/bigquery.user\" ]"
+  description = "A list of roles to bind to the serviceaccount in its project"
   type = list(object({
     role = string
-    condition = string
+    project = optional(string)
   }))
   default = []
 }

--- a/infra/gcp/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/modules/workload-identity-service-account/versions.tf
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.69.1"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.69.1"
+    }
+  }
+}

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -26,7 +26,15 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prowjob-release@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
-  # Service account that has more permissions on the shared GCP projects, check
-  # with a Googler on what permissions it has.
-  # Please only use it when you do need them.
-  name: prowjob-advanced-sa
+  # Service account that has permissions for release jobs.
+  # This should ONLY be used for release jobs.
+  name: prowjob-release
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-rbe@istio-prow-build.iam.gserviceaccount.com
+  namespace: test-pods
+  # Service account that has permissions for RBE access. For use by istio/proxy
+  name: prowjob-rbe

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -19,3 +19,14 @@ metadata:
   # with a Googler on what permissions it has.
   # Please only use it when you do need them.
   name: prowjob-advanced-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-release@istio-prow-build.iam.gserviceaccount.com
+  namespace: test-pods
+  # Service account that has more permissions on the shared GCP projects, check
+  # with a Googler on what permissions it has.
+  # Please only use it when you do need them.
+  name: prowjob-advanced-sa


### PR DESCRIPTION
This gets us ready to use more fine-scoped service accounts using WI to restrict access to only minimal set of resources required. This PR:

* Adds a new module to setup WI, heavily copied from Kubernetes with some tweaks for our own needs.
* Adds 2 new accounts, one for release jobs and one for RBE.
* The release permissions are currently a small stub so we can do some testing on fake secrets, after testing will give it the real ones. The RBE one _should_ be sufficient, but I will do some manual testing before moving those jobs over