### PR TITLE
jobs: cleanup legacy secret-mounting job configs

### DIFF
--- a/prow/cluster/build/kubernetes_external_secrets.yaml
+++ b/prow/cluster/build/kubernetes_external_secrets.yaml
@@ -1,17 +1,6 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: "grafana-token"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow__test-pods__grafana-token" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: "oauth-token"
   namespace: "test-pods"
 spec:
@@ -19,37 +8,4 @@ spec:
   projectId: "istio-prow-build"
   dataFrom:
   - "gke_istio-prow-build_us-west1-a_prow__test-pods__oauth-token" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
-  name: "rel-pipeline-docker-config"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow__test-pods__rel-pipeline-docker-config" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
-  name: "rel-pipeline-github"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow__test-pods__rel-pipeline-github" # Secret name in GSM
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
-  name: "rel-pipeline-service-account"
-  namespace: "test-pods"
-spec:
-  backendType: gcpSecretsManager
-  projectId: "istio-prow-build"
-  dataFrom:
-  - "gke_istio-prow-build_us-west1-a_prow__test-pods__rel-pipeline-service-account" # Secret name in GSM
 ---

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -125,25 +107,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -224,25 +188,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -321,25 +267,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/api-1.16.yaml
+++ b/prow/config/jobs/api-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -211,43 +175,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -346,43 +274,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -479,43 +371,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -602,43 +458,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/api-1.17.yaml
+++ b/prow/config/jobs/api-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -137,25 +119,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -243,25 +207,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -347,25 +293,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/api-1.17.yaml
+++ b/prow/config/jobs/api-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -223,43 +187,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -365,43 +293,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -505,43 +397,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -638,43 +494,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -221,43 +185,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -362,43 +290,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -501,43 +393,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -634,43 +490,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/api-1.18.yaml
+++ b/prow/config/jobs/api-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -135,25 +117,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -240,25 +204,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -343,25 +289,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/client-go-1.16.yaml
+++ b/prow/config/jobs/client-go-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -125,25 +107,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -215,25 +179,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -316,25 +262,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/client-go-1.16.yaml
+++ b/prow/config/jobs/client-go-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -211,43 +175,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -337,43 +265,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -474,43 +366,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -597,43 +453,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/client-go-1.17.yaml
+++ b/prow/config/jobs/client-go-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -223,43 +187,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -356,43 +284,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -500,43 +392,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -633,43 +489,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/client-go-1.17.yaml
+++ b/prow/config/jobs/client-go-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -137,25 +119,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -234,25 +198,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -342,25 +288,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -221,43 +185,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -353,43 +281,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -496,43 +388,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -629,43 +485,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/client-go-1.18.yaml
+++ b/prow/config/jobs/client-go-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -135,25 +117,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -231,25 +195,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -338,25 +284,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/common-files-1.16.yaml
+++ b/prow/config/jobs/common-files-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -135,25 +117,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -238,25 +202,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -345,25 +291,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/common-files-1.16.yaml
+++ b/prow/config/jobs/common-files-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -221,43 +185,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -360,43 +288,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -503,43 +395,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -626,43 +482,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/common-files-1.17.yaml
+++ b/prow/config/jobs/common-files-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -147,25 +129,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -257,25 +221,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -371,25 +317,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/common-files-1.17.yaml
+++ b/prow/config/jobs/common-files-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -233,43 +197,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -379,43 +307,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -529,43 +421,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -662,43 +518,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/common-files-1.18.yaml
+++ b/prow/config/jobs/common-files-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -145,25 +127,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -254,25 +218,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -367,25 +313,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/common-files-1.18.yaml
+++ b/prow/config/jobs/common-files-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -231,43 +195,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -376,43 +304,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -525,43 +417,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -658,43 +514,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/enhancements-1.16.yaml
+++ b/prow/config/jobs/enhancements-1.16.yaml
@@ -41,25 +41,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/enhancements-1.16.yaml
+++ b/prow/config/jobs/enhancements-1.16.yaml
@@ -91,43 +91,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -213,43 +177,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/enhancements-1.17.yaml
+++ b/prow/config/jobs/enhancements-1.17.yaml
@@ -46,25 +46,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/enhancements-1.17.yaml
+++ b/prow/config/jobs/enhancements-1.17.yaml
@@ -96,43 +96,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -228,43 +192,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/enhancements-1.18.yaml
+++ b/prow/config/jobs/enhancements-1.18.yaml
@@ -95,43 +95,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -227,43 +191,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/enhancements-1.18.yaml
+++ b/prow/config/jobs/enhancements-1.18.yaml
@@ -45,25 +45,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -93,43 +93,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -240,43 +204,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -390,43 +318,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -545,43 +437,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -696,43 +552,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -849,43 +669,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -999,43 +783,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1149,43 +897,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1304,43 +1016,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1455,43 +1131,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1607,43 +1247,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1759,43 +1363,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1909,43 +1477,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2057,43 +1589,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2205,43 +1701,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2355,43 +1815,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2507,43 +1931,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2662,43 +2050,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2817,43 +2169,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2966,43 +2282,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3115,43 +2395,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3267,43 +2511,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3422,43 +2630,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3571,43 +2743,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3725,43 +2861,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3882,43 +2982,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4039,43 +3103,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4196,43 +3224,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4353,43 +3345,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4510,43 +3466,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4667,43 +3587,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4822,43 +3706,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4979,43 +3827,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5134,43 +3946,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5290,43 +4066,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5438,43 +4178,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5586,43 +4290,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5735,43 +4403,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5885,43 +4517,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6041,43 +4637,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6185,43 +4745,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -43,25 +43,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -154,25 +136,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -268,25 +232,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -387,25 +333,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -502,25 +430,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -619,25 +529,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -733,25 +625,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -847,25 +721,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -966,25 +822,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1081,25 +919,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1197,25 +1017,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1313,25 +1115,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1427,25 +1211,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1539,25 +1305,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1651,25 +1399,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1765,25 +1495,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1881,25 +1593,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2000,25 +1694,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2119,25 +1795,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2232,25 +1890,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2345,25 +1985,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2461,25 +2083,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2580,25 +2184,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2693,25 +2279,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2811,25 +2379,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2932,25 +2482,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3053,25 +2585,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3174,25 +2688,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3295,25 +2791,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3416,25 +2894,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3537,25 +2997,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3656,25 +3098,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3777,25 +3201,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3896,25 +3302,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4016,25 +3404,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4128,25 +3498,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4240,25 +3592,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4353,25 +3687,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4467,25 +3783,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4587,25 +3885,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -98,43 +98,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -252,43 +216,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -409,43 +337,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -571,43 +463,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -729,43 +585,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -890,43 +710,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1047,43 +831,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1204,43 +952,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1367,43 +1079,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1526,43 +1202,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1686,43 +1326,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1846,43 +1450,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2003,43 +1571,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2158,43 +1690,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2313,43 +1809,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2471,43 +1931,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2630,43 +2054,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2793,43 +2181,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2956,43 +2308,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3112,43 +2428,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3268,43 +2548,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3427,43 +2671,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3590,43 +2798,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3746,43 +2918,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3908,43 +3044,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4073,43 +3173,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4238,43 +3302,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4403,43 +3431,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4568,43 +3560,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4733,43 +3689,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4898,43 +3818,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5061,43 +3945,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5224,43 +4072,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5387,43 +4199,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5550,43 +4326,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5714,43 +4454,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5869,43 +4573,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6024,43 +4692,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6180,43 +4812,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6337,43 +4933,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6501,43 +5061,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6655,43 +5179,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -48,25 +48,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -166,25 +148,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -287,25 +251,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -413,25 +359,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -535,25 +463,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -660,25 +570,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -781,25 +673,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -902,25 +776,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1029,25 +885,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1152,25 +990,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1276,25 +1096,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1400,25 +1202,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1521,25 +1305,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1640,25 +1406,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1759,25 +1507,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1881,25 +1611,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2004,25 +1716,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2131,25 +1825,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2258,25 +1934,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2378,25 +2036,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2498,25 +2138,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2621,25 +2243,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2748,25 +2352,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2868,25 +2454,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2994,25 +2562,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3123,25 +2673,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3252,25 +2784,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3381,25 +2895,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3510,25 +3006,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3639,25 +3117,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3768,25 +3228,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3895,25 +3337,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4022,25 +3446,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4149,25 +3555,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4276,25 +3664,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4404,25 +3774,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4523,25 +3875,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4642,25 +3976,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4762,25 +4078,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4883,25 +4181,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -5011,25 +4291,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -97,43 +97,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -250,43 +214,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -406,43 +334,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -567,43 +459,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -724,43 +580,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -884,43 +704,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1040,43 +824,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1196,43 +944,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1358,43 +1070,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1516,43 +1192,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1675,43 +1315,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1834,43 +1438,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1990,43 +1558,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2144,43 +1676,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2298,43 +1794,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2455,43 +1915,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2613,43 +2037,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2775,43 +2163,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -2937,43 +2289,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3092,43 +2408,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3247,43 +2527,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3405,43 +2649,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3567,43 +2775,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3727,43 +2899,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -3881,43 +3017,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4042,43 +3142,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4206,43 +3270,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4370,43 +3398,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4532,43 +3524,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4694,43 +3650,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -4856,43 +3776,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5018,43 +3902,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5180,43 +4028,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5343,43 +4155,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5497,43 +4273,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5651,43 +4391,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5806,43 +4510,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -5962,43 +4630,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6125,43 +4757,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6291,43 +4887,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -6444,43 +5004,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -47,25 +47,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -164,25 +146,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -284,25 +248,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -409,25 +355,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -530,25 +458,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -654,25 +564,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -774,25 +666,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -894,25 +768,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1020,25 +876,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1142,25 +980,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1265,25 +1085,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1388,25 +1190,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1508,25 +1292,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1626,25 +1392,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1744,25 +1492,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1865,25 +1595,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1987,25 +1699,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2113,25 +1807,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2239,25 +1915,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2358,25 +2016,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2477,25 +2117,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2599,25 +2221,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2725,25 +2329,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2849,25 +2435,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -2967,25 +2535,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3092,25 +2642,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3220,25 +2752,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3348,25 +2862,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3474,25 +2970,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3600,25 +3078,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3726,25 +3186,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3852,25 +3294,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -3978,25 +3402,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4105,25 +3511,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4223,25 +3611,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4341,25 +3711,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4460,25 +3812,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4580,25 +3914,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4707,25 +4023,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -4837,25 +4135,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio.io-1.16.yaml
+++ b/prow/config/jobs/istio.io-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -218,43 +182,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -353,43 +281,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -489,43 +381,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -625,43 +481,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -763,43 +583,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -905,43 +689,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   resources_presets:
@@ -1033,43 +781,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/istio.io-1.16.yaml
+++ b/prow/config/jobs/istio.io-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -132,25 +114,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -231,25 +195,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -331,25 +277,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -431,25 +359,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -533,25 +443,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -639,25 +531,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio.io-1.17.yaml
+++ b/prow/config/jobs/istio.io-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -230,43 +194,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -372,43 +300,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -515,43 +407,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -658,43 +514,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -803,43 +623,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -952,43 +736,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   resources_presets:
@@ -1090,43 +838,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/istio.io-1.17.yaml
+++ b/prow/config/jobs/istio.io-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -144,25 +126,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -250,25 +214,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -357,25 +303,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -464,25 +392,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -573,25 +483,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -686,25 +578,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -149,25 +131,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -261,25 +225,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -375,25 +321,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -488,25 +416,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -601,25 +511,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -716,25 +608,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -835,25 +709,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/istio.io-1.18.yaml
+++ b/prow/config/jobs/istio.io-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -235,43 +199,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -383,43 +311,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -533,43 +425,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -682,43 +538,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -831,43 +651,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -982,43 +766,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1137,43 +885,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   resources_presets:
@@ -1282,43 +994,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/pkg-1.16.yaml
+++ b/prow/config/jobs/pkg-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -125,25 +107,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -215,25 +179,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -305,25 +251,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -405,25 +333,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/pkg-1.16.yaml
+++ b/prow/config/jobs/pkg-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -211,43 +175,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -337,43 +265,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -463,43 +355,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -599,43 +455,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -722,43 +542,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/pkg-1.17.yaml
+++ b/prow/config/jobs/pkg-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -137,25 +119,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -234,25 +198,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -331,25 +277,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -438,25 +366,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/pkg-1.17.yaml
+++ b/prow/config/jobs/pkg-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -223,43 +187,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -356,43 +284,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -489,43 +381,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -632,43 +488,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -765,43 +585,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -221,43 +185,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -353,43 +281,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -485,43 +377,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -627,43 +483,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -760,43 +580,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/pkg-1.18.yaml
+++ b/prow/config/jobs/pkg-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -135,25 +117,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -231,25 +195,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -327,25 +273,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -433,25 +361,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -84,43 +84,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -217,43 +181,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -350,43 +278,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -483,43 +375,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -622,43 +478,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -756,43 +576,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -890,43 +674,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1025,43 +773,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1166,43 +878,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1301,43 +977,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1445,43 +1085,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1589,43 +1193,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1717,43 +1285,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -34,25 +34,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -131,25 +113,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -228,25 +192,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -325,25 +271,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -428,25 +356,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -526,25 +436,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -624,25 +516,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -723,25 +597,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -828,25 +684,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -927,25 +765,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1035,25 +855,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1143,25 +945,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -143,25 +125,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -247,25 +211,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -351,25 +297,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -462,25 +390,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -567,25 +477,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -672,25 +564,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -778,25 +652,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -891,25 +747,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -997,25 +835,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1112,25 +932,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1227,25 +1029,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -229,43 +193,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -369,43 +297,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -509,43 +401,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -656,43 +512,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -797,43 +617,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -938,43 +722,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1080,43 +828,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1229,43 +941,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1371,43 +1047,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1522,43 +1162,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1673,43 +1277,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1811,43 +1379,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -88,43 +88,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -227,43 +191,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -366,43 +294,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -506,43 +398,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -652,43 +508,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -793,43 +613,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -933,43 +717,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1074,43 +822,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1222,43 +934,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1364,43 +1040,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1515,43 +1155,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1666,43 +1270,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1804,43 +1372,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -38,25 +38,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -141,25 +123,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -244,25 +208,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -348,25 +294,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -458,25 +386,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -563,25 +473,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -667,25 +559,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -772,25 +646,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -884,25 +740,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -990,25 +828,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1105,25 +925,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -1220,25 +1022,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/release-builder-1.16.yaml
+++ b/prow/config/jobs/release-builder-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -132,25 +114,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -229,25 +193,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -327,25 +273,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -428,25 +356,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -529,25 +439,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -629,25 +521,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -732,25 +606,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -836,25 +692,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/release-builder-1.16.yaml
+++ b/prow/config/jobs/release-builder-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -218,43 +182,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -351,43 +279,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -485,43 +377,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -622,43 +478,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -759,43 +579,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -895,43 +679,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   service_account_name: prowjob-release
   requirements:
   - cache
