### PR TITLE
ar: disable immutable tags on private registry

### DIFF
--- a/infra/gcp/istio-prow-private/ar.tf
+++ b/infra/gcp/istio-prow-private/ar.tf
@@ -5,7 +5,7 @@ resource "google_artifact_registry_repository" "main" {
   format        = "DOCKER"
 
   docker_config {
-    immutable_tags = true
+    immutable_tags = false
   }
 
   lifecycle {


### PR DESCRIPTION
We often need to do rebuilds
