### PR TITLE
Fix some incorrect job tests

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -198,59 +198,6 @@ postsubmits:
     cluster: test-infra-trusted
     decorate: true
     max_concurrency: 1
-    name: push-prowbazel_test-infra_postsubmit
-    path_alias: istio.io/test-infra
-    run_if_changed: ^docker/prowbazel/Makefile$
-    spec:
-      automountServiceAccountToken: false
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - -C
-        - docker/prowbazel
-        - image
-        - push-safe
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        image: gcr.io/istio-testing/build-tools:master-03285f22d0d1f21a8fa63b76aeac574e09c0c5d1
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: "1"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /var/lib/docker
-          name: docker-root
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        prod: prow
-      serviceAccountName: prowjob-advanced-sa
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-      - emptyDir: {}
-        name: docker-root
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_test-infra_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    cluster: test-infra-trusted
-    decorate: true
-    max_concurrency: 1
     name: push-authentikos_test-infra_postsubmit
     path_alias: istio.io/test-infra
     run_if_changed: ^authentikos/Makefile$
@@ -278,9 +225,6 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -288,10 +232,6 @@ postsubmits:
         prod: prow
       serviceAccountName: prowjob-advanced-sa
       volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -330,9 +270,6 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -340,10 +277,6 @@ postsubmits:
         prod: prow
       serviceAccountName: prowjob-advanced-sa
       volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -382,9 +315,6 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -392,10 +322,6 @@ postsubmits:
         prod: prow
       serviceAccountName: prowjob-advanced-sa
       volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -80,15 +80,6 @@ postsubmits:
             memory: 3Gi
         securityContext:
           privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
 
 periodics:
 - interval: 5m

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -12,36 +12,6 @@ jobs:
   - name: gencheck
     command: [make, gen-check]
 
-# disable as it requires GOOGLE_AUTHENTICATION_CREDENTIALs which is no longer supported
-#  - name: integ-test-authentikos
-#    service_account_name: prowjob-advanced-sa
-#    types: [presubmit]
-#    # trigger on changes in `authentikos/` directory to the following:
-#    # - `test/`  : integration test library, scripts, and object configuration files.
-#    #              If there are changes to the tests themselves, run the modified tests.
-#    # - `.go`    : Golang source files. When the source code changes, test the validity of the change.
-#    # - `go.mod` : Golang module dependencies. When the dependencies change, test the compatibility of the change.
-#    regex: '^authentikos/(test/.+|.+\.go|go\.mod)$'
-#    command: [entrypoint, make, -C, authentikos, integ-test]
-#    requirements: [kind]
-
-  - name: push-prowbazel
-    service_account_name: prowjob-advanced-sa
-    types: [postsubmit]
-    regex: '^docker/prowbazel/Makefile$'
-    cluster: test-infra-trusted
-    max_concurrency: 1
-    command:
-    - entrypoint
-    - make
-    - -C
-    - docker/prowbazel
-    - image
-    - push-safe
-    requirements: [docker]
-    node_selector:
-        prod: prow
-
   - name: push-authentikos
     service_account_name: prowjob-advanced-sa
     types: [postsubmit]
@@ -55,6 +25,7 @@ jobs:
     - authentikos
     - deploy
     requirements: [docker]
+    excluded_requirements: [cache]
     node_selector:
       prod: prow
   
@@ -71,6 +42,7 @@ jobs:
     - tools/prowgen
     - deploy
     requirements: [docker]
+    excluded_requirements: [cache]
     node_selector:
       prod: prow
 
@@ -87,6 +59,7 @@ jobs:
     - tools/prowtrans
     - deploy
     requirements: [docker]
+    excluded_requirements: [cache]
     node_selector:
       prod: prow
 

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -40,7 +40,7 @@ func TestJobs(t *testing.T) {
 			}
 		case "istio":
 			if !PublicClusters.Has(j.Base.Cluster) {
-				return fmt.Errorf("periodic run on unexpected cluster: %v", j.Base.Cluster)
+				return fmt.Errorf("primary org must use a public cluster, got: %v", j.Base.Cluster)
 			}
 		default:
 			if j.Type != Periodic {
@@ -67,8 +67,8 @@ func TestJobs(t *testing.T) {
 		if j.Base.Cluster != "test-infra-trusted" {
 			return nil
 		}
-		if j.Type == Presubmit {
-			return fmt.Errorf("trusted jobs cannot run in presubmit")
+		if j.Volumes().Has(BuildCache) {
+			return fmt.Errorf("trusted jobs cannot use caches")
 		}
 		return nil
 	})


### PR DESCRIPTION
The test for no caching in trusted jobs (to avoid cache poisoning) was
copy+pasted from another test without actually checking what it meant
to.

A few jobs failed this new check. One of them was obsolete, so its
removed. Fixed the rest.