@@ -1138,43 +886,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache

--- a/prow/config/jobs/release-builder-1.17.yaml
+++ b/prow/config/jobs/release-builder-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -230,43 +194,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -370,43 +298,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -511,43 +403,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -655,43 +511,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -799,43 +619,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -942,43 +726,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   service_account_name: prowjob-release
   requirements:
   - cache
@@ -1200,43 +948,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache

--- a/prow/config/jobs/release-builder-1.17.yaml
+++ b/prow/config/jobs/release-builder-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -144,25 +126,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -248,25 +212,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -353,25 +299,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -461,25 +389,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -569,25 +479,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -676,25 +568,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -786,25 +660,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -898,25 +754,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -142,25 +124,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -245,25 +209,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -349,25 +295,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -456,25 +384,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -563,25 +473,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -669,25 +561,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -811,25 +685,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/release-builder-1.18.yaml
+++ b/prow/config/jobs/release-builder-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -228,43 +192,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -367,43 +295,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -507,43 +399,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -650,43 +506,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -793,43 +613,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -935,43 +719,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   service_account_name: prowjob-release
   requirements:
   - cache
@@ -1113,43 +861,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache

--- a/prow/config/jobs/tools-1.16.yaml
+++ b/prow/config/jobs/tools-1.16.yaml
@@ -35,25 +35,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -132,25 +114,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -229,25 +193,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -326,25 +272,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -436,25 +364,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -544,25 +454,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -648,25 +540,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -753,25 +627,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/tools-1.16.yaml
+++ b/prow/config/jobs/tools-1.16.yaml
@@ -85,43 +85,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -218,43 +182,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -351,43 +279,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -484,43 +376,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -630,43 +486,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -774,43 +594,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -914,43 +698,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1055,43 +803,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1186,43 +898,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/tools-1.17.yaml
+++ b/prow/config/jobs/tools-1.17.yaml
@@ -40,25 +40,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -144,25 +126,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -248,25 +212,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -352,25 +298,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -470,25 +398,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -586,25 +496,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -697,25 +589,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -809,25 +683,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/tools-1.17.yaml
+++ b/prow/config/jobs/tools-1.17.yaml
@@ -90,43 +90,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -230,43 +194,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -370,43 +298,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -510,43 +402,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -664,43 +520,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -816,43 +636,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -963,43 +747,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1111,43 +859,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1252,43 +964,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -228,43 +192,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -367,43 +295,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -506,43 +398,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -659,43 +515,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -810,43 +630,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -956,43 +740,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1103,43 +851,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -1244,43 +956,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/tools-1.18.yaml
+++ b/prow/config/jobs/tools-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -142,25 +124,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -245,25 +209,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -348,25 +294,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -465,25 +393,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -580,25 +490,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -690,25 +582,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -801,25 +675,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs/ztunnel-1.18.yaml
+++ b/prow/config/jobs/ztunnel-1.18.yaml
@@ -89,43 +89,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -225,43 +189,7 @@ jobs:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    release:
-      env:
-      - name: COSIGN_KEY
-        value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-      - name: DOCKER_CONFIG
-        value: /etc/rel-pipeline-docker-config
-      - name: GITHUB_TOKEN_FILE
-        value: /etc/github/rel-pipeline-github
-      - name: GRAFANA_TOKEN_FILE
-        value: /etc/grafana/token
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/rel-pipeline-service-account.json
-      volumeMounts:
-      - mountPath: /etc/rel-pipeline-docker-config
-        name: rel-pipeline-docker-config
-      - mountPath: /etc/github
-        name: rel-pipeline-github
-        readOnly: true
-      - mountPath: /etc/grafana
-        name: rel-pipeline-grafana
-        readOnly: true
-      - mountPath: /etc/service-account
-        name: rel-pipeline-service-account
-        readOnly: true
-      volumes:
-      - name: rel-pipeline-service-account
-        secret:
-          secretName: rel-pipeline-service-account
-      - name: rel-pipeline-github
-        secret:
-          secretName: rel-pipeline-github
-      - name: rel-pipeline-grafana
-        secret:
-          secretName: grafana-token
-      - name: rel-pipeline-docker-config
-        secret:
-          secretName: rel-pipeline-docker-config
+
   requirements:
   - cache
   - cache
