### PR TITLE
prowgen: fix env var null vs ""

### DIFF
--- a/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
@@ -16,6 +16,7 @@ postsubmits:
         - make
         - presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -60,6 +61,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.17.gen.yaml
@@ -16,6 +16,7 @@ postsubmits:
         - make
         - presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -58,6 +59,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/api/istio-private.api.release-1.18.gen.yaml
@@ -16,6 +16,7 @@ postsubmits:
         - make
         - presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -58,6 +59,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -20,6 +20,7 @@ postsubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -82,6 +83,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -144,6 +146,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -206,6 +209,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-minimal
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -268,6 +272,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -328,6 +333,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -370,6 +376,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -420,6 +427,7 @@ presubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -486,6 +494,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -552,6 +561,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -618,6 +628,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-minimal
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -684,6 +695,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -748,6 +760,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -793,6 +806,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.17.gen.yaml
@@ -20,6 +20,7 @@ postsubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -82,6 +83,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -144,6 +146,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -206,6 +209,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -266,6 +270,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -308,6 +313,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -358,6 +364,7 @@ presubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -424,6 +431,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -490,6 +498,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -556,6 +565,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -620,6 +630,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -665,6 +676,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.18.gen.yaml
@@ -20,6 +20,7 @@ postsubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -82,6 +83,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -144,6 +146,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -206,6 +209,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-minimal
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -268,6 +272,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -328,6 +333,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -370,6 +376,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -420,6 +427,7 @@ presubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -486,6 +494,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -552,6 +561,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -618,6 +628,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-minimal
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -684,6 +695,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -748,6 +760,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -793,6 +806,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.19.gen.yaml
@@ -20,6 +20,7 @@ postsubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -82,6 +83,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -144,6 +146,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -206,6 +209,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-minimal
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -268,6 +272,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -328,6 +333,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -370,6 +376,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -420,6 +427,7 @@ presubmits:
         - MULTICLUSTER
         - doc.test.multicluster
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -486,6 +494,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-default
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -552,6 +561,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-demo
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -618,6 +628,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-minimal
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -684,6 +695,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - doc.test.profile-none
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -748,6 +760,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -793,6 +806,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -19,6 +19,7 @@ postsubmits:
         - prow/config/ambient-sc.yaml
         - test.integration.ambient.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -105,6 +106,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -189,6 +191,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -278,6 +281,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -364,6 +368,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -448,6 +453,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -534,6 +540,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -616,6 +623,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -708,6 +716,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -798,6 +807,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -886,6 +896,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.23.9
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -974,6 +985,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.24.9
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1062,6 +1074,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.25.9
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1150,6 +1163,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.26.6
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1240,6 +1254,7 @@ postsubmits:
         - prow/config/modern.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1324,6 +1339,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1406,6 +1422,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1494,6 +1511,7 @@ postsubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1582,6 +1600,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1668,6 +1687,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1750,6 +1770,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1836,6 +1857,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1922,6 +1944,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2004,6 +2027,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2090,6 +2114,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2176,6 +2201,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2258,6 +2284,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2413,6 +2440,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2483,6 +2511,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2547,6 +2576,7 @@ presubmits:
         - make
         - test.integration.analyze
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2615,6 +2645,7 @@ presubmits:
         - make
         - benchtest
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2680,6 +2711,7 @@ presubmits:
         - make
         - bookinfo.build
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2754,6 +2786,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2839,6 +2872,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2908,6 +2942,7 @@ presubmits:
         - prow/config/ambient-sc.yaml
         - test.integration.ambient.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2998,6 +3033,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3085,6 +3121,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3175,6 +3212,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3262,6 +3300,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3349,6 +3388,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3438,6 +3478,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3523,6 +3564,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3612,6 +3654,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3702,6 +3745,7 @@ presubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3794,6 +3838,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3884,6 +3929,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3970,6 +4016,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4059,6 +4106,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4149,6 +4197,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4235,6 +4284,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4324,6 +4374,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4414,6 +4465,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4499,6 +4551,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4583,6 +4636,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4646,6 +4700,7 @@ presubmits:
         - entrypoint
         - prow/release-test.sh
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4718,6 +4773,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4791,6 +4847,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.17.gen.yaml
@@ -19,6 +19,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -103,6 +104,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -192,6 +194,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -278,6 +281,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -362,6 +366,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -448,6 +453,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -530,6 +536,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -622,6 +629,7 @@ postsubmits:
         - prow/config/trustworthy-jwt.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -712,6 +720,7 @@ postsubmits:
         - prow/config/endpointslice.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -802,6 +811,7 @@ postsubmits:
         - prow/config/trustworthy-jwt.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -892,6 +902,7 @@ postsubmits:
         - prow/config/trustworthy-jwt.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -982,6 +993,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1072,6 +1084,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1162,6 +1175,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1250,6 +1264,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.23.1
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1338,6 +1353,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.24.3
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1426,6 +1442,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.25.4
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1510,6 +1527,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1592,6 +1610,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1680,6 +1699,7 @@ postsubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1768,6 +1788,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1854,6 +1875,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1936,6 +1958,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2022,6 +2045,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2108,6 +2132,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2190,6 +2215,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2276,6 +2302,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2362,6 +2389,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2444,6 +2472,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2599,6 +2628,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2669,6 +2699,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2733,6 +2764,7 @@ presubmits:
         - make
         - test.integration.analyze
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2801,6 +2833,7 @@ presubmits:
         - make
         - benchtest
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2864,6 +2897,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2934,6 +2968,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3021,6 +3056,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3111,6 +3147,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3198,6 +3235,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3285,6 +3323,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3374,6 +3413,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3459,6 +3499,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3548,6 +3589,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3638,6 +3680,7 @@ presubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3730,6 +3773,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3820,6 +3864,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3906,6 +3951,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3995,6 +4041,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4085,6 +4132,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4171,6 +4219,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4260,6 +4309,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4350,6 +4400,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4435,6 +4486,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4519,6 +4571,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4582,6 +4635,7 @@ presubmits:
         - entrypoint
         - prow/release-test.sh
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4654,6 +4708,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4727,6 +4782,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.18.gen.yaml
@@ -19,6 +19,7 @@ postsubmits:
         - prow/config/ambient-sc.yaml
         - test.integration.ambient.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -105,6 +106,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -189,6 +191,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -278,6 +281,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -364,6 +368,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -448,6 +453,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -534,6 +540,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -616,6 +623,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -708,6 +716,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -798,6 +807,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -888,6 +898,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -976,6 +987,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.23.1
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1064,6 +1076,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.24.3
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1152,6 +1165,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.25.4
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1240,6 +1254,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.26.3
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1324,6 +1339,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1406,6 +1422,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1494,6 +1511,7 @@ postsubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1582,6 +1600,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1668,6 +1687,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1750,6 +1770,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1836,6 +1857,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1922,6 +1944,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2004,6 +2027,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2090,6 +2114,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2176,6 +2201,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2258,6 +2284,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2413,6 +2440,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2483,6 +2511,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2547,6 +2576,7 @@ presubmits:
         - make
         - test.integration.analyze
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2615,6 +2645,7 @@ presubmits:
         - make
         - benchtest
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2678,6 +2709,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2747,6 +2779,7 @@ presubmits:
         - prow/config/ambient-sc.yaml
         - test.integration.ambient.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2837,6 +2870,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2924,6 +2958,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3014,6 +3049,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3101,6 +3137,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3188,6 +3225,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3277,6 +3315,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3362,6 +3401,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3451,6 +3491,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3541,6 +3582,7 @@ presubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3633,6 +3675,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3723,6 +3766,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3809,6 +3853,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3898,6 +3943,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3988,6 +4034,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4074,6 +4121,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4163,6 +4211,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4253,6 +4302,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4338,6 +4388,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4422,6 +4473,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4485,6 +4537,7 @@ presubmits:
         - entrypoint
         - prow/release-test.sh
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4557,6 +4610,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4630,6 +4684,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.19.gen.yaml
@@ -19,6 +19,7 @@ postsubmits:
         - prow/config/ambient-sc.yaml
         - test.integration.ambient.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -105,6 +106,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -189,6 +191,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -278,6 +281,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -364,6 +368,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -448,6 +453,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -534,6 +540,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -616,6 +623,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -708,6 +716,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -798,6 +807,7 @@ postsubmits:
         - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -886,6 +896,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.23.9
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -974,6 +985,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.24.9
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1062,6 +1074,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.25.9
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1150,6 +1163,7 @@ postsubmits:
         - gcr.io/istio-testing/kind-node:v1.26.6
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1240,6 +1254,7 @@ postsubmits:
         - prow/config/modern.yaml
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1324,6 +1339,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1406,6 +1422,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1494,6 +1511,7 @@ postsubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1582,6 +1600,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1668,6 +1687,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1750,6 +1770,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1836,6 +1857,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -1922,6 +1944,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2004,6 +2027,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2090,6 +2114,7 @@ postsubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2176,6 +2201,7 @@ postsubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2258,6 +2284,7 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2413,6 +2440,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2483,6 +2511,7 @@ postsubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2547,6 +2576,7 @@ presubmits:
         - make
         - test.integration.analyze
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2615,6 +2645,7 @@ presubmits:
         - make
         - benchtest
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -2680,6 +2711,7 @@ presubmits:
         - make
         - bookinfo.build
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2754,6 +2786,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2839,6 +2872,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2908,6 +2942,7 @@ presubmits:
         - prow/config/ambient-sc.yaml
         - test.integration.ambient.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -2998,6 +3033,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3085,6 +3121,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3175,6 +3212,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube.presubmit
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3262,6 +3300,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3349,6 +3388,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3438,6 +3478,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.helm.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3523,6 +3564,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.kube.environment
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED
@@ -3612,6 +3654,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.operator.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3702,6 +3745,7 @@ presubmits:
         - prow/config/topology/external-istiod-multicluster.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3794,6 +3838,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3884,6 +3929,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -3970,6 +4016,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.pilot.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4059,6 +4106,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4149,6 +4197,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4235,6 +4284,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.security.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4324,6 +4374,7 @@ presubmits:
         - prow/config/topology/external-istiod.json
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4414,6 +4465,7 @@ presubmits:
         - MULTICLUSTER
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4499,6 +4551,7 @@ presubmits:
         - prow/integ-suite-kind.sh
         - test.integration.telemetry.kube
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -4583,6 +4636,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4646,6 +4700,7 @@ presubmits:
         - entrypoint
         - prow/release-test.sh
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4718,6 +4773,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES
@@ -4791,6 +4847,7 @@ presubmits:
         - racetest
         - binaries-test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: DEPENDENCIES

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.17.gen.yaml
@@ -28,6 +28,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
+        - name: PUSH_RELEASE_FLAGS
         image: gcr.io/istio-testing/build-tools-proxy:release-1.17-6c7535f4b170af845367915982c488bc99f36f2e
         name: ""
         resources:
