### PR TITLE
jobs: give release-builder large machines

### DIFF
--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -19,8 +19,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GOMAXPROCS
-          value: "8"
         - name: GCP_SECRETS
         - name: GCS_BUCKET
           value: istio-prerelease-private/prerelease
@@ -39,11 +37,10 @@ postsubmits:
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -286,6 +286,7 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    max_concurrency: 1
     name: publish-release_release-builder_postsubmit
     path_alias: istio.io/release-builder
     run_if_changed: ^release/trigger-publish$

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -207,17 +207,14 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GOMAXPROCS
-          value: "8"
         image: gcr.io/istio-testing/build-tools:master-bb3a18f9d6ecb6f876d08fbfa6fde229979bcb1e
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -255,17 +252,14 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GOMAXPROCS
-          value: "8"
         image: gcr.io/istio-testing/build-tools:master-bb3a18f9d6ecb6f876d08fbfa6fde229979bcb1e
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -314,17 +308,14 @@ postsubmits:
           value: /var/run/ci/github/token
         - name: GCP_SECRETS
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"}]'
-        - name: GOMAXPROCS
-          value: "8"
         image: gcr.io/istio-testing/build-tools:master-bb3a18f9d6ecb6f876d08fbfa6fde229979bcb1e
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -497,17 +488,14 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GOMAXPROCS
-          value: "8"
         image: gcr.io/istio-testing/build-tools:master-bb3a18f9d6ecb6f876d08fbfa6fde229979bcb1e
         name: ""
         resources:
           limits:
-            cpu: "8"
             memory: 24Gi
           requests:
-            cpu: "5"
-            memory: 3Gi
+            cpu: "15"
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -46,6 +46,7 @@ jobs:
     command: [entrypoint, release/publish.sh]
     requirements: [release, docker]
     resources: dedicated
+    max_concurrency: 1
 
   - name: build-base-images
     types: [periodic]

--- a/prow/config/jobs/release-builder.yaml
+++ b/prow/config/jobs/release-builder.yaml
@@ -16,7 +16,7 @@ jobs:
   - name: dry-run
     command: [entrypoint, test/publish.sh]
     requirements: [docker]
-    resources: build
+    resources: dedicated
     regex: '\.go$|\.sh$'
 
   - name: build-warning
@@ -36,7 +36,7 @@ jobs:
     regex: '^release/trigger-build$'
     command: [entrypoint, release/build.sh]
     requirements: [docker]
-    resources: build
+    resources: dedicated
     # For build, we just need SA (giving GCS/GCR access)
     service_account_name: prowjob-release
 
@@ -45,7 +45,7 @@ jobs:
     regex: '^release/trigger-publish$'
     command: [entrypoint, release/publish.sh]
     requirements: [release, docker]
-    resources: build
+    resources: dedicated
 
   - name: build-base-images
     types: [periodic]
@@ -65,3 +65,10 @@ resources_presets:
     limits:
       memory: "24Gi"
       cpu: "8000m"
+  # Give 15 CPUs which will put us on a dedicated node, ensuring fast builds
+  dedicated:
+    requests:
+      memory: "8Gi"
+      cpu: "15000m"
+    limits:
+      memory: "24Gi"


### PR DESCRIPTION
These take a ton of CPU, no need to throttle
