### PR TITLE
Migrate proxy jobs over to RBE sa

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -168,7 +168,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -218,7 +218,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -268,7 +268,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -376,7 +376,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -420,7 +420,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -464,7 +464,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -508,7 +508,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -557,7 +557,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -603,7 +603,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -652,7 +652,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -699,7 +699,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
@@ -104,7 +104,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -204,7 +204,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -310,7 +310,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -354,7 +354,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -398,7 +398,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -442,7 +442,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -488,7 +488,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -537,7 +537,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -584,7 +584,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
@@ -104,7 +104,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -204,7 +204,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -310,7 +310,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -354,7 +354,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -398,7 +398,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -442,7 +442,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -488,7 +488,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -537,7 +537,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -584,7 +584,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -104,7 +104,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -204,7 +204,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -310,7 +310,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -354,7 +354,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -398,7 +398,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -442,7 +442,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -488,7 +488,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -537,7 +537,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -584,7 +584,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -41,7 +41,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -91,7 +91,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -141,7 +141,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -186,7 +186,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -230,7 +230,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -274,7 +274,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -318,7 +318,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -367,7 +367,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -413,7 +413,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -462,7 +462,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -509,7 +509,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-rbe
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -139,7 +139,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -275,7 +275,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -411,7 +411,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -547,7 +547,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -690,7 +690,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -826,7 +826,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -964,7 +964,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -1102,7 +1102,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1247,7 +1247,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1383,7 +1383,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -144,7 +144,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -287,7 +287,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -430,7 +430,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -573,7 +573,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -724,7 +724,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -867,7 +867,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -1012,7 +1012,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -1157,7 +1157,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1310,7 +1310,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1453,7 +1453,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -143,7 +143,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -285,7 +285,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -427,7 +427,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -570,7 +570,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -720,7 +720,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -863,7 +863,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - presubmit
@@ -1007,7 +1007,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 4h0m0s
   types:
   - presubmit
@@ -1151,7 +1151,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1303,7 +1303,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1446,7 +1446,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -7,19 +7,19 @@ node_selector:
 
 jobs:
 - name: test
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 4h
 
 - name: test-asan
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
   timeout: 4h
 
 - name: test-tsan
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit-tsan.sh]
   timeout: 4h
@@ -29,7 +29,7 @@ jobs:
   env:
   - name: ARCH_SUFFIX
     value: $(params.arch)
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 6h
@@ -39,7 +39,7 @@ jobs:
     testing: test-pool
 
 - name: release-test
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
   timeout: 6h
@@ -51,7 +51,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
   timeout: 6h
