### PR TITLE
jobs: drop github token on ref-docs-dry-run

### DIFF
--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -939,7 +939,6 @@ presubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=$AUTOMATOR_ORG
         - --repo=istio.io
-        - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
         env:
@@ -962,9 +961,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
@@ -973,8 +969,5 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
       .* )update-ref-docs-dry-run_istio.io,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
@@ -691,7 +691,6 @@ presubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio.io
-        - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
         env:
@@ -712,9 +711,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
@@ -723,8 +719,5 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
       .* )update-ref-docs-dry-run_istio.io_release-1.16,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.17.gen.yaml
@@ -691,7 +691,6 @@ presubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio.io
-        - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
         env:
@@ -712,9 +711,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
@@ -723,8 +719,5 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
       .* )update-ref-docs-dry-run_istio.io_release-1.17,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
@@ -815,7 +815,6 @@ presubmits:
         - ../test-infra/tools/automator/automator.sh
         - --org=istio
         - --repo=istio.io
-        - --token-path=/etc/github-token/oauth
         - --cmd=make update_ref_docs
         - --dry-run
         env:
@@ -836,9 +835,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
@@ -847,8 +843,5 @@ presubmits:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )update-ref-docs-dry-run,?($|\s.*))|((?m)^/test( |
       .* )update-ref-docs-dry-run_istio.io_release-1.18,?($|\s.*))

--- a/prow/config/jobs/istio.io-1.16.yaml
+++ b/prow/config/jobs/istio.io-1.16.yaml
@@ -841,7 +841,6 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio.io
-  - --token-path=/etc/github-token/oauth
   - --cmd=make update_ref_docs
   - --dry-run
   env:
@@ -965,8 +964,6 @@ jobs:
           secretName: rel-pipeline-docker-config
   requirements:
   - cache
-  - cache
-  - github
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/istio.io-1.17.yaml
+++ b/prow/config/jobs/istio.io-1.17.yaml
@@ -881,7 +881,6 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio.io
-  - --token-path=/etc/github-token/oauth
   - --cmd=make update_ref_docs
   - --dry-run
   image: gcr.io/istio-testing/build-tools:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
@@ -1012,8 +1011,6 @@ jobs:
           secretName: rel-pipeline-docker-config
   requirements:
   - cache
-  - cache
-  - github
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -1070,7 +1070,6 @@ jobs:
   - ../test-infra/tools/automator/automator.sh
   - --org=istio
   - --repo=istio.io
-  - --token-path=/etc/github-token/oauth
   - --cmd=make update_ref_docs
   - --dry-run
   modifiers:
@@ -1200,8 +1199,6 @@ jobs:
           secretName: rel-pipeline-docker-config
   requirements:
   - cache
-  - cache
-  - github
   resources_presets:
     6Gi:
       limits:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -47,10 +47,8 @@ jobs:
     - ../test-infra/tools/automator/automator.sh
     - --org=$AUTOMATOR_ORG
     - --repo=istio.io
-    - --token-path=/etc/github-token/oauth
     - --cmd=make update_ref_docs
     - --dry-run
-    requirements: [github]
     modifiers: [presubmit_optional]
     repos: [istio/test-infra@master]
     env:

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -86,7 +86,7 @@ func TestJobs(t *testing.T) {
 			return nil
 		}
 		// legacy
-		if strings.HasPrefix(j.Name, "release-notes") || strings.HasPrefix(j.Name, "update-ref-docs-dry-run") {
+		if strings.HasPrefix(j.Name, "release-notes") {
 			return nil
 		}
 		// Private volumes are handled in another test


### PR DESCRIPTION
It is a dry-run, no permissions needed

Testing manually in https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio.io/13439/update-ref-docs-dry-run_istio.io/1672305629571584000
