### PR TITLE
Fix k8s 1.23 config

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -712,6 +712,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.23.9
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1704,6 +1704,8 @@ postsubmits:
         - prow/integ-suite-kind.sh
         - --node-image
         - gcr.io/istio-testing/kind-node:v1.23.9
+        - --kind-config
+        - prow/config/mixedlb-service.yaml
         - test.integration.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -236,6 +236,8 @@ jobs:
       - prow/integ-suite-kind.sh
       - --node-image
       - gcr.io/istio-testing/kind-node:v1.23.9
+      - --kind-config
+      - prow/config/mixedlb-service.yaml
       - test.integration.kube
     requirements: [kind]
     timeout: 4h


### PR DESCRIPTION
We changed the defaults, which broke 1.23. Move them explicitly to the legacyconfig