### PR TITLE
Manually update 1.16 build-tools image to latest

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.16.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -66,7 +66,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.16.gen.yaml
@@ -23,7 +23,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -84,7 +84,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -206,7 +206,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -306,7 +306,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -420,7 +420,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -485,7 +485,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -550,7 +550,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -613,7 +613,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -657,7 +657,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.16.gen.yaml
@@ -29,7 +29,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -96,7 +96,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -175,7 +175,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -245,7 +245,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -317,7 +317,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -385,7 +385,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -457,7 +457,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -533,7 +533,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -609,7 +609,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -685,7 +685,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -761,7 +761,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -837,7 +837,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -913,7 +913,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -989,7 +989,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1063,7 +1063,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1141,7 +1141,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1209,7 +1209,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1279,7 +1279,7 @@ postsubmits:
           value: "0"
         - name: GRPC_ECHO_IMAGE
           value: grpctesting/istio_echo_cpp
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1353,7 +1353,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1427,7 +1427,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1497,7 +1497,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1565,7 +1565,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1639,7 +1639,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1709,7 +1709,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1777,7 +1777,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1851,7 +1851,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1921,7 +1921,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1989,7 +1989,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2061,7 +2061,7 @@ postsubmits:
           value: istio-private-build/dev
         - name: HELM_BUCKET
           value: istio-private-build/dev/charts
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2118,7 +2118,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2176,7 +2176,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2228,7 +2228,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2282,7 +2282,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2333,7 +2333,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2391,7 +2391,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2461,7 +2461,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2539,7 +2539,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2612,7 +2612,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2687,7 +2687,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2758,7 +2758,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2833,7 +2833,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2904,7 +2904,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2982,7 +2982,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3060,7 +3060,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3134,7 +3134,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3206,7 +3206,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3283,7 +3283,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3357,7 +3357,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3429,7 +3429,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3506,7 +3506,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3580,7 +3580,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3651,7 +3651,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3721,7 +3721,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3772,7 +3772,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3831,7 +3831,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3892,7 +3892,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.16.gen.yaml
@@ -36,7 +36,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           requests:
@@ -96,7 +96,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-centos:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -151,7 +151,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -210,7 +210,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -267,7 +267,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-centos:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -328,7 +328,7 @@ presubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-private-build
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           requests:
@@ -383,7 +383,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -436,7 +436,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -489,7 +489,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -542,7 +542,7 @@ presubmits:
           value: envoy
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
@@ -42,7 +42,7 @@ postsubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -112,7 +112,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -155,7 +155,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -198,7 +198,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -250,7 +250,7 @@ presubmits:
           value: istio-private-build/dev/charts
         - name: PRERELEASE_DOCKER_HUB
           value: gcr.io/istio-prow-build
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -296,7 +296,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -342,7 +342,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -388,7 +388,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.16.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -116,7 +116,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -202,7 +202,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -249,7 +249,7 @@ presubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.16.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -159,7 +159,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -203,7 +203,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -245,7 +245,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -287,7 +287,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.16.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -75,7 +75,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -132,7 +132,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.16.gen.yaml
@@ -30,7 +30,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.16.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -103,7 +103,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -225,7 +225,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -391,7 +391,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -435,7 +435,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -498,7 +498,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -561,7 +561,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -626,7 +626,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -697,7 +697,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -22,7 +22,7 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
-      image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+      image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
       name: ""
       resources:
         limits:
@@ -91,7 +91,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -140,7 +140,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -188,7 +188,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -238,7 +238,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -283,7 +283,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -348,7 +348,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -417,7 +417,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -482,7 +482,7 @@ postsubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -549,7 +549,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -616,7 +616,7 @@ postsubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -680,7 +680,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -748,7 +748,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -811,7 +811,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -876,7 +876,7 @@ postsubmits:
           value: "0"
         - name: GRPC_ECHO_IMAGE
           value: grpctesting/istio_echo_cpp
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -941,7 +941,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1010,7 +1010,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1079,7 +1079,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1142,7 +1142,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1207,7 +1207,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1276,7 +1276,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1339,7 +1339,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1410,7 +1410,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1481,7 +1481,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1552,7 +1552,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1623,7 +1623,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1694,7 +1694,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1765,7 +1765,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1836,7 +1836,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1905,7 +1905,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -1978,7 +1978,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.retries=1 '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2047,7 +2047,7 @@ postsubmits:
           value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
         - name: TEST_SELECT
           value: -flaky
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2114,7 +2114,7 @@ postsubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2200,7 +2200,7 @@ postsubmits:
           value: /etc/service-account/rel-pipeline-service-account.json
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2279,7 +2279,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2329,7 +2329,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2378,7 +2378,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2428,7 +2428,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2475,7 +2475,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.enableCNI=true '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2539,7 +2539,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2605,7 +2605,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2675,7 +2675,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2742,7 +2742,7 @@ presubmits:
           value: "0"
         - name: VARIANT
           value: distroless
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2810,7 +2810,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2878,7 +2878,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -2943,7 +2943,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3012,7 +3012,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3077,7 +3077,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3143,7 +3143,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3214,7 +3214,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3285,7 +3285,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3350,7 +3350,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3416,7 +3416,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3487,7 +3487,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.skipVM
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3552,7 +3552,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3621,7 +3621,7 @@ presubmits:
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3684,7 +3684,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3729,7 +3729,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3773,7 +3773,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -3822,7 +3822,7 @@ presubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/pkg/istio.pkg.release-1.16.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -243,7 +243,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -327,7 +327,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -369,7 +369,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
@@ -36,7 +36,7 @@ periodics:
         value: "0"
       - name: GCP_SECRETS
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-      image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+      image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
       name: ""
       resources:
         limits:
@@ -82,7 +82,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -135,7 +135,7 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           requests:
@@ -184,7 +184,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-centos:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -243,7 +243,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -332,7 +332,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -420,7 +420,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -469,7 +469,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           requests:
@@ -515,7 +515,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-centos:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -560,7 +560,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
@@ -37,7 +37,7 @@ periodics:
         value: /etc/service-account/rel-pipeline-service-account.json
       - name: GCP_SECRETS
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-      image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+      image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
       name: ""
       resources:
         limits:
@@ -108,7 +108,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -149,7 +149,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -190,7 +190,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -232,7 +232,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -367,7 +367,7 @@ postsubmits:
           value: /etc/grafana/token
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/rel-pipeline-service-account.json
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -479,7 +479,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -521,7 +521,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -564,7 +564,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -611,7 +611,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -654,7 +654,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.16.gen.yaml
@@ -19,7 +19,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -60,7 +60,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -142,7 +142,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -204,7 +204,7 @@ postsubmits:
           value: arm64 amd64
         - name: GCP_SECRETS
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -254,7 +254,7 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: MANIFEST_ARCH
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -307,7 +307,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -349,7 +349,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -391,7 +391,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -477,7 +477,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:
@@ -526,7 +526,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+        image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build
   node_selector:
     testing: test-pool
@@ -139,7 +139,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -272,7 +272,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-api-dep-client-go
   node_selector:
     testing: test-pool
@@ -405,7 +405,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/config/jobs/client-go-1.16.yaml
+++ b/prow/config/jobs/client-go-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build
   node_selector:
     testing: test-pool
@@ -139,7 +139,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -265,7 +265,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -400,7 +400,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-client-go-dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/common-files-1.16.yaml
+++ b/prow/config/jobs/common-files-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -147,7 +147,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-common
   node_selector:
     testing: test-pool
@@ -286,7 +286,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -429,7 +429,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements-1.16.yaml
+++ b/prow/config/jobs/enhancements-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh
@@ -14,7 +14,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - architectures:
   - amd64
@@ -21,7 +21,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -168,7 +168,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release-test
   node_selector:
     testing: test-pool
@@ -318,7 +318,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release
   node_selector:
     testing: test-pool
@@ -470,7 +470,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -624,7 +624,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: benchmark-report
   node_selector:
     testing: test-pool
@@ -777,7 +777,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -927,7 +927,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -1077,7 +1077,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-telemetry-mc
   node_selector:
     testing: test-pool
@@ -1232,7 +1232,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
@@ -1383,7 +1383,7 @@ jobs:
     value: "0"
   - name: VARIANT
     value: distroless
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -1535,7 +1535,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-ipv6
   node_selector:
     testing: test-pool
@@ -1687,7 +1687,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: dual
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-ds
   node_selector:
     testing: test-pool
@@ -1837,7 +1837,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-basic
   node_selector:
     testing: test-pool
@@ -1985,7 +1985,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-operator-controller
   node_selector:
     testing: test-pool
@@ -2133,7 +2133,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -2283,7 +2283,7 @@ jobs:
     value: "0"
   - name: GRPC_ECHO_IMAGE
     value: grpctesting/istio_echo_cpp
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-pilot-cpp
   node_selector:
     testing: test-pool
@@ -2435,7 +2435,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -2590,7 +2590,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
@@ -2745,7 +2745,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
@@ -2894,7 +2894,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-security
   node_selector:
     testing: test-pool
@@ -3043,7 +3043,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -3195,7 +3195,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -3350,7 +3350,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-security-istiodremote
   node_selector:
     testing: test-pool