@@ -93,6 +94,7 @@ postsubmits:
           value: istio-build-private
         - name: GOMAXPROCS
           value: "64"
+        - name: PUSH_RELEASE_FLAGS
         image: gcr.io/istio-testing/build-tools-centos:release-1.17-6c7535f4b170af845367915982c488bc99f36f2e
         name: ""
         resources:
@@ -153,6 +155,7 @@ postsubmits:
           value: istio-build-private
         - name: GOMAXPROCS
           value: "64"
+        - name: PUSH_RELEASE_FLAGS
         image: gcr.io/istio-testing/build-tools-proxy:release-1.17-6c7535f4b170af845367915982c488bc99f36f2e
         name: ""
         resources:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -85,6 +85,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -138,6 +139,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -191,6 +193,7 @@ postsubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -300,6 +303,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -356,6 +360,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -412,6 +417,7 @@ presubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.17.gen.yaml
@@ -88,6 +88,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -141,6 +142,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -194,6 +196,7 @@ postsubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -303,6 +306,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -359,6 +363,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -415,6 +420,7 @@ presubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.18.gen.yaml
@@ -88,6 +88,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -141,6 +142,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -194,6 +196,7 @@ postsubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -303,6 +306,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -359,6 +363,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -415,6 +420,7 @@ presubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.19.gen.yaml
@@ -85,6 +85,7 @@ postsubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -138,6 +139,7 @@ postsubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -191,6 +193,7 @@ postsubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -300,6 +303,7 @@ presubmits:
         - make
         - gen-check
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -356,6 +360,7 @@ presubmits:
         - make
         - lint
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -412,6 +417,7 @@ presubmits:
         - make
         - test
         env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS

