### PR TITLE
Update proxy release 1.20 to pull from Envoy 1.28 branch

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.20.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.20.gen.yaml
@@ -30,7 +30,7 @@ periodics:
       - --labels=auto-merge
       - --modifier=update_envoy_dep
       - --token-env
-      - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
+      - --cmd=UPDATE_BRANCH=release/v1.28 scripts/update_envoy.sh
       env:
       - name: AUTOMATOR_ORG
         value: istio

--- a/prow/config/jobs/proxy-1.20.yaml
+++ b/prow/config/jobs/proxy-1.20.yaml
@@ -1587,7 +1587,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=update_envoy_dep
   - --token-env
-  - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
+  - --cmd=UPDATE_BRANCH=release/v1.28 scripts/update_envoy.sh
   env:
   - name: AUTOMATOR_ORG
     value: istio


### PR DESCRIPTION
Update the proxy updating to pull from the Envoy 1.28 branch.