### PR TITLE
Fix prow-controller-manager lock permission

### DIFF
--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -73,7 +73,7 @@ rules:
   resources:
   - leases
   resourceNames:
-  - prow-sinker-leaderlock
+  - prow-controller-manager-leader-lock
   verbs:
   - get
   - update


### PR DESCRIPTION
This wasn't needed before since we had legacy ABAC enabled which gave access. Now we need proper permissions