@@ -3499,7 +3499,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -3653,7 +3653,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-116
   node_selector:
     testing: test-pool
@@ -3810,7 +3810,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-117
   node_selector:
     testing: test-pool
@@ -3967,7 +3967,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-118
   node_selector:
     testing: test-pool
@@ -4124,7 +4124,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-119
   node_selector:
     testing: test-pool
@@ -4281,7 +4281,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-120
   node_selector:
     testing: test-pool
@@ -4438,7 +4438,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-121
   node_selector:
     testing: test-pool
@@ -4595,7 +4595,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-122
   node_selector:
     testing: test-pool
@@ -4750,7 +4750,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-k8s-123
   node_selector:
     testing: test-pool
@@ -4905,7 +4905,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - hidden
   name: integ-k8s-124
@@ -5062,7 +5062,7 @@ jobs:
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -5215,7 +5215,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -5366,7 +5366,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: analyze-tests
   node_selector:
     testing: test-pool
@@ -5514,7 +5514,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -5663,7 +5663,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -5813,7 +5813,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release-notes
   node_selector:
     testing: test-pool
@@ -5968,7 +5968,7 @@ jobs:
     value: "1.16"
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/istio.io-1.16.yaml
+++ b/prow/config/jobs/istio.io-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -146,7 +146,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -280,7 +280,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: doc.test.profile-default
   node_selector:
     testing: test-pool
@@ -416,7 +416,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: doc.test.profile-demo
   node_selector:
     testing: test-pool
@@ -552,7 +552,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: doc.test.profile-none
   node_selector:
     testing: test-pool
@@ -690,7 +690,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -829,7 +829,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/config/jobs/pkg-1.16.yaml
+++ b/prow/config/jobs/pkg-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build
   node_selector:
     testing: test-pool
@@ -139,7 +139,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -265,7 +265,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: test
   node_selector:
     testing: test-pool
@@ -391,7 +391,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -525,7 +525,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-pkg-dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -5,14 +5,14 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: test
   node_selector:
     testing: build-pool
@@ -145,7 +145,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: test-asan
   node_selector:
     testing: build-pool
@@ -278,7 +278,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: test-tsan
   node_selector:
     testing: build-pool
@@ -411,7 +411,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release-test
   node_selector:
     testing: build-pool
@@ -550,7 +550,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release-test
   node_selector:
     testing: test-pool
@@ -684,7 +684,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-centos:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release-centos-test
   node_selector:
     testing: build-pool
@@ -818,7 +818,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: check-wasm
   node_selector:
     testing: build-pool
@@ -953,7 +953,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release
   node_selector:
     testing: build-pool
@@ -1094,7 +1094,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release
   node_selector:
     testing: test-pool
@@ -1229,7 +1229,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-centos:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools-centos:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: release-centos
   node_selector:
     testing: build-pool
@@ -1371,7 +1371,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1514,7 +1514,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.16.yaml
+++ b/prow/config/jobs/release-builder-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -146,7 +146,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: test
   node_selector:
     testing: test-pool
@@ -279,7 +279,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -412,7 +412,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: dry-run
   node_selector:
     testing: test-pool
@@ -547,7 +547,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -684,7 +684,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -822,7 +822,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build-release
   node_selector:
     testing: test-pool
@@ -961,7 +961,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: publish-release
   node_selector:
     testing: test-pool
@@ -1105,7 +1105,7 @@ jobs:
     value: "true"
   - name: VERSION
     value: "1.16"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/tools-1.16.yaml
+++ b/prow/config/jobs/tools-1.16.yaml
@@ -5,7 +5,7 @@ env:
   value: "0"
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: build
   node_selector:
     testing: test-pool
@@ -146,7 +146,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: lint
   node_selector:
     testing: test-pool
@@ -279,7 +279,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: test
   node_selector:
     testing: test-pool
@@ -412,7 +412,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: gencheck
   node_selector:
     testing: test-pool
@@ -554,7 +554,7 @@ jobs:
     value: "0"
   - name: MANIFEST_ARCH
     value: arm64 amd64
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: containers
   node_selector:
     testing: test-pool
@@ -701,7 +701,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   - name: MANIFEST_ARCH
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: containers
   node_selector:
     testing: test-pool
@@ -841,7 +841,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: containers-test
   node_selector:
     testing: test-pool
@@ -982,7 +982,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.16-370cc29a6684396492862c9bc6bc00c202835e0b
+  image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
   name: containers-test
   node_selector:
     testing: test-pool


### PR DESCRIPTION
Manually update the build-tools image so that the pimple can use the image for automation tests which are currently failing.