### PR TITLE
Remove cosign 'secret'

### DIFF
--- a/prow/cluster/build/kubernetes_external_secrets.yaml
+++ b/prow/cluster/build/kubernetes_external_secrets.yaml
@@ -1,17 +1,6 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: "cosign-key"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow__test-pods__cosign-key" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: "grafana-token"
   namespace: "test-pods"
 spec:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -155,10 +155,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
@@ -155,10 +155,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
@@ -155,10 +155,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
@@ -155,10 +155,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2237,10 +2237,7 @@ postsubmits:
         - name: VERSION
           value: master
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -2189,10 +2189,7 @@ postsubmits:
         - name: VERSION
           value: "1.16"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -2254,10 +2254,7 @@ postsubmits:
         - name: VERSION
           value: release-1.17
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -2169,10 +2169,7 @@ postsubmits:
         - name: VERSION
           value: release-1.18
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -26,10 +26,7 @@ periodics:
       - name: VERSION
         value: master
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -287,10 +284,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE
@@ -369,10 +363,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
@@ -26,10 +26,7 @@ periodics:
       - name: VERSION
         value: "1.16"
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -287,10 +284,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE
@@ -369,10 +363,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
@@ -26,10 +26,7 @@ periodics:
       - name: VERSION
         value: "1.17"
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -287,10 +284,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE
@@ -369,10 +363,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
@@ -26,10 +26,7 @@ periodics:
       - name: VERSION
         value: "1.18"
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -287,10 +284,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE
@@ -369,10 +363,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: COSIGN_KEY
-          valueFrom:
-            secretKeyRef:
-              key: key
-              name: cosign-key
+          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /etc/rel-pipeline-docker-config
         - name: GITHUB_TOKEN_FILE