--- a/prow/config/istio-private_jobs/.defaults.yaml
+++ b/prow/config/istio-private_jobs/.defaults.yaml
@@ -18,7 +18,7 @@ defaults:
   resolve: true
   env:
     GCP_SECRETS: ~ # Don't use their secrets.
-    BAZEL_BUILD_RBE_INSTANCE: ~ # No RBE support
+    BAZEL_BUILD_RBE_INSTANCE: "" # No RBE support
     # No tracing in private cluster
     OTEL_EXPORTER_OTLP_PROTOCOL: ~
     OTEL_EXPORTER_OTLP_ENDPOINT: ~

--- a/tools/prowtrans/pkg/configuration/configuration.go
+++ b/tools/prowtrans/pkg/configuration/configuration.go
@@ -64,7 +64,7 @@ type Transform struct {
 	JobType                []string                `json:"job-type,omitempty"`
 	Selector               map[string]string       `json:"selector,omitempty"`
 	Labels                 map[string]string       `json:"labels,omitempty"`
-	Env                    map[string]string       `json:"env,omitempty"`
+	Env                    map[string]*string      `json:"env,omitempty"`
 	RefOrgMap              map[string]string       `json:"ref-mapping,omitempty"`
 	OrgMap                 map[string]string       `json:"mapping,omitempty"`
 	HubMap                 map[string]string       `json:"hub,omitempty"`


### PR DESCRIPTION
Sometimes we need to actually write `""`, other times we want to erase
the value.

In particular, this explicitly makes RBE=""; otherwise we cannot opt out
