### PR TITLE
Move release-notes job to fine scoped github token

### DIFF
--- a/infra/gcp/istio-prow-build/secrets.tf
+++ b/infra/gcp/istio-prow-build/secrets.tf
@@ -13,7 +13,7 @@ locals {
   # github_read_secret contains secrets for prowjob-github-read
   github_readonly_secret = [
     # Fine grained PAT in the Istio org, "github/release-notes/public-read-only". Has public access only.
-    "github-read_github_read"
+    "github-read_github_read" # Expires on 6/23/2024. TODO: find the best way to ensure this is noted.
   ]
 
   all_secrets = concat(
@@ -63,4 +63,5 @@ resource "google_secret_manager_secret_iam_policy" "github_readonly_access" {
   project     = local.project_id
   secret_id   = each.key
   policy_data = data.google_iam_policy.github_readonly_access.policy_data
+  depends_on  = [google_secret_manager_secret.secrets]
 }

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -35,5 +35,14 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: prowjob-rbe@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
-  # Service account that has permissions for RBE access. For use by istio/proxy
+  # Service account that has permissions for RBE access. For use by istio/proxy, currently.
   name: prowjob-rbe
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-github-read@istio-prow-build.iam.gserviceaccount.com
+  namespace: test-pods
+  # Service account that has permissions for GitHub read-only (public) access. For use by release-notes jobs, currently.
+  name: prowjob-github-read

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -253,11 +253,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:master-03285f22d0d1f21a8fa63b76aeac574e09c0c5d1
         name: ""
         resources:
@@ -273,18 +275,13 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
@@ -251,11 +251,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
         name: ""
         resources:
@@ -271,18 +273,13 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.16,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
@@ -251,11 +251,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
         name: ""
         resources:
@@ -271,18 +273,13 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.17,?($|\s.*))

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
@@ -251,11 +251,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
         name: ""
         resources:
@@ -271,18 +273,13 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_api_release-1.18,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -3942,11 +3942,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:master-03285f22d0d1f21a8fa63b76aeac574e09c0c5d1
         name: ""
         resources:
@@ -3965,20 +3967,15 @@ presubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio,?($|\s.*))
   - always_run: false
     annotations:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -3826,11 +3826,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
         name: ""
         resources:
@@ -3849,18 +3851,13 @@ presubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.16,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -3891,11 +3891,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
         name: ""
         resources:
@@ -3914,18 +3916,13 @@ presubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.17,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -3874,11 +3874,13 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ../test-infra/tools/check_release_notes.sh
-        - --token-path=/etc/github-token/oauth
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
         name: ""
         resources:
@@ -3897,18 +3899,13 @@ presubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/github-token
-          name: github
-          readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: github
-        secret:
-          secretName: oauth-token
     trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_istio_release-1.18,?($|\s.*))

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -143,3 +143,10 @@ requirement_presets:
     - name: rel-pipeline-docker-config
       secret:
         secretName: rel-pipeline-docker-config
+  github-readonly:
+    podSpec:
+      serviceAccountName: prowjob-github-read
+    secrets:
+      - secret: github-read_github_read
+        project: istio-prow-build
+        env: GH_TOKEN

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -397,8 +397,8 @@ jobs:
   types:
   - postsubmit
 - command:
+  - entrypoint
   - ../test-infra/tools/check_release_notes.sh
-  - --token-path=/etc/github-token/oauth
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
@@ -519,7 +519,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github
+  - github-readonly
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/api-1.17.yaml
+++ b/prow/config/jobs/api-1.17.yaml
@@ -416,8 +416,8 @@ jobs:
   types:
   - postsubmit
 - command:
+  - entrypoint
   - ../test-infra/tools/check_release_notes.sh
-  - --token-path=/etc/github-token/oauth
   image: gcr.io/istio-testing/build-tools:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
   modifiers:
   - presubmit_optional
@@ -545,7 +545,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github
+  - github-readonly
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -413,8 +413,8 @@ jobs:
   types:
   - postsubmit
 - command:
+  - entrypoint
   - ../test-infra/tools/check_release_notes.sh
-  - --token-path=/etc/github-token/oauth
   modifiers:
   - presubmit_optional
   name: release-notes
@@ -541,7 +541,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github
+  - github-readonly
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -31,7 +31,7 @@ jobs:
     types: [presubmit]
     modifiers: [presubmit_optional]
     command:
+      - entrypoint
       - ../test-infra/tools/check_release_notes.sh
-      - --token-path=/etc/github-token/oauth
-    requirements: [github]
+    requirements: [github-readonly]
     repos: [istio/test-infra@master,istio/tools@master]

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -5806,8 +5806,8 @@ jobs:
   types:
   - presubmit
 - command:
+  - entrypoint
   - ../test-infra/tools/check_release_notes.sh
-  - --token-path=/etc/github-token/oauth
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
@@ -5927,7 +5927,7 @@ jobs:
   - cache
   - cache
   - gocache
-  - github
+  - github-readonly
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -6251,8 +6251,8 @@ jobs:
   types:
   - presubmit
 - command:
+  - entrypoint
   - ../test-infra/tools/check_release_notes.sh
-  - --token-path=/etc/github-token/oauth
   image: gcr.io/istio-testing/build-tools:release-1.17-fd4e8747931dd1d3fa57f5a562e99420f079152b
   name: release-notes
   node_selector:
@@ -6379,7 +6379,7 @@ jobs:
   - cache
   - cache
   - gocache
-  - github
+  - github-readonly
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -5877,8 +5877,8 @@ jobs:
   types:
   - presubmit
 - command:
+  - entrypoint
   - ../test-infra/tools/check_release_notes.sh
-  - --token-path=/etc/github-token/oauth
   name: release-notes
   node_selector:
     testing: test-pool
@@ -6004,7 +6004,7 @@ jobs:
   - cache
   - cache
   - gocache
-  - github
+  - github-readonly
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -357,9 +357,9 @@ jobs:
   - name: release-notes
     types: [presubmit]
     command:
+      - entrypoint
       - ../test-infra/tools/check_release_notes.sh
-      - --token-path=/etc/github-token/oauth
-    requirements: [github]
+    requirements: [github-readonly]
     repos: [istio/test-infra@master,istio/tools@master]
 
   # Recreate base images if the dockerfile changes (in postsubmit)

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -85,10 +86,6 @@ func TestJobs(t *testing.T) {
 		if j.Type != Presubmit {
 			return nil
 		}
-		// legacy
-		if strings.HasPrefix(j.Name, "release-notes") {
-			return nil
-		}
 		// Private volumes are handled in another test
 		priv := j.Volumes().Difference(LowPrivilegeVolumes).Difference(PrivateVolumes)
 		if len(priv) == 0 {
@@ -129,11 +126,19 @@ func TestJobs(t *testing.T) {
 			// Anyone can use low privilege accounts
 			return nil
 		case MediumPrivilege:
-			// Only proxy is allowed to run these jobs, which use RBE.
-			allowedJobs := j.Repo() == "proxy"
-			if !allowedJobs {
-				return fmt.Errorf("RBE account can only run in proxy repo: %v", j.Repo())
+			// Postsubmit job can use
+			if j.Type != Presubmit {
+				return nil
 			}
+			// Only proxy is allowed to run these jobs, which use RBE.
+			if j.ServiceAccount() == "prowjob-rbe" && j.Repo() == "proxy" {
+				return nil
+			}
+			if j.ServiceAccount() == "prowjob-github-read" && strings.HasPrefix(j.Name, "release-notes") {
+				// Only release notes job is allowed
+				return nil
+			}
+			return fmt.Errorf("privileged service account %v cannot run as presubmit", j.ServiceAccount())
 		case HighPrivilege:
 			legacyJob := strings.HasPrefix(j.Name, "dry-run_release-builder")
 			if !legacyJob && j.Type == Presubmit {
@@ -223,7 +228,7 @@ func TestJobs(t *testing.T) {
 	})
 
 	RunTest("secret access", func(j Job) error {
-		secrets := false
+		secrets := sets.NewString()
 		hasEntrypoint := false
 		for _, c := range j.Base.Spec.Containers {
 			if len(c.Command) > 0 && c.Command[0] == "entrypoint" {
@@ -231,19 +236,27 @@ func TestJobs(t *testing.T) {
 			}
 			for _, e := range c.Env {
 				if e.Name == "GCP_SECRETS" {
-					secrets = true
+					gcpSecrets := []Secret{}
+					if err := json.Unmarshal([]byte(e.Value), &gcpSecrets); err != nil {
+						return err
+					}
+					for _, s := range gcpSecrets {
+						secrets.Insert(s.Project + "/" + s.Name)
+					}
 				}
 			}
 		}
-		if !secrets {
+		if secrets.Len() == 0 {
 			return nil
 		}
 
-		if j.Type == Presubmit {
-			return fmt.Errorf("jobs with secrets cannot be presubmits")
-		}
 		if !hasEntrypoint {
 			return fmt.Errorf("jobs with secrets must use entrypoint")
+		}
+		allowedSecret := strings.HasPrefix(j.Name, "release-notes") &&
+			sets.NewString("istio-prow-build/github-read_github_read").IsSuperset(secrets)
+		if !allowedSecret && j.Type == Presubmit {
+			return fmt.Errorf("jobs with secrets %v cannot be presubmits", secrets.UnsortedList())
 		}
 		return nil
 	})
@@ -435,6 +448,7 @@ const (
 var ServiceAccounts = map[string]Sensitivity{
 	"":                    LowPrivilege, // Default is prowjob-default-sa
 	"prowjob-rbe":         MediumPrivilege,
+	"prowjob-github-read": MediumPrivilege,
 	"prowjob-default-sa":  LowPrivilege,
 	"prow-deployer":       HighPrivilege,
 	"testgrid-updater":    HighPrivilege,
@@ -445,3 +459,9 @@ var ServiceAccounts = map[string]Sensitivity{
 var PrivateServiceAccounts = sets.NewString(
 	"prowjob-private-sa",
 )
+
+type Secret struct {
+	Name    string `json:"secret,omitempty"`
+	Project string `json:"project,omitempty"`
+	Env     string `json:"env,omitempty"`
+}


### PR DESCRIPTION
Tested with a manual run in https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/45630/release-notes_istio/1672369233444474880

There is also some changes to the testing to allow this job to have access to the Secret, and remove the allowance for it to have access to the github secret-mount