--- a/prow/cluster/private/kubernetes_external_secrets.yaml
+++ b/prow/cluster/private/kubernetes_external_secrets.yaml
@@ -1,17 +1,6 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: "cosign-key"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow-private__test-pods__cosign-key" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: "gitconfig"
   namespace: "test-pods"
 spec:

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -109,10 +109,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          name: "cosign-key"
-          key: "key"
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -217,10 +214,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -354,10 +348,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -491,10 +482,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -617,10 +605,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/api-1.17.yaml
+++ b/prow/config/jobs/api-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -229,10 +226,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -373,10 +367,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -517,10 +508,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -653,10 +641,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -227,10 +224,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -370,10 +364,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -513,10 +504,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -649,10 +637,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/client-go-1.16.yaml
+++ b/prow/config/jobs/client-go-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -217,10 +214,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -346,10 +340,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -485,10 +476,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -611,10 +599,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/client-go-1.17.yaml
+++ b/prow/config/jobs/client-go-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -229,10 +226,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -365,10 +359,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -511,10 +502,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -647,10 +635,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -227,10 +224,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -362,10 +356,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -507,10 +498,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -643,10 +631,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/common-files-1.16.yaml
+++ b/prow/config/jobs/common-files-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -226,10 +223,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -367,10 +361,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -512,10 +503,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -638,10 +626,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/common-files-1.17.yaml
+++ b/prow/config/jobs/common-files-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -238,10 +235,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -386,10 +380,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -538,10 +529,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -674,10 +662,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/common-files-1.18.yaml
+++ b/prow/config/jobs/common-files-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -236,10 +233,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -383,10 +377,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -534,10 +525,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -670,10 +658,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/enhancements-1.16.yaml
+++ b/prow/config/jobs/enhancements-1.16.yaml
@@ -94,10 +94,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -219,10 +216,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/enhancements-1.17.yaml
+++ b/prow/config/jobs/enhancements-1.17.yaml
@@ -99,10 +99,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -234,10 +231,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/enhancements-1.18.yaml
+++ b/prow/config/jobs/enhancements-1.18.yaml
@@ -98,10 +98,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -233,10 +230,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -96,10 +96,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -246,10 +243,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -400,10 +394,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -558,10 +549,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -712,10 +700,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -868,10 +853,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1021,10 +1003,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1174,10 +1153,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1332,10 +1308,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1486,10 +1459,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1641,10 +1611,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1796,10 +1763,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1949,10 +1913,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2100,10 +2061,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2251,10 +2209,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2404,10 +2359,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2559,10 +2511,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2717,10 +2666,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2875,10 +2821,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3027,10 +2970,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3179,10 +3119,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3334,10 +3271,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3492,10 +3426,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3644,10 +3575,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3801,10 +3729,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3961,10 +3886,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4121,10 +4043,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4281,10 +4200,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4441,10 +4357,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4601,10 +4514,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4761,10 +4671,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4919,10 +4826,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5079,10 +4983,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5237,10 +5138,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5396,10 +5294,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5547,10 +5442,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5698,10 +5590,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5850,10 +5739,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6004,10 +5890,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6165,10 +6048,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6313,10 +6193,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -101,10 +101,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -258,10 +255,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -419,10 +413,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -584,10 +575,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -745,10 +733,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -909,10 +894,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1069,10 +1051,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1229,10 +1208,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1395,10 +1371,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1557,10 +1530,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1720,10 +1690,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1883,10 +1850,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2043,10 +2007,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2201,10 +2162,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2359,10 +2317,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2520,10 +2475,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2682,10 +2634,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2848,10 +2797,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3014,10 +2960,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3173,10 +3116,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3332,10 +3272,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3494,10 +3431,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3660,10 +3594,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3819,10 +3750,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3984,10 +3912,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4152,10 +4077,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4320,10 +4242,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4488,10 +4407,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4656,10 +4572,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4824,10 +4737,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4992,10 +4902,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5158,10 +5065,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5324,10 +5228,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5490,10 +5391,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5656,10 +5554,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5823,10 +5718,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5981,10 +5873,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6139,10 +6028,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6298,10 +6184,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6459,10 +6342,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6628,10 +6508,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6786,10 +6663,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -100,10 +100,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -256,10 +253,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -416,10 +410,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -580,10 +571,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -740,10 +728,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -903,10 +888,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1062,10 +1044,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1221,10 +1200,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1386,10 +1362,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1547,10 +1520,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1709,10 +1679,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1871,10 +1838,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2030,10 +1994,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2187,10 +2148,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2344,10 +2302,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2504,10 +2459,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2665,10 +2617,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2830,10 +2779,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -2995,10 +2941,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3153,10 +3096,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3311,10 +3251,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3472,10 +3409,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3637,10 +3571,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3800,10 +3731,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -3957,10 +3885,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4121,10 +4046,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4288,10 +4210,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4455,10 +4374,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4620,10 +4536,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4785,10 +4698,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -4950,10 +4860,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5115,10 +5022,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5280,10 +5184,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5446,10 +5347,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5603,10 +5501,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5760,10 +5655,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -5918,10 +5810,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6078,10 +5967,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6246,10 +6132,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6415,10 +6298,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -6571,10 +6451,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/istio.io-1.16.yaml
+++ b/prow/config/jobs/istio.io-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -224,10 +221,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -362,10 +356,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -501,10 +492,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -640,10 +628,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -781,10 +766,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -926,10 +908,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1059,10 +1038,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/istio.io-1.17.yaml
+++ b/prow/config/jobs/istio.io-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -236,10 +233,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -381,10 +375,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -527,10 +518,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -673,10 +661,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -821,10 +806,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -973,10 +955,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1116,10 +1095,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -241,10 +238,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -392,10 +386,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -545,10 +536,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -697,10 +685,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -849,10 +834,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1003,10 +985,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1161,10 +1140,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1311,10 +1287,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/pkg-1.16.yaml
+++ b/prow/config/jobs/pkg-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -217,10 +214,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -346,10 +340,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -475,10 +466,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -613,10 +601,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -739,10 +724,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/pkg-1.17.yaml
+++ b/prow/config/jobs/pkg-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -229,10 +226,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -365,10 +359,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -501,10 +492,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -646,10 +634,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -782,10 +767,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -227,10 +224,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -362,10 +356,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -497,10 +488,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -641,10 +629,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -777,10 +762,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -87,10 +87,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -223,10 +220,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -359,10 +353,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -495,10 +486,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -637,10 +625,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -774,10 +759,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -911,10 +893,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1049,10 +1028,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1193,10 +1169,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1331,10 +1304,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1477,10 +1447,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1623,10 +1590,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1754,10 +1718,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -235,10 +232,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -378,10 +372,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -521,10 +512,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -671,10 +659,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -815,10 +800,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -959,10 +941,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1104,10 +1083,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1256,10 +1232,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1401,10 +1374,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1554,10 +1524,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1707,10 +1674,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1848,10 +1812,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -91,10 +91,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -233,10 +230,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -375,10 +369,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -518,10 +509,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -667,10 +655,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -811,10 +796,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -954,10 +936,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1098,10 +1077,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1249,10 +1225,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1394,10 +1367,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1547,10 +1517,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1700,10 +1667,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1841,10 +1805,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/release-builder-1.16.yaml
+++ b/prow/config/jobs/release-builder-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -224,10 +221,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -360,10 +354,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -497,10 +488,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -638,10 +626,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -778,10 +763,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -917,10 +899,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1059,10 +1038,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1205,10 +1181,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1341,10 +1314,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/release-builder-1.17.yaml
+++ b/prow/config/jobs/release-builder-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -236,10 +233,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -379,10 +373,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -523,10 +514,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -671,10 +659,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -818,10 +803,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -964,10 +946,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1113,10 +1092,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1267,10 +1243,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1413,10 +1386,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -234,10 +231,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -376,10 +370,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -519,10 +510,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -666,10 +654,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -812,10 +797,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -957,10 +939,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1105,10 +1084,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1258,10 +1234,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1404,10 +1377,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/tools-1.16.yaml
+++ b/prow/config/jobs/tools-1.16.yaml
@@ -88,10 +88,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -224,10 +221,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -360,10 +354,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -496,10 +487,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -645,10 +633,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -792,10 +777,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -935,10 +917,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1080,10 +1059,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1215,10 +1191,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/tools-1.17.yaml
+++ b/prow/config/jobs/tools-1.17.yaml
@@ -93,10 +93,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -236,10 +233,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -379,10 +373,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -522,10 +513,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -679,10 +667,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -834,10 +819,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -984,10 +966,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1136,10 +1115,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1281,10 +1257,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -234,10 +231,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -376,10 +370,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -518,10 +509,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -674,10 +662,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -828,10 +813,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -977,10 +959,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1128,10 +1107,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -1273,10 +1249,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE

--- a/prow/config/jobs/ztunnel-1.18.yaml
+++ b/prow/config/jobs/ztunnel-1.18.yaml
@@ -92,10 +92,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -231,10 +228,7 @@ jobs:
     release:
       env:
       - name: COSIGN_KEY
-        valueFrom:
-          secretKeyRef:
-            key: key
-            name: cosign-key
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
       - name: DOCKER_CONFIG
         value: /etc/rel-pipeline-docker-config
       - name: GITHUB_TOKEN_FILE
@@ -368,10 +362,7 @@ requirement_presets:
   release:
     env:
     - name: COSIGN_KEY
-      valueFrom:
-        secretKeyRef:
-          key: key
-          name: cosign-key
+      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
     - name: DOCKER_CONFIG
       value: /etc/rel-pipeline-docker-config
     - name: GITHUB_TOKEN_FILE


### PR DESCRIPTION
This is not a secret, its just a simple value.

To keep things simple, we remove the secret and inline it.

This is part of an effort to remove all secrets from the cluster. While
this one technically is fine, I think it causes confusion that it is
confidential when it isn't.
