### PR TITLE
deck-private: allow prowjob watch

### DIFF
--- a/prow/cluster/deck_private_rbac.yaml
+++ b/prow/cluster/deck_private_rbac.yaml
@@ -20,6 +20,8 @@ rules:
   - get
   - list
   - watch
+    # Required when deck runs with `--rerun-creates-job=true`
+  - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/prow/cluster/deck_private_rbac.yaml
+++ b/prow/cluster/deck_private_rbac.yaml
@@ -19,6 +19,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This was broken in the move to RBAC
