### PR TITLE
Manully update 1.18 build-tools image to latest

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -66,7 +66,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -103,7 +103,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -286,7 +286,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -412,7 +412,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -456,7 +456,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -502,7 +502,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -567,7 +567,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -632,7 +632,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -697,7 +697,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -764,7 +764,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.18.gen.yaml
@@ -29,7 +29,7 @@ postsubmits:
           value: istio-private-build/dev
         - name: HELM_BUCKET
           value: istio-private-build/dev/charts
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -136,7 +136,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -206,7 +206,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -280,7 +280,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -350,7 +350,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -494,7 +494,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -562,7 +562,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -630,7 +630,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -700,7 +700,7 @@ postsubmits:
           value: "0"
         - name: GRPC_ECHO_IMAGE
           value: grpctesting/istio_echo_cpp
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -770,7 +770,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -844,7 +844,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -918,7 +918,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -986,7 +986,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1056,7 +1056,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1130,7 +1130,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1202,7 +1202,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.ambient
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1270,7 +1270,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1346,7 +1346,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1422,7 +1422,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1498,7 +1498,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1572,7 +1572,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1646,7 +1646,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1720,7 +1720,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1794,7 +1794,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1868,7 +1868,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1940,7 +1940,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2011,7 +2011,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2064,7 +2064,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2145,7 +2145,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2196,7 +2196,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2253,7 +2253,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2307,7 +2307,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2378,7 +2378,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2451,7 +2451,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2528,7 +2528,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2602,7 +2602,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2677,7 +2677,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2752,7 +2752,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2823,7 +2823,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2895,7 +2895,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2968,7 +2968,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3046,7 +3046,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3124,7 +3124,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3196,7 +3196,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3269,7 +3269,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3347,7 +3347,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3423,7 +3423,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.ambient
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3494,7 +3494,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3570,7 +3570,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3640,7 +3640,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3692,7 +3692,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3743,7 +3743,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3799,7 +3799,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3855,7 +3855,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.18.gen.yaml
@@ -32,7 +32,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -90,7 +90,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           requests:
@@ -209,7 +209,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -262,7 +262,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -315,7 +315,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -368,7 +368,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -421,7 +421,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -475,7 +475,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ presubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           requests:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -107,7 +107,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -171,7 +171,7 @@ postsubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -245,7 +245,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -291,7 +291,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -337,7 +337,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -388,7 +388,7 @@ presubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -116,7 +116,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -249,7 +249,7 @@ presubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -203,7 +203,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -245,7 +245,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -287,7 +287,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -75,7 +75,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -132,7 +132,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.18.gen.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -103,7 +103,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -286,7 +286,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -410,7 +410,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -452,7 +452,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -496,7 +496,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -559,7 +559,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -622,7 +622,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -685,7 +685,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -750,7 +750,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -821,7 +821,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -22,7 +22,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+      image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
       name: ""
       resources:
         limits:
@@ -100,7 +100,7 @@ periodics:
         value: "0"
       - name: GCP_SECRETS
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-      image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+      image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
       name: ""
       resources:
         limits:
@@ -152,7 +152,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -249,7 +249,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -299,7 +299,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -344,7 +344,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -409,7 +409,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -478,7 +478,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -543,7 +543,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -610,7 +610,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -677,7 +677,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -741,7 +741,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -809,7 +809,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -872,7 +872,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -937,7 +937,7 @@ postsubmits:
           value: "0"
         - name: GRPC_ECHO_IMAGE
           value: grpctesting/istio_echo_cpp
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1002,7 +1002,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1071,7 +1071,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1140,7 +1140,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1203,7 +1203,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1268,7 +1268,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1337,7 +1337,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1404,7 +1404,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.ambient
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1467,7 +1467,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1538,7 +1538,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1609,7 +1609,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1680,7 +1680,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1749,7 +1749,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1818,7 +1818,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1887,7 +1887,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -1956,7 +1956,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2025,7 +2025,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2092,7 +2092,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2178,7 +2178,7 @@ postsubmits:
           value: /etc/service-account/rel-pipeline-service-account.json
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2257,7 +2257,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2307,7 +2307,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2356,7 +2356,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2406,7 +2406,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2453,7 +2453,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2517,7 +2517,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2583,7 +2583,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2653,7 +2653,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2720,7 +2720,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2788,7 +2788,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2856,7 +2856,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2921,7 +2921,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -2990,7 +2990,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3055,7 +3055,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3121,7 +3121,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3192,7 +3192,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3263,7 +3263,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3328,7 +3328,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3394,7 +3394,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3465,7 +3465,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3534,7 +3534,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.ambient
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3598,7 +3598,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3667,7 +3667,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3730,7 +3730,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3775,7 +3775,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3819,7 +3819,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -3868,7 +3868,7 @@ presubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -243,7 +243,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -327,7 +327,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -369,7 +369,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -36,7 +36,7 @@ periodics:
         value: "0"
       - name: GCP_SECRETS
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-      image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+      image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
       name: ""
       resources:
         limits:
@@ -82,7 +82,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -135,7 +135,7 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           requests:
@@ -184,7 +184,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -243,7 +243,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -420,7 +420,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -469,7 +469,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           requests:
@@ -515,7 +515,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-centos:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -560,7 +560,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
@@ -37,7 +37,7 @@ periodics:
         value: /etc/service-account/rel-pipeline-service-account.json
       - name: GCP_SECRETS
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-      image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+      image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
       name: ""
       resources:
         limits:
@@ -108,7 +108,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -190,7 +190,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -232,7 +232,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -367,7 +367,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -479,7 +479,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -521,7 +521,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -564,7 +564,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -611,7 +611,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -654,7 +654,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ postsubmits:
           value: arm64 amd64
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: MANIFEST_ARCH
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -307,7 +307,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -391,7 +391,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -477,7 +477,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -526,7 +526,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.18.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -63,7 +63,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -109,7 +109,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:
@@ -161,7 +161,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+        image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/common-files-1.18.yaml
+++ b/prow/config/jobs/common-files-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/enhancements-1.18.yaml
+++ b/prow/config/jobs/enhancements-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - architectures:
   - amd64

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools-proxy:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools-proxy:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -711,7 +711,7 @@ jobs:
   - presubmit
 - command:
   - ./prow/proxy-presubmit-centos-release.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+  image: gcr.io/istio-testing/build-tools-centos:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -1282,7 +1282,7 @@ jobs:
   - postsubmit
 - command:
   - ./prow/proxy-postsubmit-centos.sh
-  image: gcr.io/istio-testing/build-tools-centos:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+  image: gcr.io/istio-testing/build-tools-centos:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
   name: release-centos
   node_selector:
     testing: build-pool
@@ -1431,7 +1431,7 @@ jobs:
   - --token-env
   - --git-exclude=^common/
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
-  image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+  image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1581,7 +1581,7 @@ jobs:
   - --modifier=update_envoy_dep
   - --token-env
   - --cmd=UPDATE_BRANCH=release/v1.26 scripts/update_envoy.sh
-  image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+  image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make

--- a/prow/config/jobs/ztunnel-1.18.yaml
+++ b/prow/config/jobs/ztunnel-1.18.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.18-3ab47e21398bfdfb31e0ee3b7511f6028bc15973
+image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
 jobs:
 - command:
   - make


### PR DESCRIPTION
The 1.18 pipeline needs to have an image with new entry-point changes to fix the GH_TOKEN issue. The pipeline is blocked for automator jobs until this image is merged.