### PR TITLE
automator: fix arg parsing

### DIFF
--- a/tools/automator/automator.sh
+++ b/tools/automator/automator.sh
@@ -103,7 +103,7 @@ get_opts() {
       tmp_token="$(mktemp -t token-XXXXXXXXXX)"
       echo "$token" >"$tmp_token"
       token_path="$tmp_token"
-      shift 2
+      shift
       ;;
     --merge-repository)
       merge_repository="$2"


### PR DESCRIPTION
Boolean flag doesn't shift 2
