### PR TITLE
Migrate jobs off prowjob-advanced-sa

### DIFF
--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -108,3 +108,20 @@ module "prowjob_build_tools_account" {
   ]
   prowjob = true
 }
+
+module "prowjob_testing_write_account" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "prowjob-testing-write"
+  description       = "Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build."
+  cluster_namespace = local.pod_namespace
+  gcs_acls = [
+    { bucket = "artifacts.istio-testing.appspot.com", role = "OWNER" },
+    { bucket = "istio-build", role = "OWNER" },
+  ]
+  project_roles = [
+    { role = "roles/remotebuildexecution.actionCacheWriter", project = "istio-testing" },
+    { role = "roles/remotebuildexecution.artifactCreator", project = "istio-testing" },
+  ]
+  prowjob = true
+}

--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -123,5 +123,9 @@ module "prowjob_testing_write_account" {
     { role = "roles/remotebuildexecution.actionCacheWriter", project = "istio-testing" },
     { role = "roles/remotebuildexecution.artifactCreator", project = "istio-testing" },
   ]
+  # Allow the same SA in istio-testing to access the secret. This is the trusted build cluster.
+  additional_workload_identity_principals = [
+    "serviceAccount:istio-testing.svc.id.goog[test-pods/prowjob-testing-write]"
+  ]
   prowjob = true
 }

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -105,3 +105,16 @@ resource "google_service_account_iam_policy" "prow_control_plane" {
   service_account_id = google_service_account.prow_control_plane.name
   policy_data        = data.google_iam_policy.prow_control_plane.policy_data
 }
+
+module "prowjob_bots_deployer_account" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "prowjob-bots-deployer"
+  description       = "ProwJob SA for deploying istio/bots"
+  cluster_namespace = local.pod_namespace
+  # Grant container admin so we can get credentials to deploy to the policy-bot GKE cluster
+  project_roles = [
+    { role = "roles/container.admin" },
+  ]
+  prowjob = true
+}

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -51,6 +51,7 @@ resource "google_service_account" "istio_prow_test_job_private" {
   project      = "istio-testing"
 }
 # Used with WI as the "prowjob-advanced-sa" service account. This is used for jobs that need elevated permissions
