### PR TITLE
Fix release-1.19 build-base-images to update correct istio branch

### DIFF
--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.19.gen.yaml
@@ -22,7 +22,7 @@ periodics:
       - name: BUILD_WITH_CONTAINER
         value: "0"
       - name: VERSION
-        value: release-1.19
+        value: "1.19"
       - name: DOCKER_CONFIG
         value: /var/run/ci/docker
       - name: GCP_SECRETS

--- a/prow/config/jobs/release-builder-1.19.yaml
+++ b/prow/config/jobs/release-builder-1.19.yaml
@@ -1341,7 +1341,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   - name: VERSION
-    value: release-1.19
+    value: "1.19"
   image: gcr.io/istio-testing/build-tools:release-1.19-2c811198beb59ea19c456059fc940eef9537f311
   name: build-base-images
   node_selector:


### PR DESCRIPTION
Looking at https://github.com/istio/istio/pull/47193, the job is trying to update the main istio branch instead of the release-1.19 branch. Issue was an incorrect value for the env var.

Pointer to job in the 1.18 yaml: https://github.com/istio/test-infra/blob/master/prow/config/jobs/release-builder-1.18.yaml#L650-L657