@@ -359,43 +287,7 @@ requirement_presets:
       name: cgroup
     - emptyDir: {}
       name: docker-root
-  release:
-    env:
-    - name: COSIGN_KEY
-      value: "gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1"
-    - name: DOCKER_CONFIG
-      value: /etc/rel-pipeline-docker-config
-    - name: GITHUB_TOKEN_FILE
-      value: /etc/github/rel-pipeline-github
-    - name: GRAFANA_TOKEN_FILE
-      value: /etc/grafana/token
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: /etc/service-account/rel-pipeline-service-account.json
-    volumeMounts:
-    - mountPath: /etc/rel-pipeline-docker-config
-      name: rel-pipeline-docker-config
-    - mountPath: /etc/github
-      name: rel-pipeline-github
-      readOnly: true
-    - mountPath: /etc/grafana
-      name: rel-pipeline-grafana
-      readOnly: true
-    - mountPath: /etc/service-account
-      name: rel-pipeline-service-account
-      readOnly: true
-    volumes:
-    - name: rel-pipeline-service-account
-      secret:
-        secretName: rel-pipeline-service-account
-    - name: rel-pipeline-github
-      secret:
-        secretName: rel-pipeline-github
-    - name: rel-pipeline-grafana
-      secret:
-        secretName: grafana-token
-    - name: rel-pipeline-docker-config
-      secret:
-        secretName: rel-pipeline-docker-config
+
 requirements:
 - cache
 - cache

