### PR TITLE
Revert "Update community job to use new tool"

### DIFF
--- a/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -214,7 +214,7 @@ postsubmits:
           name: docker-root
       nodeSelector:
         kubernetes.io/arch: amd64
-        prod: prow
+        testing: test-pool
       serviceAccountName: prowjob-bots-deployer
       volumes:
       - emptyDir: {}

--- a/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -102,9 +102,8 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - command:
-        - org-gen
-        - --write-to-github
-        - --github-token=/etc/github-token/oauth
+        - sh
+        - prow/sync-org.sh
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -127,7 +126,7 @@ postsubmits:
           readOnly: true
       nodeSelector:
         kubernetes.io/arch: amd64
-        prod: prow
+        testing: test-pool
       volumes:
       - name: github
         secret:

--- a/prow/config/jobs/bots.yaml
+++ b/prow/config/jobs/bots.yaml
@@ -18,8 +18,6 @@ jobs:
   - name: deploy-policybot
     cluster: test-infra-trusted
     excluded_requirements: [cache]
-    node_selector:
-      prod: prow
     service_account_name: prowjob-bots-deployer
     regex: '^policybot/'
     types: [postsubmit]

--- a/prow/config/jobs/community.yaml
+++ b/prow/config/jobs/community.yaml
@@ -11,9 +11,7 @@ jobs:
 
   - name: sync-org
     types: [postsubmit]
-    command: [org-gen, --write-to-github, --github-token=/etc/github-token/oauth]
-    node_selector:
-      prod: prow
+    command: [sh, prow/sync-org.sh]
     requirements: [github-organization]
     excluded_requirements: [cache]
     timeout: 4h

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -190,14 +190,8 @@ func TestJobs(t *testing.T) {
 	})
 
 	RunTest("selectors", func(j Job) error {
-		// Only 'prod' label is set on nodes in trusted cluster
+		// Node selectors are not used on trusted cluster (for now, anyways)
 		if j.Base.Cluster == "test-infra-trusted" {
-			allowed := sets.NewString("prod", "kubernetes.io/arch")
-			for k, v := range j.Base.Spec.NodeSelector {
-				if !allowed.Has(k) {
-					return fmt.Errorf("trusted cluster doesn't have nodes matching '%v=%v'", k, v)
-				}
-			}
 			return nil
 		}
 		validSelectors := []map[string]string{}


### PR DESCRIPTION
Reverts istio/test-infra#4881 -- fixes failing sync-org postsubmit job: https://prow.istio.io/view/gs/istio-prow/logs/sync-org_community_postsubmit/1677529337726767104

The image that contains the new tool was reverted in #4887, so we may need to revert this to use the old tool until the new image is ready.