### PR TITLE
Benchmarking Ztunnel is a presubmit job

### DIFF
--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -52,49 +52,6 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
-    name: bench_ztunnel_postsubmit
-    path_alias: istio.io/ztunnel
-    spec:
-      automountServiceAccountToken: false
-      containers:
-      - command:
-        - ./scripts/benchtest.sh
-        env:
-        - name: BUILD_WITH_CONTAINER
-          value: "0"
-        image: gcr.io/istio-testing/build-tools:master-7c2cba5679671f40312e6324d270a0d70ad097d0
-        name: ""
-        resources:
-          limits:
-            cpu: "3"
-            memory: 24Gi
-          requests:
-            cpu: "1"
-            memory: 3Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
-        - mountPath: /home/.cargo
-          name: build-cache
-          subPath: cargo
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        testing: test-pool
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-  - annotations:
-      testgrid-alert-email: istio-oncall@googlegroups.com
-      testgrid-dashboards: istio_ztunnel_postsubmit
-      testgrid-num-failures-to-alert: "1"
-    branches:
-    - ^master$
-    decorate: true
     name: release_ztunnel_postsubmit
     path_alias: istio.io/ztunnel
     spec:

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -11,6 +11,7 @@ jobs:
   - name: bench
     command: [./scripts/benchtest.sh]
     modifiers: [presubmit_optional, presubmit_skipped]
+    types: [presubmit]
     requirements: [cratescache]
 
   - name: release


### PR DESCRIPTION
Should fix failing postsubmit CI on ztunnel by making benches presubmit only.