### PR TITLE
Remove obsolete variable from prow jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -30,8 +30,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:master-6ca22a4265c8306755fc53a5be49ceaeeae92003
@@ -90,8 +88,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-centos:master-6ca22a4265c8306755fc53a5be49ceaeeae92003
@@ -151,8 +147,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:master-6ca22a4265c8306755fc53a5be49ceaeeae92003
@@ -542,8 +536,6 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:master-6ca22a4265c8306755fc53a5be49ceaeeae92003
@@ -607,8 +599,6 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:master-6ca22a4265c8306755fc53a5be49ceaeeae92003

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.16.gen.yaml
@@ -30,8 +30,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
@@ -90,8 +88,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
@@ -151,8 +147,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
@@ -544,8 +538,6 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.17.gen.yaml
@@ -30,8 +30,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
@@ -90,8 +88,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-centos:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
@@ -151,8 +147,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
@@ -544,8 +538,6 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
@@ -30,8 +30,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
@@ -90,8 +88,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
@@ -151,8 +147,6 @@ postsubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
@@ -544,8 +538,6 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        - name: GCS_ARTIFACTS_BUCKET
-          value: istio-private-artifacts
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
         image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973

--- a/prow/config/istio-private_jobs/proxy-1.16.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.16.yaml
@@ -22,7 +22,6 @@ transforms:
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_PREFIX: envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     GCS_BUILD_BUCKET: istio-private-build
   job-denylist:
   - update-istio_proxy_release-1.16
@@ -34,7 +33,6 @@ transforms:
 - env:
     BAZEL_BUILD_RBE_INSTANCE: null
     GCS_BUILD_BUCKET: istio-private-build
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     ENVOY_PREFIX: envoy

--- a/prow/config/istio-private_jobs/proxy-1.17.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.17.yaml
@@ -22,7 +22,6 @@ transforms:
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_PREFIX: envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     GCS_BUILD_BUCKET: istio-private-build
   job-denylist:
   - update-istio_proxy_release-1.17
@@ -34,7 +33,6 @@ transforms:
 - env:
     BAZEL_BUILD_RBE_INSTANCE: null
     GCS_BUILD_BUCKET: istio-private-build
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     ENVOY_PREFIX: envoy

--- a/prow/config/istio-private_jobs/proxy-1.18.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.18.yaml
@@ -22,7 +22,6 @@ transforms:
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_PREFIX: envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     GCS_BUILD_BUCKET: istio-private-build
   job-denylist:
   - update-istio_proxy_release-1.18
@@ -37,7 +36,6 @@ transforms:
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_PREFIX: envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     GCS_BUILD_BUCKET: istio-private-build
   job-allowlist:
   - .*arm64.*_release-1.18

--- a/prow/config/istio-private_jobs/proxy.yaml
+++ b/prow/config/istio-private_jobs/proxy.yaml
@@ -24,7 +24,6 @@ transforms:
 - env:
     BAZEL_BUILD_RBE_INSTANCE: null
     GCS_BUILD_BUCKET: istio-private-build
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     ENVOY_PREFIX: envoy
@@ -35,7 +34,6 @@ transforms:
 - env:
     BAZEL_BUILD_RBE_INSTANCE: null
     GCS_BUILD_BUCKET: istio-private-build
-    GCS_ARTIFACTS_BUCKET: istio-private-artifacts
     DOCKER_REPOSITORY: istio-prow-build/envoy
     ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     ENVOY_PREFIX: envoy


### PR DESCRIPTION
This is no longer used since 1.14+