### PR TITLE
Sync old branches with new changes in release-builder

### DIFF
--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
@@ -19,16 +19,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
         - name: GCP_SECRETS
         - name: GCS_BUCKET
           value: istio-prerelease-private/prerelease
@@ -58,17 +48,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -78,23 +57,12 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
       - name: netrc

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.16.gen.yaml
@@ -57,7 +57,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-private-sa
+      serviceAccountName: prowjob-private
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
@@ -19,16 +19,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
         - name: GCP_SECRETS
         - name: GCS_BUCKET
           value: istio-prerelease-private/prerelease
@@ -58,17 +48,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -78,23 +57,12 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
       - name: netrc

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
@@ -57,7 +57,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-private-sa
+      serviceAccountName: prowjob-private
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
@@ -19,16 +19,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
         - name: GCP_SECRETS
         - name: GCS_BUCKET
           value: istio-prerelease-private/prerelease
@@ -58,17 +48,6 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -78,23 +57,12 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-private-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
       - name: netrc

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
@@ -57,7 +57,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-private-sa
+      serviceAccountName: prowjob-private
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2224,6 +2224,8 @@ postsubmits:
         - entrypoint
         - ../release-builder/release/build-base-images.sh
         env:
+        - name: ALWAYS_GENERATE_BASE_IMAGE
+          value: "true"
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: VERSION

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -2178,28 +2178,18 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - ../release-builder/release/build.sh
+        - ../release-builder/release/build-base-images.sh
         env:
         - name: ALWAYS_GENERATE_BASE_IMAGE
-          value: "true"
-        - name: BUILD_BASE_IMAGES
           value: "true"
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: VERSION
           value: "1.16"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
-          value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
@@ -2218,40 +2208,17 @@ postsubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -2243,28 +2243,18 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - ../release-builder/release/build.sh
+        - ../release-builder/release/build-base-images.sh
         env:
         - name: ALWAYS_GENERATE_BASE_IMAGE
-          value: "true"
-        - name: BUILD_BASE_IMAGES
           value: "true"
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: VERSION
           value: release-1.17
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
-          value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.17-23e3713f79cb748106e9b407dcff8d7d3546cbea
         name: ""
         resources:
@@ -2283,40 +2273,17 @@ postsubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -2156,28 +2156,18 @@ postsubmits:
       containers:
       - command:
         - entrypoint
-        - ../release-builder/release/build.sh
+        - ../release-builder/release/build-base-images.sh
         env:
         - name: ALWAYS_GENERATE_BASE_IMAGE
-          value: "true"
-        - name: BUILD_BASE_IMAGES
           value: "true"
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: VERSION
           value: release-1.18
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
+          value: /var/run/ci/docker
         - name: GCP_SECRETS
-          value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
@@ -2196,40 +2186,17 @@ postsubmits:
         - mountPath: /gocache
           name: build-cache
           subPath: gocache
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-github-istio-testing
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.16.gen.yaml
@@ -17,26 +17,16 @@ periodics:
     containers:
     - command:
       - entrypoint
-      - release/build.sh
+      - release/build-base-images.sh
       env:
-      - name: BUILD_BASE_IMAGES
-        value: "true"
       - name: BUILD_WITH_CONTAINER
         value: "0"
       - name: VERSION
         value: "1.16"
-      - name: COSIGN_KEY
-        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
+        value: /var/run/ci/docker
       - name: GCP_SECRETS
-        value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+        value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
       name: ""
       resources:
@@ -52,40 +42,17 @@ periodics:
       - mountPath: /home/prow/go/pkg
         name: build-cache
         subPath: gomod
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing
+    serviceAccountName: prowjob-release
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
         type: DirectoryOrCreate
       name: build-cache
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
     - emptyDir: {}
       name: docker-root
 postsubmits:
@@ -278,16 +245,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
         image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
@@ -303,39 +260,17 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -360,13 +295,13 @@ postsubmits:
         - name: COSIGN_KEY
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
+          value: /var/run/ci/docker
         - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
+          value: /var/run/ci/grafana/token
+        - name: GITHUB_TOKEN_FILE
+          value: /var/run/ci/github/token
+        - name: GCP_SECRETS
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"}]'
         image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
         name: ""
         resources:
@@ -382,39 +317,17 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.17.gen.yaml
@@ -17,26 +17,16 @@ periodics:
     containers:
     - command:
       - entrypoint
-      - release/build.sh
+      - release/build-base-images.sh
       env:
-      - name: BUILD_BASE_IMAGES
-        value: "true"
       - name: BUILD_WITH_CONTAINER
         value: "0"
       - name: VERSION
         value: "1.17"
-      - name: COSIGN_KEY
-        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
+        value: /var/run/ci/docker
       - name: GCP_SECRETS
-        value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+        value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       image: gcr.io/istio-testing/build-tools:release-1.17-23e3713f79cb748106e9b407dcff8d7d3546cbea
       name: ""
       resources:
@@ -52,40 +42,17 @@ periodics:
       - mountPath: /home/prow/go/pkg
         name: build-cache
         subPath: gomod
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing
+    serviceAccountName: prowjob-release
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
         type: DirectoryOrCreate
       name: build-cache
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
     - emptyDir: {}
       name: docker-root
 postsubmits:
@@ -278,16 +245,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
         image: gcr.io/istio-testing/build-tools:release-1.17-23e3713f79cb748106e9b407dcff8d7d3546cbea
         name: ""
         resources:
@@ -303,39 +260,17 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -360,13 +295,13 @@ postsubmits:
         - name: COSIGN_KEY
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
+          value: /var/run/ci/docker
         - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
+          value: /var/run/ci/grafana/token
+        - name: GITHUB_TOKEN_FILE
+          value: /var/run/ci/github/token
+        - name: GCP_SECRETS
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"}]'
         image: gcr.io/istio-testing/build-tools:release-1.17-23e3713f79cb748106e9b407dcff8d7d3546cbea
         name: ""
         resources:
@@ -382,39 +317,17 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.18.gen.yaml
@@ -17,26 +17,16 @@ periodics:
     containers:
     - command:
       - entrypoint
-      - release/build.sh
+      - release/build-base-images.sh
       env:
-      - name: BUILD_BASE_IMAGES
-        value: "true"
       - name: BUILD_WITH_CONTAINER
         value: "0"
       - name: VERSION
         value: "1.18"
-      - name: COSIGN_KEY
-        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
       - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
+        value: /var/run/ci/docker
       - name: GCP_SECRETS
-        value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
+        value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
       name: ""
       resources:
@@ -52,40 +42,17 @@ periodics:
       - mountPath: /home/prow/go/pkg
         name: build-cache
         subPath: gomod
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
     nodeSelector:
       kubernetes.io/arch: amd64
       testing: test-pool
-    serviceAccountName: prowjob-github-istio-testing
+    serviceAccountName: prowjob-release
     volumes:
     - hostPath:
         path: /var/tmp/prow/cache
         type: DirectoryOrCreate
       name: build-cache
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
     - emptyDir: {}
       name: docker-root
 postsubmits:
@@ -278,16 +245,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: COSIGN_KEY
-          value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
-        - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
-        - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
         image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
@@ -303,39 +260,17 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -360,13 +295,13 @@ postsubmits:
         - name: COSIGN_KEY
           value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
         - name: DOCKER_CONFIG
-          value: /etc/rel-pipeline-docker-config
-        - name: GITHUB_TOKEN_FILE
-          value: /etc/github/rel-pipeline-github
+          value: /var/run/ci/docker
         - name: GRAFANA_TOKEN_FILE
-          value: /etc/grafana/token
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/rel-pipeline-service-account.json
+          value: /var/run/ci/grafana/token
+        - name: GITHUB_TOKEN_FILE
+          value: /var/run/ci/github/token
+        - name: GCP_SECRETS
+          value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"}]'
         image: gcr.io/istio-testing/build-tools:release-1.18-fca3cc9d04eba433bb39c0a48492f3477a2d5a03
         name: ""
         resources:
@@ -382,39 +317,17 @@ postsubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /etc/rel-pipeline-docker-config
-          name: rel-pipeline-docker-config
-        - mountPath: /etc/github
-          name: rel-pipeline-github
-          readOnly: true
-        - mountPath: /etc/grafana
-          name: rel-pipeline-grafana
-          readOnly: true
-        - mountPath: /etc/service-account
-          name: rel-pipeline-service-account
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-release
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
           type: DirectoryOrCreate
         name: build-cache
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -5958,12 +5958,10 @@ jobs:
   - presubmit
 - command:
   - entrypoint
-  - ../release-builder/release/build.sh
+  - ../release-builder/release/build-base-images.sh
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  - name: BUILD_BASE_IMAGES
-    value: "true"
   - name: VERSION
     value: "1.16"
   - name: ALWAYS_GENERATE_BASE_IMAGE
@@ -6084,9 +6082,8 @@ jobs:
   - cache
   - cache
   - gocache
-  - release
+  - build-base
   - docker
-  - github-istio-testing
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -6410,10 +6410,8 @@ jobs:
   - presubmit
 - command:
   - entrypoint
-  - ../release-builder/release/build.sh
+  - ../release-builder/release/build-base-images.sh
   env:
-  - name: BUILD_BASE_IMAGES
-    value: "true"
   - name: VERSION
     value: release-1.17
   - name: ALWAYS_GENERATE_BASE_IMAGE
@@ -6544,9 +6542,8 @@ jobs:
   - cache
   - cache
   - gocache
-  - release
+  - build-base
   - docker
-  - github-istio-testing
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -6035,10 +6035,8 @@ jobs:
   - presubmit
 - command:
   - entrypoint
-  - ../release-builder/release/build.sh
+  - ../release-builder/release/build-base-images.sh
   env:
-  - name: BUILD_BASE_IMAGES
-    value: "true"
   - name: VERSION
     value: release-1.18
   - name: ALWAYS_GENERATE_BASE_IMAGE
@@ -6168,9 +6166,8 @@ jobs:
   - cache
   - cache
   - gocache
