### PR TITLE
add a job for existing tests in ambient mode

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -2330,6 +2330,92 @@ postsubmits:
     - ^master$
     cluster: private
     decorate: true
+    name: integ-traffic-ambient_istio_postsubmit_pri
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - test.integration.traffic.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.everywhere -run TestTraffic
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/istio-build-private/proxy
+        image: gcr.io/istio-testing/build-tools:master-415d8353c095cdc3cb100d23fe4cb8e60611d3b4
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: release_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1560,6 +1560,75 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-traffic-ambient_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - test.integration.traffic.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.everywhere -run TestTraffic
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-415d8353c095cdc3cb100d23fe4cb8e60611d3b4
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-helm_istio_postsubmit
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -216,6 +216,19 @@ jobs:
     - prow/config/ambient-sc.yaml
     - test.integration.ambient.kube
 
+  - name: integ-traffic-ambient
+    requirements: [kind]
+    types: [postsubmit]
+    env:
+    - name: INTEGRATION_TEST_FLAGS
+      value: --istio.test.ambient --istio.test.ambient.everywhere -run TestTraffic
+    command:
+    - entrypoint
+    - prow/integ-suite-kind.sh
+    - --kind-config
+    - prow/config/ambient-sc.yaml
+    - test.integration.traffic.kube
+
   - name: integ-helm
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.helm.kube]
     requirements: [kind]


### PR DESCRIPTION
This deserves some discussion, but I think it adds valuable coverage. 
It could also be accomplished by forcing the "everywhere" mode in Go code. 

This invocation without the ambient.everywhere flag results in mostly testing sidecars (I think with HBONE turned on?). We end up skipping a lot. If we grep down to `to_waypoint|from_captured|to_captured` we only gain coverage on the `virtualservice` cases. 

When we run with the everywhere flag, pretty much all our apps get a waypoint. This means we cover pretty much all of the L7 functionality. (That isn't explicitly skipped, which is still a lot). 

```
2023-09-07T19:36:29.084617Z	info	tf	adding waypoint to /a
2023-09-07T19:36:29.084623Z	info	tf	adding waypoint to /b
2023-09-07T19:36:29.084627Z	info	tf	adding waypoint to /c
2023-09-07T19:36:29.084631Z	info	tf	adding waypoint to /headless
2023-09-07T19:36:29.084635Z	info	tf	adding waypoint to /statefulset
2023-09-07T19:36:29.084640Z	info	tf	adding waypoint to /naked
2023-09-07T19:36:29.084644Z	info	tf	adding waypoint to /tproxy
2023-09-07T19:36:29.084649Z	info	tf	adding waypoint to /vm
```

---

I intend to expand this job to run `pilot` rather than `ambient` with `-run TestTraffic`. That will rely on https://github.com/istio/istio/pull/46863 and enumerating valuable tests/and valid skips. 

