### PR TITLE
Fix service account name

### DIFF
--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: prowjob-github-istio-testing@istio-prow-build.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: prowjob-github-istio-testing-push@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
   # Service account that has permissions for GitHub from istio-testing account. Has permissions to push PRs. For use by automation
   # that creates PRs.

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -51,8 +51,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: prowjob-github-istio-testing-push@istio-prow-build.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: prowjob-github-istio-testing@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
   # Service account that has permissions for GitHub from istio-testing account. Has permissions to push PRs. For use by automation
   # that creates PRs.
-  name: prowjob-github-istio-testing-push
+  name: prowjob-github-istio-testing

--- a/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -136,7 +136,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
@@ -134,7 +134,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.17.gen.yaml
@@ -134,7 +134,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
@@ -134,7 +134,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -179,7 +179,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
@@ -177,7 +177,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.17.gen.yaml
@@ -177,7 +177,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
@@ -177,7 +177,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -95,7 +95,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -154,7 +154,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -213,7 +213,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -276,7 +276,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.16.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -150,7 +150,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -211,7 +211,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.17.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -150,7 +150,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -211,7 +211,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.18.gen.yaml
@@ -93,7 +93,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -150,7 +150,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -211,7 +211,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -54,7 +54,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -113,7 +113,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -124,7 +124,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -187,7 +187,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -2234,7 +2234,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -2299,7 +2299,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -121,7 +121,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -2212,7 +2212,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
@@ -217,7 +217,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.17.gen.yaml
@@ -217,7 +217,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
@@ -217,7 +217,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -56,7 +56,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: build-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -116,7 +116,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: build-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -325,7 +325,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
@@ -54,7 +54,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: build-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -261,7 +261,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
@@ -54,7 +54,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: build-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -261,7 +261,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -54,7 +54,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: build-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
@@ -261,7 +261,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
@@ -68,7 +68,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
@@ -68,7 +68,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
@@ -68,7 +68,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -56,7 +56,7 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing-push
+    serviceAccountName: prowjob-github-istio-testing
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -108,7 +108,7 @@ requirement_presets:
         project: istio-prow-build
         env: GH_TOKEN
   # Access to push GitHub from 'istio-testing' account.
-  github-istio-testing-push:
+  github-istio-testing:
     podSpec:
       serviceAccountName: prowjob-github-istio-testing
     secrets:

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -110,7 +110,7 @@ requirement_presets:
   # Access to push GitHub from 'istio-testing' account.
   github-istio-testing-push:
     podSpec:
-      serviceAccountName: prowjob-github-istio-testing-push
+      serviceAccountName: prowjob-github-istio-testing
     secrets:
       - secret: github_istio-testing_pusher
         project: istio-prow-build

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -386,7 +386,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/api-1.17.yaml
+++ b/prow/config/jobs/api-1.17.yaml
@@ -405,7 +405,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -402,7 +402,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/api.yaml
+++ b/prow/config/jobs/api.yaml
@@ -22,7 +22,7 @@ jobs:
     - --modifier=update_api_dep
     - --token-env
     - --cmd=go get istio.io/api@$AUTOMATOR_SHA && go mod tidy && make clean gen
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG

--- a/prow/config/jobs/client-go-1.16.yaml
+++ b/prow/config/jobs/client-go-1.16.yaml
@@ -514,7 +514,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/client-go-1.17.yaml
+++ b/prow/config/jobs/client-go-1.17.yaml
@@ -540,7 +540,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -536,7 +536,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/client-go.yaml
+++ b/prow/config/jobs/client-go.yaml
@@ -26,7 +26,7 @@ jobs:
     - --token-env
     - --git-exclude=^common/
     - --cmd=go get istio.io/client-go@$AUTOMATOR_SHA && go mod tidy && make clean gen
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG

--- a/prow/config/jobs/common-files-1.16.yaml
+++ b/prow/config/jobs/common-files-1.16.yaml
@@ -261,7 +261,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:
@@ -400,7 +400,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:
@@ -543,7 +543,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/common-files-1.17.yaml
+++ b/prow/config/jobs/common-files-1.17.yaml
@@ -273,7 +273,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:
@@ -419,7 +419,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:
@@ -569,7 +569,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/common-files-1.18.yaml
+++ b/prow/config/jobs/common-files-1.18.yaml
@@ -271,7 +271,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:
@@ -416,7 +416,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:
@@ -565,7 +565,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/common-files.yaml
+++ b/prow/config/jobs/common-files.yaml
@@ -20,7 +20,7 @@ jobs:
     - --modifier=commonfiles
     - --token-env
     - --cmd=make update-common && make gen
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG
@@ -40,7 +40,7 @@ jobs:
     - --modifier=commonfiles
     - --token-env
     - --cmd=make update-common && make gen
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG
@@ -59,7 +59,7 @@ jobs:
     - --modifier=commonfiles
     - --token-env
     - --cmd=make update-common && make gen
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG
@@ -82,7 +82,7 @@ jobs:
     - --
     - --post=make gen
     - --source=$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -6086,7 +6086,7 @@ jobs:
   - gocache
   - release
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -6546,7 +6546,7 @@ jobs:
   - gocache
   - release
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -6170,7 +6170,7 @@ jobs:
   - gocache
   - release
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     dedicated:
       limits:
@@ -6335,7 +6335,7 @@ jobs:
   - cache
   - cache
   - gocache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -70,7 +70,7 @@ jobs:
     - --modifier=refdocs
     - --token-env
     - --cmd=make update_ref_docs
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG
@@ -89,7 +89,7 @@ jobs:
     - --labels=release-notes-none
     - --token-env
     - --cmd=make update_test_reference
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -398,7 +398,7 @@ jobs:
     - --token-env
     - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make gen
     disable_release_branching: true
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG
@@ -417,7 +417,7 @@ jobs:
     - --modifier=update_ztunnel_dep
     - --token-env
     - --cmd=./bin/update_ztunnel.sh
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
     - name: AUTOMATOR_ORG

--- a/prow/config/jobs/pkg-1.16.yaml
+++ b/prow/config/jobs/pkg-1.16.yaml
@@ -639,7 +639,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/pkg-1.17.yaml
+++ b/prow/config/jobs/pkg-1.17.yaml
@@ -672,7 +672,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -667,7 +667,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     default:
       limits:

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -1485,7 +1485,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     arm:
       requests:
@@ -1629,7 +1629,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     arm:
       requests:

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -1562,7 +1562,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     arm:
       requests:
@@ -1713,7 +1713,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     arm:
       requests:

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -1555,7 +1555,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     arm:
       requests:
@@ -1706,7 +1706,7 @@ jobs:
   requirements:
   - cache
   - cache
-  - github-istio-testing-push
+  - github-istio-testing
   resources_presets:
     arm:
       requests:

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -117,7 +117,7 @@ jobs:
   - --token-env
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  requirements: [github-istio-testing-push]
+  requirements: [github-istio-testing]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-7c2cba5679671f40312e6324d270a0d70ad097d0
   env:
@@ -138,7 +138,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-env
   - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
-  requirements: [github-istio-testing-push]
+  requirements: [github-istio-testing]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-7c2cba5679671f40312e6324d270a0d70ad097d0
   env:
@@ -160,7 +160,7 @@ jobs:
   - --token-env
   - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy
   disable_release_branching: true
-  requirements: [github-istio-testing-push]
+  requirements: [github-istio-testing]
   repos: [istio/test-infra@master]
   image: gcr.io/istio-testing/build-tools:master-7c2cba5679671f40312e6324d270a0d70ad097d0
   env:

--- a/prow/config/jobs/release-builder-1.16.yaml
+++ b/prow/config/jobs/release-builder-1.16.yaml
@@ -1219,7 +1219,7 @@ jobs:
   - cache
   - release
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources: build
   resources_presets:
     build:

--- a/prow/config/jobs/release-builder-1.17.yaml
+++ b/prow/config/jobs/release-builder-1.17.yaml
@@ -1281,7 +1281,7 @@ jobs:
   - cache
   - release
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources: build
   resources_presets:
     build:

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -1272,7 +1272,7 @@ jobs:
   - cache
   - release
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources: build
   resources_presets:
     build:

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -28,7 +28,7 @@ jobs:
     excluded_requirements: [cache]
     node_selector:
       prod: prow
-  
+
   - name: push-prowgen
     service_account_name: prowjob-advanced-sa
     types: [postsubmit]
@@ -82,7 +82,7 @@ jobs:
     - --image=gcr.io/k8s-prow/.*
     - --tag=v[0-9]{8}-[a-f0-9]{10}
     - --var=image
-    requirements: [github-istio-testing-push]
+    requirements: [github-istio-testing]
     env:
     - name: AUTOMATOR_ORG
       value: istio

--- a/prow/config/jobs/tools-1.16.yaml
+++ b/prow/config/jobs/tools-1.16.yaml
@@ -671,7 +671,7 @@ jobs:
   - cache
   - cache
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources: build
   resources_presets:
     build:

--- a/prow/config/jobs/tools-1.17.yaml
+++ b/prow/config/jobs/tools-1.17.yaml
@@ -705,7 +705,7 @@ jobs:
   - cache
   - cache
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources: build
   resources_presets:
     build:

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -700,7 +700,7 @@ jobs:
   - cache
   - cache
   - docker
-  - github-istio-testing-push
+  - github-istio-testing
   resources: build
   resources_presets:
     build:

--- a/prow/config/jobs/tools.yaml
+++ b/prow/config/jobs/tools.yaml
@@ -32,7 +32,7 @@ jobs:
     - --script-path=../common-files/bin/create-buildtools-and-update.sh
     resources: build
     regex: 'docker/.+|cmd/.+|pkg/.+'
-    requirements: [docker, github-istio-testing-push]
+    requirements: [docker, github-istio-testing]
     repos: [istio/test-infra@master,istio/common-files@master]
     env:
     # For amd64, publish the manifest for arm64+amd64

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -118,7 +118,7 @@ func TestJobs(t *testing.T) {
 	RunTest("org volumes only used in org jobs", func(j Job) error {
 		orgJob := (j.RepoOrg == "istio/community" && j.Type == Postsubmit) ||
 			(j.Name == "ci-test-infra-branchprotector" && j.Type == Periodic) ||
-			// TODO: move these to use `github-istio-testing-push`
+			// TODO: move these to use `github-istio-testing`
 			(j.Name == "ci-prow-autobump" && j.Type == Periodic) ||
 			(j.Name == "ci-prow-autobump-for-auto-deploy" && j.Type == Periodic)
 		if orgJob {

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -460,16 +460,16 @@ const (
 )
 
 var ServiceAccounts = map[string]Sensitivity{
-	"":                                  LowPrivilege, // Default is prowjob-default-sa
-	"prowjob-default-sa":                LowPrivilege,
-	"prowjob-private-sa":                LowPrivilege,
-	"prowjob-rbe":                       MediumPrivilege,
-	"prowjob-github-read":               MediumPrivilege,
-	"prow-deployer":                     HighPrivilege,
-	"testgrid-updater":                  HighPrivilege,
-	"prowjob-advanced-sa":               HighPrivilege,
-	"prowjob-github-istio-testing-push": HighPrivilege,
-	"prowjob-release":                   HighPrivilege,
+	"":                             LowPrivilege, // Default is prowjob-default-sa
+	"prowjob-default-sa":           LowPrivilege,
+	"prowjob-private-sa":           LowPrivilege,
+	"prowjob-rbe":                  MediumPrivilege,
+	"prowjob-github-read":          MediumPrivilege,
+	"prow-deployer":                HighPrivilege,
+	"testgrid-updater":             HighPrivilege,
+	"prowjob-advanced-sa":          HighPrivilege,
+	"prowjob-github-istio-testing": HighPrivilege,
+	"prowjob-release":              HighPrivilege,
 }
 
 var PrivateServiceAccounts = sets.NewString(


### PR DESCRIPTION
Some jobs are failing with:
```
Init container initupload not ready: (state: terminated, reason: "Error", message: "ntity documentation:\\n\\thttps://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to\\n\\n` writer close error: Post \\\"https://storage.googleapis.com/upload/storage/v1/b/istio-prow/o?alt=json\\u0026name=logs%2Fupdate-ztunnel_istio_release-1.18_periodic%2F1673676152201285632%2Fstarted.json\\u0026prettyPrint=false\\u0026projection=full\\u0026uploadType=multipart\\\": compute: Received 403 `Unable to generate access token; IAM returned 403 Forbidden: Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).\\nThis error could be caused by a missing IAM policy binding on the target IAM service account.\\nFor more information, refer to the Workload Identity documentation:\\n\\thttps://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to\\n\\n`]\",\"file\":\"k8s.io/test-infra/prow/gcsupload/run.go:60\",\"func\":\"k8s.io/test-infra/prow/gcsupload.Options.Run\",\"level\":\"info\",\"msg\":\"Also failed to upload extra targets\",\"severity\":\"info\",\"time\":\"2023-06-27T12:55:34Z\"}\n{\"component\":\"initupload\",\"error\":\"failed to upload to blob storage: failed to upload to blob storage: encountered errors during upload: [writer close error: Post \\\"https://storage.googleapis.com/upload/storage/v1/b/istio-prow/o?alt=json\\u0026name=logs%2Fupdate-ztunnel_istio_release-1.18_periodic%2Flatest-build.txt\\u0026prettyPrint=false\\u0026projection=full\\u0026uploadType=multipart\\\": compute: Received 403 `Unable to generate access token; IAM returned 403 Forbidden: Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).\\nThis error could be caused by a missing IAM policy binding on the target IAM service account.\\nFor more information, refer to the Workload Identity documentation:\\n\\thttps://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to\\n\\n`]\",\"file\":\"k8s.io/test-infra/prow/cmd/initupload/main.go:45\",\"func\":\"main.main\",\"level\":\"fatal\",\"msg\":\"Failed to initialize job\",\"severity\":\"fatal\",\"time\":\"2023-06-27T12:55:34Z\"}\n") Init container place-entrypoint not ready: (state: waiting, reason: "PodInitializing", message: "")
```
They seem to be using `prowjob-github-istio-testing-push` and I notice a discrepancy in the gap-service-account name.

Not sure if this is the correct fix, but getting this out there.