### PR TITLE
Extend runtime for istio.io profile-none jobs

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -328,6 +328,8 @@ postsubmits:
     - ^master$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -821,6 +823,8 @@ presubmits:
     - ^master$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_pri
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-none

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.19.gen.yaml
@@ -261,6 +261,8 @@ postsubmits:
     - ^release-1.19$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.19_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -683,6 +685,8 @@ presubmits:
     - ^release-1.19$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.19_pri
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-none

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.20.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.20.gen.yaml
@@ -261,6 +261,8 @@ postsubmits:
     - ^release-1.20$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.20_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -683,6 +685,8 @@ presubmits:
     - ^release-1.20$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.20_pri
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-none

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -344,6 +344,8 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -821,6 +823,8 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-none

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.19.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.19.gen.yaml
@@ -220,6 +220,8 @@ postsubmits:
     branches:
     - ^release-1.19$
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.19_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -630,6 +632,8 @@ presubmits:
     branches:
     - ^release-1.19$
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.19
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-none

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.20.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.20.gen.yaml
@@ -220,6 +220,8 @@ postsubmits:
     branches:
     - ^release-1.20$
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.20_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -630,6 +632,8 @@ presubmits:
     branches:
     - ^release-1.20$
     decorate: true
+    decoration_config:
+      timeout: 1h30m0s
     name: doc.test.profile-none_istio.io_release-1.20
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-none

--- a/prow/config/jobs/istio.io-1.19.yaml
+++ b/prow/config/jobs/istio.io-1.19.yaml
@@ -679,6 +679,7 @@ jobs:
   name: doc.test.profile-none
   node_selector:
     testing: test-pool
+  timeout: 1h30m0s
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
   requirement_presets:
     build-base:

--- a/prow/config/jobs/istio.io-1.20.yaml
+++ b/prow/config/jobs/istio.io-1.20.yaml
@@ -659,6 +659,7 @@ jobs:
   name: doc.test.profile-none
   node_selector:
     testing: test-pool
+  timeout: 1h30m0s
   regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
   requirement_presets:
     build-base:

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -24,6 +24,7 @@ jobs:
   - name: doc.test.profile-none
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-none]
     requirements: [kind]
+    timeout: 1h30m0s
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 
   - name: doc.test.profile-minimal


### PR DESCRIPTION
Looking at https://prow.istio.io/job-history/gs/istio-prow/logs/doc.test.profile-none_istio.io_postsubmit, we see this job takes around 60 minutes to finish and sometimes its goes over and it terminated as a failure. Extend the timeout for the job.