### PR TITLE
release-builder: use files instead of env

### DIFF
--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -156,6 +156,8 @@ postsubmits:
           value: "0"
         - name: COSIGN_KEY
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
+        - name: DOCKER_CONFIG
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
         - name: GCS_BUCKET
           value: istio-private-prerelease/prerelease

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -245,8 +245,10 @@ postsubmits:
           value: "0"
         - name: COSIGN_KEY
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
+        - name: DOCKER_CONFIG
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
-          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","env":"DOCKER_CONFIG_DATA"},{"secret":"release_github_istio-release","project":"istio-prow-build","env":"GH_TOKEN"},{"secret":"release_grafana_istio","project":"istio-prow-build","env":"GRAFANA_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","env":"GH_TOKEN"},{"secret":"release_grafana_istio","project":"istio-prow-build","env":"GRAFANA_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:master-4c71169512fe79b59b89664ef1b273da813d1c93
         name: ""
         resources:
@@ -296,8 +298,10 @@ postsubmits:
           value: "0"
         - name: COSIGN_KEY
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
+        - name: DOCKER_CONFIG
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
-          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","env":"DOCKER_CONFIG_DATA"},{"secret":"release_github_istio-release","project":"istio-prow-build","env":"GH_TOKEN"},{"secret":"release_grafana_istio","project":"istio-prow-build","env":"GRAFANA_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","env":"GH_TOKEN"},{"secret":"release_grafana_istio","project":"istio-prow-build","env":"GRAFANA_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:master-4c71169512fe79b59b89664ef1b273da813d1c93
         name: ""
         resources:

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -133,10 +133,12 @@ requirement_presets:
     env:
     - name: COSIGN_KEY
       value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
+    - name: DOCKER_CONFIG
+      value: /var/run/ci/docker
     secrets:
       - secret: release_docker_istio
         project: istio-prow-build
-        env: DOCKER_CONFIG_DATA
+        file: /var/run/ci/docker/config.json
       - secret: release_github_istio-release
         project: istio-prow-build
         env: GH_TOKEN

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -497,4 +497,5 @@ type Secret struct {
 	Name    string `json:"secret,omitempty"`
 	Project string `json:"project,omitempty"`
 	Env     string `json:"env,omitempty"`
+	File    string `json:"file,omitempty"`
 }

--- a/tools/prowgen/pkg/spec/spec.go
+++ b/tools/prowgen/pkg/spec/spec.go
@@ -161,4 +161,5 @@ type Secret struct {
 	Name    string `json:"secret,omitempty"`
 	Project string `json:"project,omitempty"`
 	Env     string `json:"env,omitempty"`
+	File    string `json:"file,omitempty"`
 }


### PR DESCRIPTION
Env is a bit prone to leaking accidentally, such as
https://prow.istio.io/view/gs/istio-prow/logs/build-release_release-builder_postsubmit/1673714939367264256#

Needs https://github.com/istio/tools/pull/2541
