### PR TITLE
terraform: create new istio-prow-private GCP account

### DIFF
--- a/infra/gcp/istio-prow-private/ar.tf
+++ b/infra/gcp/istio-prow-private/ar.tf
@@ -1,0 +1,29 @@
+resource "google_artifact_registry_repository" "main" {
+  location      = "us"
+  repository_id = "istio-prow-private"
+  description   = "registry to host private Istio release artifacts"
+  format        = "DOCKER"
+
+  docker_config {
+    immutable_tags = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+data "google_iam_policy" "artifact_registry" {
+  binding {
+    role    = "roles/artifactregistry.createOnPushWriter"
+    members = [
+      "serviceAccount:${module.prowjob_private_account.email}",
+    ]
+  }
+}
+resource "google_artifact_registry_repository_iam_policy" "policy" {
+  project     = google_artifact_registry_repository.main.project
+  location    = google_artifact_registry_repository.main.location
+  repository  = google_artifact_registry_repository.main.name
+  policy_data = data.google_iam_policy.artifact_registry.policy_data
+}

--- a/infra/gcp/istio-prow-private/ar.tf
+++ b/infra/gcp/istio-prow-private/ar.tf
@@ -15,7 +15,7 @@ resource "google_artifact_registry_repository" "main" {
 
 data "google_iam_policy" "artifact_registry" {
   binding {
-    role    = "roles/artifactregistry.createOnPushWriter"
+    role = "roles/artifactregistry.createOnPushWriter"
     members = [
       "serviceAccount:${module.prowjob_private_account.email}",
     ]

--- a/infra/gcp/istio-prow-private/cluster.tf
+++ b/infra/gcp/istio-prow-private/cluster.tf
@@ -1,0 +1,76 @@
+module "prow_cluster" {
+  source       = "../modules/gke-cluster"
+  cluster_name = "prow"
+  project_name = local.project_id
+  # ARM node pools are (currently) only available here, so ensure we use this region.
+  cluster_location = "us-central1-f"
+}
+module "prow_node_test" {
+  source = "../modules/gke-nodepool"
+  name   = "test"
+
+  project_name = local.project_id
+  cluster_name = module.prow_cluster.cluster.name
+  location     = module.prow_cluster.cluster.location
+
+  machine_type  = "e2-standard-16"
+  initial_count = 1
+  min_count     = 1
+  max_count     = 15
+
+  disk_size_gb = 256
+  disk_type    = "pd-ssd"
+
+  service_account = module.prow_cluster.cluster_node_sa.email
+
+  labels = {
+    "testing" = "test-pool"
+  }
+}
+module "prow_node_build" {
+  source = "../modules/gke-nodepool"
+  name   = "build"
+
+  project_name = local.project_id
+  cluster_name = module.prow_cluster.cluster.name
+  location     = module.prow_cluster.cluster.location
+
+  machine_type  = "n1-highmem-64"
+  initial_count = 0
+  min_count     = 0
+  max_count     = 10
+
+  disk_size_gb = 2000
+  disk_type    = "pd-ssd"
+
+  service_account = module.prow_cluster.cluster_node_sa.email
+
+  labels = {
+    "testing" = "build-pool"
+  }
+}
+module "prow_node_arm" {
+  source = "../modules/gke-nodepool"
+  name   = "arm"
+
+  project_name = local.project_id
+  cluster_name = module.prow_cluster.cluster.name
+  location     = module.prow_cluster.cluster.location
+
+  machine_type  = "t2a-standard-16"
+  initial_count = 2
+  max_count     = 60
+  min_count     = 2
+
+  disk_size_gb = 256
+  disk_type    = "pd-ssd"
+
+  service_account = module.prow_cluster.cluster_node_sa.email
+
+  # GCP is only allowing non-trivial quotas for t2a nodes using spot instances, so enable spot instances.
+  spot = true
+
+  labels = {
+    "testing" = "test-pool"
+  }
+}

--- a/infra/gcp/istio-prow-private/cluster.tf
+++ b/infra/gcp/istio-prow-private/cluster.tf
@@ -1,9 +1,10 @@
 module "prow_cluster" {
-  source           = "../modules/gke-cluster"
-  cluster_name     = "prow"
-  project_name     = local.project_id
+  source       = "../modules/gke-cluster"
+  cluster_name = "prow"
+  project_name = local.project_id
   # ARM node pools are (currently) only available here, so ensure we use this region.
   cluster_location = "us-central1-f"
+  release_channel  = "REGULAR"
 }
 module "prow_node_test" {
   source = "../modules/gke-nodepool"

--- a/infra/gcp/istio-prow-private/cluster.tf
+++ b/infra/gcp/istio-prow-private/cluster.tf
@@ -1,7 +1,7 @@
 module "prow_cluster" {
-  source       = "../modules/gke-cluster"
-  cluster_name = "prow"
-  project_name = local.project_id
+  source           = "../modules/gke-cluster"
+  cluster_name     = "prow"
+  project_name     = local.project_id
   # ARM node pools are (currently) only available here, so ensure we use this region.
   cluster_location = "us-central1-f"
 }
@@ -22,6 +22,9 @@ module "prow_node_test" {
   disk_type    = "pd-ssd"
 
   service_account = module.prow_cluster.cluster_node_sa.email
+
+  # we don't use private infra much, so make it cheaper in return for slightly less stability
+  spot = true
 
   labels = {
     "testing" = "test-pool"
@@ -45,6 +48,9 @@ module "prow_node_build" {
 
   service_account = module.prow_cluster.cluster_node_sa.email
 
+  # we don't use private infra much, so make it cheaper in return for slightly less stability
+  spot = true
+
   labels = {
     "testing" = "build-pool"
   }
@@ -58,9 +64,9 @@ module "prow_node_arm" {
   location     = module.prow_cluster.cluster.location
 
   machine_type  = "t2a-standard-16"
-  initial_count = 2
-  max_count     = 60
-  min_count     = 2
+  initial_count = 0
+  min_count     = 0
+  max_count     = 6
 
   disk_size_gb = 256
   disk_type    = "pd-ssd"

--- a/infra/gcp/istio-prow-private/iam.tf
+++ b/infra/gcp/istio-prow-private/iam.tf
@@ -16,3 +16,14 @@ module "prowjob_private_account" {
   prowjob = true
   prowjob-bucket = "istio-prow-private"
 }
+
+resource "google_project_iam_member" "prow_control_wi" {
+  project        = local.project_id
+  role    = "roles/iam.workloadIdentityUser"
+  member  = "serviceAccount:prow-control-plane@istio-testing.iam.gserviceaccount.com"
+}
+resource "google_project_iam_member" "prow_control_gke" {
+  project        = local.project_id
+  role    = "roles/container.developer"
+  member  = "serviceAccount:prow-control-plane@istio-testing.iam.gserviceaccount.com"
+}

--- a/infra/gcp/istio-prow-private/iam.tf
+++ b/infra/gcp/istio-prow-private/iam.tf
@@ -13,17 +13,17 @@ module "prowjob_private_account" {
     { bucket = google_storage_bucket.istio_build_private.name, role = "roles/storage.objectAdmin" },
     { bucket = google_storage_bucket.istio_prerelease_private.name, role = "roles/storage.objectAdmin" },
   ]
-  prowjob = true
-  prowjob-bucket = "istio-prow-private"
+  prowjob        = true
+  prowjob_bucket = "istio-prow-private"
 }
 
 resource "google_project_iam_member" "prow_control_wi" {
-  project        = local.project_id
+  project = local.project_id
   role    = "roles/iam.workloadIdentityUser"
   member  = "serviceAccount:prow-control-plane@istio-testing.iam.gserviceaccount.com"
 }
 resource "google_project_iam_member" "prow_control_gke" {
-  project        = local.project_id
+  project = local.project_id
   role    = "roles/container.developer"
   member  = "serviceAccount:prow-control-plane@istio-testing.iam.gserviceaccount.com"
 }

--- a/infra/gcp/istio-prow-private/iam.tf
+++ b/infra/gcp/istio-prow-private/iam.tf
@@ -14,4 +14,5 @@ module "prowjob_private_account" {
     { bucket = google_storage_bucket.istio_prerelease_private.name, role = "roles/storage.objectAdmin" },
   ]
   prowjob = true
+  prowjob-bucket = "istio-prow-private"
 }

--- a/infra/gcp/istio-prow-private/iam.tf
+++ b/infra/gcp/istio-prow-private/iam.tf
@@ -1,0 +1,17 @@
+# Because private project is only for trusted individuals, we do not use fine-scoped service accounts.
+# Instead, everything runs as one service account with access to what we need.
+# Granted AR access in ar.tf.
+# RBE is not used in private cluster, so no permission needed there.
+# DockerHub, Grafana, and GitHub tokens are not used, so no secret access needed.
+module "prowjob_private_account" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "prowjob-private"
+  description       = "Service account that has permissions for all private jobs."
+  cluster_namespace = local.pod_namespace
+  gcs_iam = [
+    { bucket = google_storage_bucket.istio_build_private.name, role = "roles/storage.objectAdmin" },
+    { bucket = google_storage_bucket.istio_prerelease_private.name, role = "roles/storage.objectAdmin" },
+  ]
+  prowjob = true
+}

--- a/infra/gcp/istio-prow-private/main.tf
+++ b/infra/gcp/istio-prow-private/main.tf
@@ -1,0 +1,9 @@
+locals {
+  project_id     = "istio-prow-private"
+  project_number = "725673368965"
+
+  pod_namespace = "test-pods"
+}
+provider "google" {
+  project = local.project_id
+}

--- a/infra/gcp/istio-prow-private/providers.tf
+++ b/infra/gcp/istio-prow-private/providers.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "gcs" {
+    bucket = "istio-terraform"
+    prefix = "istio-prow-private" // project name
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.69.1"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.69.1"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/infra/gcp/istio-prow-private/services.tf
+++ b/infra/gcp/istio-prow-private/services.tf
@@ -1,0 +1,16 @@
+resource "google_project_service" "project" {
+  project = local.project_number
+
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "containerregistry.googleapis.com",
+    "iam.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "secretmanager.googleapis.com",
+  ])
+
+  service = each.key
+}

--- a/infra/gcp/istio-prow-private/storage.tf
+++ b/infra/gcp/istio-prow-private/storage.tf
@@ -1,0 +1,22 @@
+# Mirrors the gs://istio-build bucket
+resource "google_storage_bucket" "istio_build_private" {
+  name          = "istio-build-private"
+  location      = "US"
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+# Mirrors the gs://istio-prerelease bucket
+resource "google_storage_bucket" "istio_prerelease_private" {
+  name          = "istio-prerelease-private"
+  location      = "US"
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/gcp/istio-prow-private/storage.tf
+++ b/infra/gcp/istio-prow-private/storage.tf
@@ -20,3 +20,14 @@ resource "google_storage_bucket" "istio_prerelease_private" {
     prevent_destroy = true
   }
 }
+# Mirrors the gs://istio-prow bucket, which stores Prow logs
+resource "google_storage_bucket" "istio_prow_private" {
+  name          = "istio-prow-private"
+  location      = "US"
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/gcp/modules/gke-cluster/main.tf
+++ b/infra/gcp/modules/gke-cluster/main.tf
@@ -80,7 +80,7 @@ resource "google_container_cluster" "cluster" {
       disabled = false
     }
     network_policy_config {
-      disabled = false
+      disabled = true
     }
   }
 

--- a/infra/gcp/modules/gke-cluster/main.tf
+++ b/infra/gcp/modules/gke-cluster/main.tf
@@ -68,7 +68,7 @@ resource "google_container_cluster" "cluster" {
 
   // Enable GKE Network Policy
   network_policy {
-    enabled  = false
+    enabled = false
   }
 
   // Configure cluster addons

--- a/infra/gcp/modules/gke-cluster/outputs.tf
+++ b/infra/gcp/modules/gke-cluster/outputs.tf
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+output "cluster" {
+  description = "The cluster"
+  value       = google_container_cluster.cluster
+}
 
 output "cluster_node_sa" {
   description = "The service_account created for the cluster's nodes"

--- a/infra/gcp/modules/gke-nodepool/main.tf
+++ b/infra/gcp/modules/gke-nodepool/main.tf
@@ -17,9 +17,9 @@ limitations under the License.
 resource "google_container_node_pool" "node_pool" {
   name = var.name
 
-  project     = var.project_name
-  location    = var.location
-  cluster     = var.cluster_name
+  project  = var.project_name
+  location = var.location
+  cluster  = var.cluster_name
 
   // Auto repair, and auto upgrade nodes to match the master version
   management {
@@ -42,6 +42,7 @@ resource "google_container_node_pool" "node_pool" {
     disk_type    = var.disk_type
     labels       = var.labels
     taint        = var.taints
+    spot         = var.spot
 
     service_account = var.service_account
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -55,13 +56,16 @@ resource "google_container_node_pool" "node_pool" {
     }
   }
 
+
   // If we need to destroy the node pool, create the new one before destroying
   // the old one
   lifecycle {
     create_before_destroy = true
-    # https://www.terraform.io/docs/providers/google/r/container_cluster.html#taint
     ignore_changes = [
+      # https://www.terraform.io/docs/providers/google/r/container_cluster.html#taint
       node_config[0].taint,
+      # Terraform does not yet support this mode, so we have to just set it manually and ignore changes
+      node_config[0].linux_node_config,
     ]
   }
 }

--- a/infra/gcp/modules/gke-nodepool/variables.tf
+++ b/infra/gcp/modules/gke-nodepool/variables.tf
@@ -89,3 +89,9 @@ variable "service_account" {
   description = "The email address of the GCP Service Account to be associated with nodes in this node_pool"
   type        = string
 }
+
+variable "spot" {
+  description = "If true, spot instances should be used"
+  type        = bool
+  default     = false
+}

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -78,7 +78,7 @@ resource "google_secret_manager_secret_iam_member" "member" {
 // If this is going to be used for prowjobs, then we need to give it access to gs://istio-prow to write logs.
 resource "google_storage_bucket_iam_member" "member" {
   count  = var.prowjob ? 1 : 0
-  bucket = var.bucket
+  bucket = var.prowjob_bucket
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.serviceaccount.email}"
 }

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -78,7 +78,7 @@ resource "google_secret_manager_secret_iam_member" "member" {
 // If this is going to be used for prowjobs, then we need to give it access to gs://istio-prow to write logs.
 resource "google_storage_bucket_iam_member" "member" {
   count  = var.prowjob ? 1 : 0
-  bucket = "istio-prow"
+  bucket = var.bucket
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.serviceaccount.email}"
 }

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -93,3 +93,9 @@ variable "prowjob" {
   description = "Set to true if this service account will be used for prowjobs"
   type        = bool
 }
+
+variable "prowjob-bucket" {
+  description = "If 'prowjob' is true, which bucket to grant access to"
+  type        = string
+  default = "istio-prow"
+}

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -94,8 +94,8 @@ variable "prowjob" {
   type        = bool
 }
 
-variable "prowjob-bucket" {
+variable "prowjob_bucket" {
   description = "If 'prowjob' is true, which bucket to grant access to"
   type        = string
-  default = "istio-prow"
+  default     = "istio-prow"
 }

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -55,7 +55,7 @@ variable "cluster_namespace" {
 
 variable "project_roles" {
   description = "A list of roles to bind to the serviceaccount in its project"
-  type        = list(object({
+  type = list(object({
     role    = string
     project = optional(string)
   }))
@@ -64,7 +64,7 @@ variable "project_roles" {
 
 variable "secrets" {
   description = "A list of secrets to give access to the serviceaccount in its project"
-  type        = list(object({
+  type = list(object({
     name    = string
     project = optional(string)
   }))
@@ -73,9 +73,18 @@ variable "secrets" {
 
 variable "gcs_acls" {
   description = "A list of buckets to add ACLs for. Note: prefer using IAM for GCS; this is for legacy bucket configurations"
-  type        = list(object({
+  type = list(object({
     bucket = string
-    role = string
+    role   = string
+  }))
+  default = []
+}
+
+variable "gcs_iam" {
+  description = "A list of buckets to add IAM bindings for. Use gcs_acls for the legacy ACL config"
+  type = list(object({
+    bucket = string
+    role   = string
   }))
   default = []
 }


### PR DESCRIPTION
Contains https://github.com/istio/test-infra/pull/4838; PR will be smaller once that lands and I rebase.

Currently, our infra for private releases is tangled with istio-prow-build.

This is not great from an understanding perspective, security, etc.

This PR creates a new project from the ground up to replace the private components

The following build locations are changed:
* gcr.io/istio-prow-build => New Artifact Registry
* gs://istio-private-build => gs://istio-build-private
* gs://istio-private-prerelease => gs://istio-prerelease-private

There were a few others used in the old private process, but they are all obsolete and will not be carried forward.

GCP Secret access is not needed; this is only used for docker/grafana/github, which the private infra does not need. This is another benefit - I can say with confidence these are NOT used once we split this; today its much fuzzier.

RBE is disabled in private, so no permissions needed there.

Followups needeD:
* Point prow to the new cluster, of course
* Add humans to GCS reader access. Ideally a Google Group for PSWG, though.
* Manually set arm64 node pool to cgroupsv1, which terraform cannot handle currently.
* Grant prow control plane access to the cluster
* Setup the Kubernetes YAMLs for the cluster. This is just the namespace, service account, and release-deps.yaml (I think)

cc @jacob-delgado @stewartbutler @jjtischer @ericvn 