### PR TITLE
terraform: cleanup some minor things

### DIFF
--- a/infra/gcp/istio-prow-private/ar.tf
+++ b/infra/gcp/istio-prow-private/ar.tf
@@ -4,10 +4,6 @@ resource "google_artifact_registry_repository" "main" {
   description   = "registry to host private Istio release artifacts"
   format        = "DOCKER"
 
-  docker_config {
-    immutable_tags = false
-  }
-
   lifecycle {
     prevent_destroy = true
   }

--- a/infra/gcp/istio-testing/cluster-prow.tf
+++ b/infra/gcp/istio-testing/cluster-prow.tf
@@ -47,8 +47,6 @@ resource "google_container_cluster" "prow" {
 
   networking_mode = "ROUTES"
 
-  node_version = "1.24.12-gke.1000"
-
   private_cluster_config {
     enable_private_endpoint = false
 
@@ -125,6 +123,4 @@ resource "google_container_node_pool" "prow_pool" {
     max_surge       = 1
     max_unavailable = 0
   }
-
-  version = "1.24.12-gke.1000"
 }


### PR DESCRIPTION
We should not be setting version here, or we will downgrade when GKE
auto-upgrades. This seems to be one of the recommended options (to just
not set it).
