### PR TITLE
Fix branch for build-tools-image job

### DIFF
--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.19.gen.yaml
@@ -189,7 +189,7 @@ postsubmits:
         - --org=$AUTOMATOR_ORG
         - --repo=test-infra
         - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
-        - --branch=release-1.19
+        - --branch=master
         - --modifier=buildtools
         - --token-env
         - --script-path=../test-infra/tools/automator/scripts/update-images.sh

--- a/prow/config/jobs/common-files-1.19.yaml
+++ b/prow/config/jobs/common-files-1.19.yaml
@@ -491,7 +491,7 @@ jobs:
   - --org=$AUTOMATOR_ORG
   - --repo=test-infra
   - '--title=Automator: update build-tools:$AUTOMATOR_SRC_BRANCH'
-  - --branch=release-1.19
+  - --branch=master
   - --modifier=buildtools
   - --token-env
   - --script-path=../test-infra/tools/automator/scripts/update-images.sh


### PR DESCRIPTION
The upset-build-tools-image job for 1.19 is missing the 1.19 files so finds no jobs to change. Seems the branch should have stayed as `master` in the automation.