### PR TITLE
sinker: grant WI to prow-control-plane

### DIFF
--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -97,6 +97,7 @@ data "google_iam_policy" "prow_control_plane" {
       "serviceAccount:istio-testing.svc.id.goog[default/deck-private]",
       "serviceAccount:istio-testing.svc.id.goog[default/hook]",
       "serviceAccount:istio-testing.svc.id.goog[default/prow-controller-manager]",
+      "serviceAccount:istio-testing.svc.id.goog[default/sinker]",
       "serviceAccount:istio-testing.svc.id.goog[default/tide]",
     ]
   }

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-control-plane@istio-testing.iam.gserviceaccount.com
   namespace: default
   name: "sinker"
 ---


### PR DESCRIPTION
Sinker has been looping on permission denied due to lack of WI binding.
This is needed now that we use gke-gcloud-auth-plugin instead of gencred
for cluster auth.