+# Now obsolete; prowjob-advanced-sa is not used.
 resource "google_service_account" "istio_prow_test_job" {
   account_id   = "istio-prow-test-job"
   display_name = "Istio Prow Test Job Service Account"

--- a/infra/gcp/istio-testing/main.tf
+++ b/infra/gcp/istio-testing/main.tf
@@ -1,4 +1,6 @@
 locals {
   project_id     = "istio-testing"
   project_number = "450874614208"
+
+  pod_namespace = "test-pods"
 }

--- a/infra/gcp/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/modules/workload-identity-service-account/main.tf
@@ -34,9 +34,10 @@ resource "google_service_account" "serviceaccount" {
 }
 data "google_iam_policy" "workload_identity" {
   binding {
-    members = [
-      "serviceAccount:${local.cluster_project_id}.svc.id.goog[${var.cluster_namespace}/${local.cluster_serviceaccount_name}]"
-    ]
+    members = concat(
+      ["serviceAccount:${local.cluster_project_id}.svc.id.goog[${var.cluster_namespace}/${local.cluster_serviceaccount_name}]"],
+      var.additional_workload_identity_principals
+    )
     role = "roles/iam.workloadIdentityUser"
   }
 }

--- a/infra/gcp/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/modules/workload-identity-service-account/variables.tf
@@ -99,3 +99,9 @@ variable "prowjob_bucket" {
   type        = string
   default     = "istio-prow"
 }
+
+variable "additional_workload_identity_principals" {
+  description = "A list of extra principals to grant WorkloadIdentityUser on the service account"
+  type        = list(string)
+  default     = []
+}

--- a/prow/cluster/arm/prowjob_service_accounts.yaml
+++ b/prow/cluster/arm/prowjob_service_accounts.yaml
@@ -12,17 +12,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
-  namespace: test-pods
-  # Service account that has more permissions on the shared GCP projects, check
-  # with a Googler on what permissions it has.
-  # Please only use it when you do need them.
-  name: prowjob-advanced-sa
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: prowjob-release@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
   # Service account that has permissions for release jobs.

--- a/prow/cluster/arm/prowjob_service_accounts.yaml
+++ b/prow/cluster/arm/prowjob_service_accounts.yaml
@@ -46,3 +46,12 @@ metadata:
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and to push PRs as istio-testing account.
   name: prowjob-build-tools
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-testing-write@istio-prow-build.iam.gserviceaccount.com
+  namespace: test-pods
+  # Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build.
+  name: prowjob-testing-write

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -65,3 +65,12 @@ metadata:
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and to push PRs as istio-testing account.
   name: prowjob-build-tools
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-testing-write@istio-prow-build.iam.gserviceaccount.com
+  namespace: test-pods
+  # Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build.
+  name: prowjob-testing-write

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -12,17 +12,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
-  namespace: test-pods
-  # Service account that has more permissions on the shared GCP projects, check
-  # with a Googler on what permissions it has.
-  # Please only use it when you do need them.
-  name: prowjob-advanced-sa
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: prowjob-release@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
   # Service account that has permissions for release jobs.

--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -171,6 +171,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
+    cluster: test-infra-trusted
     decorate: true
     name: deploy-policybot_bots_postsubmit
     path_alias: istio.io/bots
@@ -199,20 +200,13 @@ postsubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /home/prow/go/pkg
-          name: build-cache
-          subPath: gomod
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-bots-deployer
       volumes:
-      - hostPath:
-          path: /var/tmp/prow/cache
-          type: DirectoryOrCreate
-        name: build-cache
       - emptyDir: {}
         name: docker-root
 presubmits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -337,7 +337,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -385,7 +385,6 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.16.gen.yaml
@@ -210,7 +210,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -258,7 +258,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.17.gen.yaml
@@ -210,7 +210,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -258,7 +258,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.18.gen.yaml
@@ -271,7 +271,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -319,7 +319,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -164,7 +164,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -214,7 +214,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -264,7 +264,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.16.gen.yaml
@@ -102,7 +102,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -152,7 +152,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -202,7 +202,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.17.gen.yaml
@@ -102,7 +102,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -152,7 +152,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -202,7 +202,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.18.gen.yaml
@@ -102,7 +102,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -152,7 +152,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -202,7 +202,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -43,7 +43,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -93,7 +93,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -139,7 +139,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -228,7 +228,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         prod: prow
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - emptyDir: {}
         name: docker-root
@@ -273,7 +273,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         prod: prow
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - emptyDir: {}
         name: docker-root
@@ -318,7 +318,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         prod: prow
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - emptyDir: {}
         name: docker-root

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -84,7 +84,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -130,7 +130,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.18.gen.yaml
@@ -84,7 +84,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -130,7 +130,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-advanced-sa
+      serviceAccountName: prowjob-testing-write
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -32,6 +32,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    iam.gke.io/gcp-service-account: bots-deployer@istio-testing.iam.gserviceaccount.com
+  namespace: test-pods
+  name: bots-deployer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     iam.gke.io/gcp-service-account: testgrid-updater@istio-testing.iam.gserviceaccount.com
   namespace: test-pods
   name: testgrid-updater

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -43,3 +43,12 @@ metadata:
     iam.gke.io/gcp-service-account: testgrid-updater@istio-testing.iam.gserviceaccount.com
   namespace: test-pods
   name: testgrid-updater
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-testing-write@istio-prow-build.iam.gserviceaccount.com
+  namespace: test-pods
+  # Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build.
+  name: prowjob-testing-write

--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -13,17 +13,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: istio-prow-test-job@istio-testing.iam.gserviceaccount.com
-  namespace: test-pods
-  # Service account that has more permissions on the shared GCP projects, check
-  # with a Googler on what permissions it has.
-  # Please only use it when you do need them.
-  name: prowjob-advanced-sa
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: prow-deployer@istio-testing.iam.gserviceaccount.com
   namespace: test-pods
   name: prow-deployer

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 	"testing"
 
@@ -318,38 +317,6 @@ func TestConfig(t *testing.T) {
 				t.Errorf("%t actual codeOwners != expected %t", *bp.RequiredPullRequestReviews.RequireOwners, *tc.codeOwners)
 			}
 		})