-  - release
+  - build-base
   - docker
-  - github-istio-testing
   resources_presets:
     dedicated:
       limits:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -371,6 +371,8 @@ jobs:
     env:
     - name: VERSION
       value: "master"
+    - name: ALWAYS_GENERATE_BASE_IMAGE
+      value: "true"
     command: [entrypoint, ../release-builder/release/build-base-images.sh]
     requirements: [build-base, docker]
 

--- a/prow/config/jobs/release-builder-1.16.yaml
+++ b/prow/config/jobs/release-builder-1.16.yaml
@@ -932,10 +932,10 @@ jobs:
       - name: rel-pipeline-docker-config
         secret:
           secretName: rel-pipeline-docker-config
+  service_account_name: prowjob-release
   requirements:
   - cache
   - cache
-  - release
   - docker
   resources: build
   resources_presets:
@@ -1034,43 +1034,6 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
   requirements:
   - cache
   - cache
@@ -1096,13 +1059,11 @@ jobs:
   - postsubmit
 - command:
   - entrypoint
-  - release/build.sh
+  - release/build-base-images.sh
   cron: 0 19 * * *
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  - name: BUILD_BASE_IMAGES
-    value: "true"
   - name: VERSION
     value: "1.16"
   image: gcr.io/istio-testing/build-tools:release-1.16-04bff0a4819cdfd500eb7817ed686f10c30b4456
@@ -1217,9 +1178,8 @@ jobs:
   requirements:
   - cache
   - cache
-  - release
+  - build-base
   - docker
-  - github-istio-testing
   resources: build
   resources_presets:
     build:
@@ -1310,43 +1270,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/release-builder-1.17.yaml
+++ b/prow/config/jobs/release-builder-1.17.yaml
@@ -979,10 +979,10 @@ jobs:
       - name: rel-pipeline-docker-config
         secret:
           secretName: rel-pipeline-docker-config
+  service_account_name: prowjob-release
   requirements:
   - cache
   - cache
-  - release
   - docker
   resources: build
   resources_presets:
@@ -1088,43 +1088,6 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
   requirements:
   - cache
   - cache
@@ -1150,11 +1113,9 @@ jobs:
   - postsubmit
 - command:
   - entrypoint
-  - release/build.sh
+  - release/build-base-images.sh
   cron: 0 19 * * *
   env:
-  - name: BUILD_BASE_IMAGES
-    value: "true"
   - name: VERSION
     value: "1.17"
   image: gcr.io/istio-testing/build-tools:release-1.17-23e3713f79cb748106e9b407dcff8d7d3546cbea
@@ -1279,9 +1240,8 @@ jobs:
   requirements:
   - cache
   - cache
-  - release
+  - build-base
   - docker
-  - github-istio-testing
   resources: build
   resources_presets:
     build:
@@ -1382,43 +1342,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -972,10 +972,10 @@ jobs:
       - name: rel-pipeline-docker-config
         secret:
           secretName: rel-pipeline-docker-config
+  service_account_name: prowjob-release
   requirements:
   - cache
   - cache
-  - release
   - docker
   resources: build
   resources_presets:
@@ -1002,121 +1002,6 @@ jobs:
   node_selector:
     testing: test-pool
   regex: ^release/trigger-publish$
-  requirement_presets:
-    cache:
-      volumeMounts:
-      - mountPath: /home/prow/go/pkg
-        name: build-cache
-        subPath: gomod
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-    cratescache:
-      volumeMounts:
-      - mountPath: /home/.cargo
-        name: build-cache
-        subPath: cargo
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-    docker:
-      volumeMounts:
-      - mountPath: /var/lib/docker
-        name: docker-root
-      volumes:
-      - emptyDir: {}
-        name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
-    gocache:
-      volumeMounts:
-      - mountPath: /gocache
-        name: build-cache
-        subPath: gocache
-      volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
-    kind:
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-        readOnly: true
-      - mountPath: /var/lib/docker
-        name: docker-root
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - emptyDir: {}
-        name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
   requirements:
   - cache
   - cache
@@ -1142,11 +1027,9 @@ jobs:
   - postsubmit
 - command:
   - entrypoint
-  - release/build.sh
+  - release/build-base-images.sh
   cron: 0 19 * * *
   env:
-  - name: BUILD_BASE_IMAGES
-    value: "true"
   - name: VERSION
     value: "1.18"
   name: build-base-images
@@ -1270,9 +1153,8 @@ jobs:
   requirements:
   - cache
   - cache
-  - release
+  - build-base
   - docker
-  - github-istio-testing
   resources: build
   resources_presets:
     build:
@@ -1373,43 +1255,6 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
 requirements:
 - cache
 - cache


### PR DESCRIPTION
This backports the changes to the release-builder and base image jobs to older releases. On this, I noticed we accidentally dropped ALWAYS_GENERATE_BASE_IMAGE=true from master istio/istio, so add that back

Goes with:
https://github.com/istio/release-builder/pull/1557
https://github.com/istio/release-builder/pull/1558
https://github.com/istio/release-builder/pull/1559