### PR TITLE
Fix crier deployment kubeconfig reference

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -28,7 +28,6 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-workers=5
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/istio-config
         - --kubernetes-blob-storage-workers=1
         - --slack-token-file=/etc/slack/token
         - --slack-workers=1


### PR DESCRIPTION
It should use KUBECONFIG (already set) like others

I already manually made this change, as the PR will not run merge without crier working ( I think )