### PR TITLE
Add prowjob-bots-deployer KSA

### DIFF
--- a/prow/cluster/prowjob_service_accounts.yaml
+++ b/prow/cluster/prowjob_service_accounts.yaml
@@ -37,6 +37,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    iam.gke.io/gcp-service-account: prowjob-bots-deployer@istio-testing.iam.gserviceaccount.com
+  namespace: test-pods
+  name: prowjob-bots-deployer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     iam.gke.io/gcp-service-account: prowjob-testing-write@istio-prow-build.iam.gserviceaccount.com
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build.


### PR DESCRIPTION
We have the GCP SA created, but forgot to make the KSA, so job fails