-	}
-}
-
-func TestTrustedJobs(t *testing.T) {
-	const trusted = "test-infra-trusted"
-	trustedPath := path.Join(*jobConfigPath, "istio", "test-infra")
-
-	// Presubmits may not use trusted clusters.
-	for _, pre := range c.AllStaticPresubmits(nil) {
-		if pre.Cluster == trusted {
-			t.Errorf("%s: presubmits cannot use trusted clusters", pre.Name)
-		}
-	}
-
-	// Trusted postsubmits must be defined in trustedPath
-	for _, post := range c.AllStaticPostsubmits(nil) {
-		if post.Cluster != trusted {
-			continue
-		}
-		if !strings.HasPrefix(post.SourcePath, trustedPath) {
-			t.Errorf("%s defined in %s may not run in trusted cluster", post.Name, post.SourcePath)
-		}
-	}
-
-	// Trusted periodics must be defined in trustedPath
-	for _, per := range c.AllPeriodics() {
-		if per.Cluster != trusted {
-			continue
-		}
-		if !strings.HasPrefix(per.SourcePath, trustedPath) {
-			t.Errorf("%s defined in %s may not run in trusted cluster", per.Name, per.SourcePath)
-		}
 	}
 }
 

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -16,7 +16,9 @@ jobs:
     command: [make, gen-check]
 
   - name: deploy-policybot
-    service_account_name: prowjob-advanced-sa
+    cluster: test-infra-trusted
+    excluded_requirements: [cache]
+    service_account_name: prowjob-bots-deployer
     regex: '^policybot/'
     types: [postsubmit]
     command:

--- a/prow/config/jobs/istio-1.16.yaml
+++ b/prow/config/jobs/istio-1.16.yaml
@@ -298,7 +298,7 @@ jobs:
       requests:
         cpu: "8"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 - command:
@@ -495,7 +495,7 @@ jobs:
       requests:
         cpu: "8"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 - command:

--- a/prow/config/jobs/istio-1.17.yaml
+++ b/prow/config/jobs/istio-1.17.yaml
@@ -317,7 +317,7 @@ jobs:
       requests:
         cpu: "8"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 - command:
@@ -528,7 +528,7 @@ jobs:
       requests:
         cpu: "8"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 - command:

--- a/prow/config/jobs/istio-1.18.yaml
+++ b/prow/config/jobs/istio-1.18.yaml
@@ -314,7 +314,7 @@ jobs:
       requests:
         cpu: "8"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 - command:
@@ -523,7 +523,7 @@ jobs:
       requests:
         cpu: "8"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 - command:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -28,7 +28,6 @@ jobs:
     resources: dedicated
 
   - name: benchmark-report
-    service_account_name: prowjob-advanced-sa
     types: [postsubmit]
     command: [entrypoint, make, benchtest, report-benchtest]
     resources: dedicated

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -15,7 +15,7 @@ jobs:
     resources: dedicated
 
   - name: release
-    service_account_name: prowjob-advanced-sa
+    service_account_name: prowjob-testing-write
     types: [postsubmit]
     command: [entrypoint, prow/release-commit.sh]
     requirements: [docker]

--- a/prow/config/jobs/proxy-1.16.yaml
+++ b/prow/config/jobs/proxy-1.16.yaml
@@ -646,7 +646,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -734,7 +734,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -813,7 +813,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy-1.17.yaml
+++ b/prow/config/jobs/proxy-1.17.yaml
@@ -701,7 +701,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -797,7 +797,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -883,7 +883,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy-1.18.yaml
+++ b/prow/config/jobs/proxy-1.18.yaml
@@ -695,7 +695,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -790,7 +790,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit
@@ -876,7 +876,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   timeout: 6h0m0s
   types:
   - postsubmit

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -75,7 +75,7 @@ jobs:
   timeout: 4h
 
 - name: release
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
@@ -87,7 +87,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker]
@@ -98,7 +98,7 @@ jobs:
     testing: test-pool
 
 - name: release-centos
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types: [postsubmit]
   command: [./prow/proxy-postsubmit-centos.sh]
   image: gcr.io/istio-testing/build-tools-centos:master-4c71169512fe79b59b89664ef1b273da813d1c93

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -13,7 +13,7 @@ jobs:
     command: [make, gen-check]
 
   - name: push-authentikos
