### PR TITLE
Add github-readonly token to istio.io gencheck job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -330,6 +330,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-3e6374cdef2a685629b265997d21b877f0e57913
@@ -350,6 +352,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-private
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -750,6 +753,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-3e6374cdef2a685629b265997d21b877f0e57913
@@ -770,6 +775,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-private
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -186,6 +186,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-3e6374cdef2a685629b265997d21b877f0e57913
@@ -206,6 +208,7 @@ postsubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -592,6 +595,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-3e6374cdef2a685629b265997d21b877f0e57913
@@ -612,6 +617,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool
+      serviceAccountName: prowjob-github-read
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -9,6 +9,7 @@ jobs:
 
   - name: gencheck
     command: [make, gen-check]
+    requirements: [github-readonly]
 
   - name: doc.test.profile-default
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-default]


### PR DESCRIPTION
https://github.com/istio/istio.io/pull/13595 adds some automation which needs to convert from a short sha to the full sha in the gateway-api repo. This requires the GitHub read-only token.