### PR TITLE
terraform: Flesh out prowjob-release complete IAM

### DIFF
--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -29,13 +29,20 @@ resource "google_service_account" "prow_internal_storage" {
 # with extreme caution.
 # Do not use this for other purposes! Create a new, more scoped, account.
 # This is granted secret access in secrets.tf
+# This is granted KMS access in keys.tf
 module "prowjob_release_account" {
   source            = "../modules/workload-identity-service-account"
   project_id        = local.project_id
   name              = "prowjob-release"
   description       = "Service account used for prow release jobs. Highly privileged."
   cluster_namespace = local.pod_namespace
-  prowjob           = true
+  gcs_acls = [
+    { bucket = "istio-prerelease", role = "OWNER" },
+    { bucket = "istio-release", role = "OWNER" },
+    { bucket = "artifacts.istio-release.appspot.com", role = "OWNER" },
+    { bucket = "artifacts.istio-prerelease-testing.appspot.com", role = "OWNER" },
+  ]
+  prowjob = true
 }
 
 # ProwJob SA used for jobs requiring RBE access.
@@ -53,6 +60,7 @@ module "prowjob_rbe_account" {
 }
 
 # ProwJob SA used for jobs requiring GitHub API readonly access.
+# This is granted secret access in secrets.tf
 module "prowjob_github_read_account" {
   source            = "../modules/workload-identity-service-account"
   project_id        = local.project_id

--- a/infra/gcp/istio-prow-build/keys.tf
+++ b/infra/gcp/istio-prow-build/keys.tf
@@ -15,3 +15,18 @@ resource "google_kms_crypto_key" "istio_cosign_key" {
     protection_level = "SOFTWARE"
   }
 }
+
+# Only release job can use the keyring
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/cloudkms.signerVerifier"
+
+    members = [
+      "serviceAccount:${module.prowjob_release_account.email}",
+    ]
+  }
+}
+resource "google_kms_key_ring_iam_policy" "key_ring" {
+  key_ring_id = google_kms_key_ring.istio_cosign_keyring.id
+  policy_data = data.google_iam_policy.admin.policy_data
+}

--- a/infra/gcp/istio-prow-build/storage.tf
+++ b/infra/gcp/istio-prow-build/storage.tf
@@ -95,7 +95,6 @@ data "google_iam_policy" "istio_private_build" {
   binding {
     members = [
       "serviceAccount:istio-prow-test-job-private@istio-testing.iam.gserviceaccount.com",
-      "serviceAccount:prow-bot@istio-testing.iam.gserviceaccount.com",
       "serviceAccount:prow-control-plane@istio-testing.iam.gserviceaccount.com",
     ]
     role = "roles/storage.objectAdmin"

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -52,6 +52,14 @@ resource "google_project_iam_member" "project_roles" {
   role     = each.value.role
   member   = "serviceAccount:${google_service_account.serviceaccount.email}"
 }
+// optional: GCS ACLs to grant the serviceaccount on the project
+resource "google_storage_bucket_access_control" "acls" {
+  for_each = {for k, v in var.gcs_acls : k => v}
+  bucket = each.value.bucket
+  role   = each.value.role
+  entity = "serviceAccount:${google_service_account.serviceaccount.email}"
+}
+
 // If this is going to be used for prowjobs, then we need to give it access to gs://istio-prow to write logs.
 resource "google_storage_bucket_iam_member" "member" {
   count  = var.prowjob ? 1 : 0

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -62,6 +62,15 @@ variable "project_roles" {
   default = []
 }
 
+variable "gcs_acls" {
+  description = "A list of buckets to add ACLs for. Note: prefer using IAM for GCS; this is for legacy bucket configurations"
+  type        = list(object({
+    bucket = string
+    role = string
+  }))
+  default = []
+}
+
 variable "prowjob" {
   description = "Set to true if this service account will be used for prowjobs"
   type        = bool


### PR DESCRIPTION
This should make the prowjob-release 100% complete in terms of permissions

Permissions needed:

gcr.io/istio-prerelease-testing
gcr.io/istio-release

gs://istio-prerelease
gs://istio-release/releases

Secrets (already setup)
github: istio org
docker.io/istio
grafana


Plan:

```

  # google_kms_key_ring_iam_policy.key_ring will be created
  + resource "google_kms_key_ring_iam_policy" "key_ring" {
      + etag        = (known after apply)
      + id          = (known after apply)
      + key_ring_id = "projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring"
      + policy_data = jsonencode(
            {
              + bindings = [
                  + {
                      + members = [
                          + "serviceAccount:prowjob-release@istio-prow-build.iam.gserviceaccount.com",
                        ]
                      + role    = "roles/cloudkms.signerVerifier"
                    },
                ]
            }
        )
    }

  # module.prowjob_release_account.google_storage_bucket_access_control.acls["0"] will be created
  + resource "google_storage_bucket_access_control" "acls" {
      + bucket = "istio-prerelease"
      + domain = (known after apply)
      + email  = (known after apply)
      + entity = "serviceAccount:prowjob-release@istio-prow-build.iam.gserviceaccount.com"
      + id     = (known after apply)
      + role   = "OWNER"
    }

  # module.prowjob_release_account.google_storage_bucket_access_control.acls["1"] will be created
  + resource "google_storage_bucket_access_control" "acls" {
      + bucket = "istio-release"
      + domain = (known after apply)
      + email  = (known after apply)
      + entity = "serviceAccount:prowjob-release@istio-prow-build.iam.gserviceaccount.com"
      + id     = (known after apply)
      + role   = "OWNER"
    }

  # module.prowjob_release_account.google_storage_bucket_access_control.acls["2"] will be created
  + resource "google_storage_bucket_access_control" "acls" {
      + bucket = "artifacts.istio-release.appspot.com"
      + domain = (known after apply)
      + email  = (known after apply)
      + entity = "serviceAccount:prowjob-release@istio-prow-build.iam.gserviceaccount.com"
      + id     = (known after apply)
      + role   = "OWNER"
    }

  # module.prowjob_release_account.google_storage_bucket_access_control.acls["3"] will be created
  + resource "google_storage_bucket_access_control" "acls" {
      + bucket = "artifacts.istio-prerelease-testing.appspot.com"
      + domain = (known after apply)
      + email  = (known after apply)
      + entity = "serviceAccount:prowjob-release@istio-prow-build.iam.gserviceaccount.com"
      + id     = (known after apply)
      + role   = "OWNER"
    }
```