### PR TITLE
Ztunnel benches only run on demand

### DIFF
--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -231,7 +231,7 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )test,?($|\s.*))|((?m)^/test( | .* )test_ztunnel,?($|\s.*))
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_ztunnel
     branches:

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -10,7 +10,7 @@ jobs:
 
   - name: bench
     command: [./scripts/benchtest.sh]
-    modifiers: [presubmit_optional]
+    modifiers: [presubmit_optional, presubmit_skipped]
     requirements: [cratescache]
 
   - name: release


### PR DESCRIPTION
Fixes #4777 so that benchmark tests only run on demand