@@ -61,21 +61,21 @@ jobs:
     testing: test-pool
 
 - name: release-centos-test
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [./prow/proxy-presubmit-centos-release.sh]
   image: gcr.io/istio-testing/build-tools-centos:master-6ca22a4265c8306755fc53a5be49ceaeeae92003
   timeout: 6h
 
 - name: check-wasm
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [presubmit]
   command: [entrypoint, ./prow/proxy-presubmit-wasm.sh]
   requirements: [docker]
   timeout: 4h
 
 - name: release
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
@@ -87,7 +87,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
@@ -98,7 +98,7 @@ jobs:
     testing: test-pool
 
 - name: release-centos
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-rbe
   types: [postsubmit]
   command: [./prow/proxy-postsubmit-centos.sh]
   image: gcr.io/istio-testing/build-tools-centos:master-6ca22a4265c8306755fc53a5be49ceaeeae92003

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -105,10 +105,10 @@ func TestJobs(t *testing.T) {
 		return nil
 	})
 	RunTest("release volumes only used in release jobs", func(j Job) error {
-		releaseJob := j.Repo == "istio/release-builder" && j.Type == Postsubmit
+		releaseJob := j.RepoOrg == "istio/release-builder" && j.Type == Postsubmit
 		// TODO: these shouldn't need grafana or docker, and they actually don't - the private cluster has empty secrets
-		privateReleaseJob := j.Repo == "istio-private/release-builder" && j.Type == Postsubmit
-		baseImageBuilder := ((j.Repo == "istio/istio" && j.Type == Postsubmit) || j.Type == Periodic) && j.BaseName() == "build-base-images"
+		privateReleaseJob := j.RepoOrg == "istio-private/release-builder" && j.Type == Postsubmit
+		baseImageBuilder := ((j.RepoOrg == "istio/istio" && j.Type == Postsubmit) || j.Type == Periodic) && j.BaseName() == "build-base-images"
 		if releaseJob || privateReleaseJob || baseImageBuilder {
 			return nil
 		}
@@ -119,26 +119,30 @@ func TestJobs(t *testing.T) {
 		return nil
 	})
 
-	// check to make sure we did not miss any volumes. This may just mean we need to update the test.
-	RunTest("known service accounts only", func(j Job) error {
-		if !AllServiceAccounts.Has(j.ServiceAccount()) {
+	RunTest("service accounts", func(j Job) error {
+		s, f := ServiceAccounts[j.ServiceAccount()]
+		if !f {
 			return fmt.Errorf("unknown service account: %q", j.ServiceAccount())
 		}
-		return nil
-	})
-	RunTest("presubmit jobs do not use privileged service accounts", func(j Job) error {
-		if j.Type != Presubmit {
+		switch s {
+		case LowPrivilege:
+			// Anyone can use low privilege accounts
 			return nil
+		case MediumPrivilege:
+			// Only proxy is allowed to run these jobs, which use RBE.
+			allowedJobs := j.Repo() == "proxy"
+			if !allowedJobs {
+				return fmt.Errorf("RBE account can only run in proxy repo: %v", j.Repo())
+			}
+		case HighPrivilege:
+			legacyJob := strings.HasPrefix(j.Name, "dry-run_release-builder")
+			if !legacyJob && j.Type == Presubmit {
+				return fmt.Errorf("privileged service accounts cannot run as presubmit")
+			}
+		default:
+			return fmt.Errorf("unknown sensitivity: %v", s)
 		}
-		// legacy
-		if strings.Contains(j.Name, "_proxy") ||
-			strings.HasPrefix(j.Name, "dry-run_release-builder") {
-			return nil
-		}
-		// Private volumes are handled in another test
-		if !LowPrivServiceAccounts.Has(j.ServiceAccount()) {
-			return fmt.Errorf("presubmit job using privileged service account: %q", j.ServiceAccount())
-		}
+
 		return nil
 	})
 	RunTest("private service account only used in private jobs", func(j Job) error {
@@ -270,20 +274,20 @@ func LoadJobs(t *testing.T) []Job {
 	for repo, repoJobs := range jc.PresubmitsStatic {
 		for _, job := range repoJobs {
 			jobs = append(jobs, Job{
-				Name: job.Name,
-				Repo: repo,
-				Type: Presubmit,
-				Base: job.JobBase,
+				Name:    job.Name,
+				RepoOrg: repo,
+				Type:    Presubmit,
+				Base:    job.JobBase,
 			})
 		}
 	}
 	for repo, repoJobs := range jc.PostsubmitsStatic {
 		for _, job := range repoJobs {
 			jobs = append(jobs, Job{
-				Name: job.Name,
-				Repo: repo,
-				Type: Postsubmit,
-				Base: job.JobBase,
+				Name:    job.Name,
+				RepoOrg: repo,
+				Type:    Postsubmit,
+				Base:    job.JobBase,
 			})
 		}
 	}
@@ -351,15 +355,20 @@ const (
 )
 
 type Job struct {
-	Name string
-	Repo string
-	Type JobType
-	Base config.JobBase
+	Name    string
+	RepoOrg string
+	Type    JobType
+	Base    config.JobBase
 }
 
 func (j Job) Org() string {
-	org, _, _ := strings.Cut(j.Repo, "/")
+	org, _, _ := strings.Cut(j.RepoOrg, "/")
 	return org
+}
+
+func (j Job) Repo() string {
+	_, repo, _ := strings.Cut(j.RepoOrg, "/")
+	return repo
 }
 
 func (j Job) BaseName() string {
@@ -415,19 +424,23 @@ func (j Job) ServiceAccount() string {
 	return j.Base.Spec.ServiceAccountName
 }
 
-var AllServiceAccounts = sets.NewString(
-	"",
-	"prow-deployer",
-	"testgrid-updater",
-	"prowjob-private-sa",
-	"prowjob-advanced-sa",
-	"prowjob-default-sa",
+type Sensitivity int
+
+const (
+	LowPrivilege Sensitivity = iota
+	MediumPrivilege
+	HighPrivilege
 )
 
-var LowPrivServiceAccounts = sets.NewString(
-	"", // Default is prowjob-default-sa
-	"prowjob-default-sa",
-)
+var ServiceAccounts = map[string]Sensitivity{
+	"":                    LowPrivilege, // Default is prowjob-default-sa
+	"prowjob-rbe":         MediumPrivilege,
+	"prowjob-default-sa":  LowPrivilege,
+	"prow-deployer":       HighPrivilege,
+	"testgrid-updater":    HighPrivilege,
+	"prowjob-private-sa":  LowPrivilege,
+	"prowjob-advanced-sa": HighPrivilege,
+}
 
 var PrivateServiceAccounts = sets.NewString(
 	"prowjob-private-sa",


### PR DESCRIPTION
Blocked by https://github.com/istio/test-infra/pull/4797, then will remove hold

Tested in https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_proxy/4738/test_proxy/1672019106187972608

This moves istio/proxy presubmit jobs over to a more fine-grained permission model. No changes are expected to the jobs.