### PR TITLE
terraform: Add readonly github account and initial secrets

### DIFF
--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -43,11 +43,21 @@ module "prowjob_rbe_account" {
   source            = "../modules/workload-identity-service-account"
   project_id        = local.project_id
   name              = "prowjob-rbe"
-  description       = "Service account used for prow jobs requireing RBE access (istio/proxy)."
+  description       = "Service account used for prow jobs requiring RBE access (istio/proxy)."
   cluster_namespace = local.pod_namespace
   project_roles = [
     { role = "roles/remotebuildexecution.actionCacheWriter", project = "istio-testing" },
     { role = "roles/remotebuildexecution.artifactCreator", project = "istio-testing" },
   ]
   prowjob = true
+}
+
+# ProwJob SA used for jobs requiring GitHub API readonly access.
+module "prowjob_github_read_account" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "prowjob-github-read"
+  description       = "Service account used for prow jobs requiring GitHub read access."
+  cluster_namespace = local.pod_namespace
+  prowjob           = true
 }


### PR DESCRIPTION
Note: the secrets are populated out of band, this just gets the
placeholder and permissions setup.

The github account will be populated with a new read-only token. The
release only will be populated with the existing logins.