--- a/prow/config/jobs/ztunnel-1.18.yaml
+++ b/prow/config/jobs/ztunnel-1.18.yaml
@@ -39,25 +39,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache
@@ -139,25 +121,7 @@ jobs:
       volumes:
       - emptyDir: {}
         name: docker-root
-    github:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          secretName: oauth-token
-    github-optional:
-      volumeMounts:
-      - mountPath: /etc/github-token
-        name: github
-        readOnly: true
-      volumes:
-      - name: github
-        secret:
-          optional: true
-          secretName: oauth-token
+
     gocache:
       volumeMounts:
       - mountPath: /gocache

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -353,9 +353,7 @@ var LowPrivilegeVolumes = sets.NewString(
 	Modules,
 )
 
-var (
-	PrivateVolumes = sets.NewString(Netrc, SSHKey)
-)
+var PrivateVolumes = sets.NewString(Netrc, SSHKey)
 
 const (
 	GithubTesting    Volumes = "github-testing"

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -101,20 +101,6 @@ func TestJobs(t *testing.T) {
 		}
 		return nil
 	})
-	RunTest("release volumes only used in release jobs", func(j Job) error {
-		releaseJob := j.RepoOrg == "istio/release-builder" && j.Type == Postsubmit
-		// TODO: these shouldn't need grafana or docker, and they actually don't - the private cluster has empty secrets
-		privateReleaseJob := j.RepoOrg == "istio-private/release-builder" && j.Type == Postsubmit
-		baseImageBuilder := ((j.RepoOrg == "istio/istio" && j.Type == Postsubmit) || j.Type == Periodic) && j.BaseName() == "build-base-images"
-		if releaseJob || privateReleaseJob || baseImageBuilder {
-			return nil
-		}
-		usesReleaseVolumes := j.Volumes().Intersection(ReleaseVolumes).Len() > 0
-		if usesReleaseVolumes {
-			return fmt.Errorf("only release jobs can use release volumes, found %v", j.Volumes().Intersection(ReleaseVolumes).UnsortedList())
-		}
-		return nil
-	})
 	RunTest("org volumes only used in org jobs", func(j Job) error {
 		orgJob := (j.RepoOrg == "istio/community" && j.Type == Postsubmit) ||
 			(j.Name == "ci-test-infra-branchprotector" && j.Type == Periodic) ||
@@ -157,6 +143,11 @@ func TestJobs(t *testing.T) {
 		case HighPrivilege:
 			if j.Type == Presubmit {
 				return fmt.Errorf("privileged service accounts cannot run as presubmit")
+			}
+			releaseJob := (j.RepoOrg == "istio/release-builder" && j.Type == Postsubmit) ||
+				(strings.HasPrefix(j.Name, "build-base-images") && j.Type != Presubmit)
+			if j.ServiceAccount() == "prowjob-release" && !releaseJob {
+				return fmt.Errorf("only release jobs can use prowjob-release account")
 			}
 		default:
 			return fmt.Errorf("unknown sensitivity: %v", s)
@@ -347,15 +338,11 @@ const (
 type Volumes = string
 
 var AllVolumes = sets.NewString(
-	GithubRelease,
 	GithubTesting,
 	GithubTestingSSH,
 	BuildCache,
-	Docker,
-	Grafana,
 	Netrc,
 	SSHKey,
-	IstioReleaseGCP,
 	Cgroups,
 	Modules,
 )
@@ -368,18 +355,11 @@ var LowPrivilegeVolumes = sets.NewString(
 
 var (
 	PrivateVolumes = sets.NewString(Netrc, SSHKey)
-	ReleaseVolumes = sets.NewString(GithubRelease, IstioReleaseGCP, Grafana, Docker)
 )
 
 const (
-	GithubRelease    Volumes = "github-release"
 	GithubTesting    Volumes = "github-testing"
 	GithubTestingSSH Volumes = "github-testing-ssh"
-
-	IstioReleaseGCP Volumes = "istio-release_gcp"
-
-	Docker  Volumes = "docker"
-	Grafana Volumes = "grafana"
 
 	BuildCache Volumes = "buildcache"
 	Cgroups    Volumes = "cgroups"
@@ -420,14 +400,6 @@ func (j Job) Volumes() sets.String {
 				r.Insert(GithubTesting)
 			case "istio-testing-robot-ssh-key":
 				r.Insert(GithubTestingSSH)
-			case "rel-pipeline-service-account":
-				r.Insert(IstioReleaseGCP)
-			case "rel-pipeline-github":
-				r.Insert(GithubRelease)
-			case "grafana-token":
-				r.Insert(Grafana)
-			case "rel-pipeline-docker-config":
-				r.Insert(Docker)
 			case "netrc-secret":
 				r.Insert(Netrc)
 			case "ssh-key-secret":


### PR DESCRIPTION
These have all been migrated, clean then up so we don't have secrets lying around in the cluster