### PR TITLE
Fix opentelemtry namespace

### DIFF
--- a/prow/cluster/build/otel.yaml
+++ b/prow/cluster/build/otel.yaml
@@ -1,7 +1,13 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: opentelemetry-collector
+  namespace: opentelemetry
   annotations:
     iam.gke.io/gcp-service-account: opentelemetry-collector@istio-prow-build.iam.gserviceaccount.com
 ---
@@ -9,6 +15,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: collector
+  namespace: opentelemetry
 data:
   config: |
     receivers:
@@ -36,6 +43,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: collector
+  namespace: opentelemetry
   labels:
     app: collector
 spec:
@@ -50,6 +58,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: collector
+  namespace: opentelemetry
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
We either need to move to this namespace or change the WI binding to default namespace - but strongly prefer to isolate in a namespace