-    service_account_name: prowjob-advanced-sa
+    service_account_name: prowjob-testing-write
     types: [postsubmit]
     regex: '^authentikos/Makefile$'
     cluster: test-infra-trusted
@@ -30,7 +30,7 @@ jobs:
       prod: prow
 
   - name: push-prowgen
-    service_account_name: prowjob-advanced-sa
+    service_account_name: prowjob-testing-write
     types: [postsubmit]
     regex: '^tools/prowgen/.*$'
     cluster: test-infra-trusted
@@ -47,7 +47,7 @@ jobs:
       prod: prow
 
   - name: push-prowtrans
-    service_account_name: prowjob-advanced-sa
+    service_account_name: prowjob-testing-write
     types: [postsubmit]
     regex: '^tools/prowtrans/.*$'
     cluster: test-infra-trusted

--- a/prow/config/jobs/ztunnel-1.18.yaml
+++ b/prow/config/jobs/ztunnel-1.18.yaml
@@ -166,7 +166,7 @@ jobs:
       requests:
         cpu: "1"
         memory: 3Gi
-  service_account_name: prowjob-advanced-sa
+  service_account_name: prowjob-testing-write
   types:
   - postsubmit
 node_selector:

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -16,7 +16,7 @@ jobs:
 
   - name: release
     architectures: [amd64, arm64]
-    service_account_name: prowjob-advanced-sa
+    service_account_name: prowjob-testing-write
     types: [postsubmit]
     command: [make, release]
     requirements: [cratescache]

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -446,6 +446,7 @@ var ServiceAccounts = map[string]Sensitivity{
 	"prow-deployer":                HighPrivilege,
 	"testgrid-updater":             HighPrivilege,
 	"prowjob-advanced-sa":          HighPrivilege,
+	"prowjob-testing-write":        HighPrivilege,
 	"prowjob-github-istio-testing": HighPrivilege,
 	"prowjob-release":              HighPrivilege,
 	"prowjob-build-tools":          HighPrivilege,

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -449,6 +449,7 @@ var ServiceAccounts = map[string]Sensitivity{
 	"prowjob-github-istio-testing": HighPrivilege,
 	"prowjob-release":              HighPrivilege,
 	"prowjob-build-tools":          HighPrivilege,
+	"prowjob-bots-deployer":        HighPrivilege,
 }
 
 var PrivateServiceAccounts = sets.NewString(

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -61,7 +61,22 @@ func TestJobs(t *testing.T) {
 		if j.Type == Presubmit {
 			return fmt.Errorf("trusted jobs cannot run in presubmit")
 		}
-		return nil
+		if j.RepoOrg == "istio/test-infra" {
+			// OK to run in trusted cluster
+			return nil
+		}
+		if j.Type == Periodic {
+			return nil
+		}
+		// Otherwise need allow-listed job only
+		Allowed := sets.NewString(
+			"sync-org_community_postsubmit",
+			"deploy-policybot_bots_postsubmit",
+		)
+		if Allowed.Has(j.Name) {
+			return nil
+		}
+		return fmt.Errorf("not allowed to run in trusted cluster")
 	})
 
 	RunTest("secure jobs do not use insecure caches", func(j Job) error {
@@ -445,7 +460,6 @@ var ServiceAccounts = map[string]Sensitivity{
 	"prowjob-github-read":          MediumPrivilege,
 	"prow-deployer":                HighPrivilege,
 	"testgrid-updater":             HighPrivilege,
-	"prowjob-advanced-sa":          HighPrivilege,
 	"prowjob-testing-write":        HighPrivilege,
 	"prowjob-github-istio-testing": HighPrivilege,
 	"prowjob-release":              HighPrivilege,


### PR DESCRIPTION
`prowjob-advanced-sa` is a monolithic account with access to a lot of things.

This moves the final jobs off of it.

One job is unique - policy bots deployer. This needs GKE access; move it to trusted cluster and create an account for it.

All the remaining jobs just need access to gcr.io/istio-testing and gs://istio-build, so we create an account to grant those access.

With the last job dropping this account, remove traces of it. A followup will clean up the actual ServiceAccount entirely in GCP but we need it in the short term to avoid breakage

https://github.com/istio/test-infra/pull/4863/files should probably land first to avoid too many changes at once.