### PR TITLE
jobs: fix proxy postsubmit

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -168,7 +168,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -218,7 +218,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -268,7 +268,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
@@ -104,7 +104,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -204,7 +204,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
@@ -104,7 +104,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -204,7 +204,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -104,7 +104,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -204,7 +204,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -41,7 +41,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -91,7 +91,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -141,7 +141,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -1078,7 +1078,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1220,7 +1220,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1353,7 +1353,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -1133,7 +1133,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1283,7 +1283,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1423,7 +1423,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -1127,7 +1127,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1276,7 +1276,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -1416,7 +1416,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -75,7 +75,7 @@ jobs:
   timeout: 4h
 
 - name: release
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
@@ -87,7 +87,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
@@ -98,7 +98,7 @@ jobs:
     testing: test-pool
 
 - name: release-centos
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-advanced-sa
   types: [postsubmit]
   command: [./prow/proxy-postsubmit-centos.sh]
   image: gcr.io/istio-testing/build-tools-centos:master-03285f22d0d1f21a8fa63b76aeac574e09c0c5d1


### PR DESCRIPTION
I meant to only change presubmit to the scoped SA. This partially
reverts the change so postsubmit has normal permissions.
