### PR TITLE
Move build clusters to dual ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,11 @@
 /prow/                               @istio/operations-maintainers
 /prow/config/                        @istio/wg-test-and-release-maintainers
 /prow/config/jobs/test-infra.yaml    @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+# Build clusters have dual ownership
+/prow/cluster/arm/                   @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+/prow/cluster/build/                 @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+/prow/cluster/private/               @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+/prow/cluster/private-arm/           @istio/wg-test-and-release-maintainers @istio/operations-maintainers
 /prow/cluster/jobs/                  @istio/wg-test-and-release-maintainers
 /prow/cluster/jobs/istio/test-infra/ @istio/wg-test-and-release-maintainers @istio/operations-maintainers
 /tools/prowtrans/                    @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Currently just operations. I think since the build clusters are owned by
Istio team, we can give T&R permissions
