### PR TITLE
Fix permission issue with bot deploy

### DIFF
--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -118,5 +118,8 @@ module "prowjob_bots_deployer_account" {
   project_roles = [
     { role = "roles/container.admin" },
   ]
+  gcs_acls = [
+    { bucket = "artifacts.istio-testing.appspot.com", role = "OWNER" },
+  ]
   prowjob = true
 }


### PR DESCRIPTION
Failing test: https://prow.istio.io/view/gs/istio-prow/logs/deploy-policybot_bots_postsubmit/1686727065161699328