### PR TITLE
Fix build-tools image tag for failing release-postsubmit test

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.19.gen.yaml
@@ -28,7 +28,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
-        image: gcr.io/istio-testing/build-tools-proxy:marelease-1.19ster-936207ec8823f21aa330a82c20649c6f9e2f7a22
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.19-936207ec8823f21aa330a82c20649c6f9e2f7a22
         name: ""
         resources:
           requests:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.19.gen.yaml
@@ -141,7 +141,7 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:marelease-1.19ster-936207ec8823f21aa330a82c20649c6f9e2f7a22
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.19-936207ec8823f21aa330a82c20649c6f9e2f7a22
         name: ""
         resources:
           requests:

--- a/prow/config/jobs/proxy-1.19.yaml
+++ b/prow/config/jobs/proxy-1.19.yaml
@@ -1289,7 +1289,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:marelease-1.19ster-936207ec8823f21aa330a82c20649c6f9e2f7a22
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.19-936207ec8823f21aa330a82c20649c6f9e2f7a22
   name: release
   node_selector:
     testing: test-pool


### PR DESCRIPTION
Job release-arm64_proxy_release-1.19_postsubmit of type postsubmit ended with state error. [View logs](https://prow.istio.io/view/gs/istio-prow/logs/release-arm64_proxy_release-1.19_postsubmit/1687224912357363712) is failing.

Looking at the job, the image name tag is incorrect.