### PR TITLE
Infra: give KMS viewer permission

### DIFF
--- a/infra/gcp/istio-prow-build/keys.tf
+++ b/infra/gcp/istio-prow-build/keys.tf
@@ -19,11 +19,12 @@ resource "google_kms_crypto_key" "istio_cosign_key" {
 # Only release job can use the keyring
 data "google_iam_policy" "admin" {
   binding {
-    role = "roles/cloudkms.signerVerifier"
-
-    members = [
-      "serviceAccount:${module.prowjob_release_account.email}",
-    ]
+    role    = "roles/cloudkms.signerVerifier"
+    members = ["serviceAccount:${module.prowjob_release_account.email}", ]
+  }
+  binding {
+    role    = "roles/cloudkms.viewer"
+    members = ["serviceAccount:${module.prowjob_release_account.email}", ]
   }
 }
 resource "google_kms_key_ring_iam_policy" "key_ring" {

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -61,7 +61,7 @@ resource "google_storage_bucket_access_control" "acls" {
 }
 // optional: GCS IAM grants access to the serviceaccount on the project
 resource "google_storage_bucket_iam_member" "gcs_member" {
-  for_each = { for k, v in var.gcs_acls : k => v }
+  for_each = { for k, v in var.gcs_iam : k => v }
   bucket   = each.value.bucket
   role     = each.value.role
   member   = "serviceAccount:${google_service_account.serviceaccount.email}"


### PR DESCRIPTION
This is needed for `cosign public-key`