### PR TITLE
Various fixes to release builder

### DIFF
--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -25,10 +25,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /var/run/ci/docker
         - name: GCP_SECRETS
         - name: GCS_BUCKET
           value: istio-private-prerelease/prerelease

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2228,8 +2228,10 @@ postsubmits:
           value: "0"
         - name: VERSION
           value: master
+        - name: DOCKER_CONFIG
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
-          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","env":"DOCKER_CONFIG_DATA"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:master-4c71169512fe79b59b89664ef1b273da813d1c93
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -23,8 +23,10 @@ periodics:
         value: "0"
       - name: VERSION
         value: master
+      - name: DOCKER_CONFIG
+        value: /var/run/ci/docker
       - name: GCP_SECRETS
-        value: '[{"secret":"release_docker_istio","project":"istio-prow-build","env":"DOCKER_CONFIG_DATA"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+        value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       image: gcr.io/istio-testing/build-tools:master-4c71169512fe79b59b89664ef1b273da813d1c93
       name: ""
       resources:
@@ -243,12 +245,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /var/run/ci/docker
-        - name: GCP_SECRETS
-          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","env":"GH_TOKEN"},{"secret":"release_grafana_istio","project":"istio-prow-build","env":"GRAFANA_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:master-4c71169512fe79b59b89664ef1b273da813d1c93
         name: ""
         resources:
@@ -300,8 +296,12 @@ postsubmits:
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
           value: /var/run/ci/docker
+        - name: GRAFANA_TOKEN_FILE
+          value: /var/run/ci/grafana/token
+        - name: GITHUB_TOKEN_FILE
+          value: /var/run/ci/github/token
         - name: GCP_SECRETS
-          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","env":"GH_TOKEN"},{"secret":"release_grafana_istio","project":"istio-prow-build","env":"GRAFANA_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"}]'
         image: gcr.io/istio-testing/build-tools:master-4c71169512fe79b59b89664ef1b273da813d1c93
         name: ""
         resources:

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -117,31 +117,39 @@ requirement_presets:
         env: GH_TOKEN
   # build-base has access to push to dockerhub and to push as istio-testing github. Only for use with base image building
   build-base:
+    env:
+    - name: DOCKER_CONFIG
+      value: /var/run/ci/docker
     podSpec:
       serviceAccountName: prowjob-release
     secrets:
       - secret: release_docker_istio
         project: istio-prow-build
-        env: DOCKER_CONFIG_DATA
+        file: /var/run/ci/docker/config.json
       - secret: github_istio-testing_pusher # Note: This is NOT "release_github_istio-release", which is why this is separate from 'releae'
         project: istio-prow-build
         env: GH_TOKEN
   # release is used for release jobs. This is the most privileged type of job.
   release:
+    # For publish, we also need Grafana token, DockerHub token, and GitHub login
     podSpec:
       serviceAccountName: prowjob-release
     env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /var/run/ci/docker
+      - name: COSIGN_KEY
+        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
+      - name: DOCKER_CONFIG
+        value: /var/run/ci/docker
+      - name: GRAFANA_TOKEN_FILE
+        value: /var/run/ci/grafana/token
+      - name: GITHUB_TOKEN_FILE
+        value: /var/run/ci/github/token
     secrets:
       - secret: release_docker_istio
         project: istio-prow-build
         file: /var/run/ci/docker/config.json
       - secret: release_github_istio-release
         project: istio-prow-build
-        env: GH_TOKEN
+        file: /var/run/ci/github/token
       - secret: release_grafana_istio
         project: istio-prow-build
-        env: GRAFANA_TOKEN
+        file: /var/run/ci/grafana/token

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -35,8 +35,10 @@ jobs:
     types: [postsubmit]
     regex: '^release/trigger-build$'
     command: [entrypoint, release/build.sh]
-    requirements: [release, docker]
+    requirements: [docker]
     resources: build
+    # For build, we just need SA (giving GCS/GCR access)
+    service_account_name: prowjob-release
 
   - name: publish-release
     types: [postsubmit]


### PR DESCRIPTION
* Finalize move off of DOCKER_CONFIG_DATA, which is insecure. Note: this never leaked any secrets as we only had dummy values there
* Move things back to files for release-builder. The current logic is a bit tricky in release-builder, as passing the token also enables it. So while, for example, you can use `GRAFANA_TOKEN` env var, if the file is not set it will never be called: https://github.com/istio/release-builder/blob/80321ef75dc108106afc6fc190419eebb9d5e040/pkg/publish/cmd.go#L130-L152. We could fix it, but its easier to just go back to files
* Make only publish have most of the release credentials. This avoids issues like https://github.com/istio/release-builder/pull/1549 as a benefit, among other possible mistakes.