### PR TITLE
add missing release-deps cm for 1.20 and 1.21

### DIFF
--- a/prow/cluster/private/release-deps.yaml
+++ b/prow/cluster/private/release-deps.yaml
@@ -149,9 +149,6 @@ data:
       ztunnel:
         git: https://github.com/istio/ztunnel
         auto: deps
-      pkg:
-        git: https://github.com/istio/pkg
-        auto: modules
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.20
@@ -184,9 +181,6 @@ data:
       ztunnel:
         git: https://github.com/istio/ztunnel
         auto: deps
-      pkg:
-        git: https://github.com/istio/pkg
-        auto: modules
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.20
@@ -219,9 +213,6 @@ data:
       ztunnel:
         git: https://github.com/istio/ztunnel
         auto: deps
-      pkg:
-        git: https://github.com/istio/pkg
-        auto: modules
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.20
@@ -254,9 +245,6 @@ data:
       ztunnel:
         git: https://github.com/istio/ztunnel
         auto: deps
-      pkg:
-        git: https://github.com/istio/pkg
-        auto: modules
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.21

--- a/prow/cluster/private/release-deps.yaml
+++ b/prow/cluster/private/release-deps.yaml
@@ -139,6 +139,41 @@ data:
   dependencies: |2
       istio:
         git: https://github.com/istio-private/istio
+        localpath: /home/prow/go/src/istio.io/istio
+      api:
+        git: https://github.com/istio/api
+        auto: modules
+      proxy:
+        git: https://github.com/istio-private/proxy
+        auto: deps
+      ztunnel:
+        git: https://github.com/istio/ztunnel
+        auto: deps
+      pkg:
+        git: https://github.com/istio/pkg
+        auto: modules
+      client-go:
+        git: https://github.com/istio/client-go
+        branch: release-1.20
+      test-infra:
+        git: https://github.com/istio/test-infra
+        branch: master
+      tools:
+        git: https://github.com/istio/tools
+        branch: release-1.20
+      release-builder:
+        git: https://github.com/istio/release-builder
+        branch: release-1.20
+kind: ConfigMap
+metadata:
+  name: release-1.20-istio-deps
+  namespace: test-pods
+---
+apiVersion: v1
+data:
+  dependencies: |2
+      istio:
+        git: https://github.com/istio-private/istio
         branch: release-1.20
       api:
         git: https://github.com/istio/api
@@ -167,6 +202,41 @@ data:
 kind: ConfigMap
 metadata:
   name: release-1.20-release-deps
+  namespace: test-pods
+---
+apiVersion: v1
+data:
+  dependencies: |2
+      istio:
+        git: https://github.com/istio-private/istio
+        localpath: /home/prow/go/src/istio.io/istio
+      api:
+        git: https://github.com/istio/api
+        auto: modules
+      proxy:
+        git: https://github.com/istio-private/proxy
+        auto: deps
+      ztunnel:
+        git: https://github.com/istio/ztunnel
+        auto: deps
+      pkg:
+        git: https://github.com/istio/pkg
+        auto: modules
+      client-go:
+        git: https://github.com/istio/client-go
+        branch: release-1.20
+      test-infra:
+        git: https://github.com/istio/test-infra
+        branch: master
+      tools:
+        git: https://github.com/istio/tools
+        branch: release-1.20
+      release-builder:
+        git: https://github.com/istio/release-builder
+        branch: release-1.20
+kind: ConfigMap
+metadata:
+  name: release-1.21-istio-deps
   namespace: test-pods
 ---
 apiVersion: v1

--- a/prow/cluster/private/release-deps.yaml
+++ b/prow/cluster/private/release-deps.yaml
@@ -133,3 +133,73 @@ kind: ConfigMap
 metadata:
   name: release-1.19-release-deps
   namespace: test-pods
+---
+apiVersion: v1
+data:
+  dependencies: |2
+      istio:
+        git: https://github.com/istio-private/istio
+        branch: release-1.20
+      api:
+        git: https://github.com/istio/api
+        auto: modules
+      proxy:
+        git: https://github.com/istio-private/proxy
+        auto: deps
+      ztunnel:
+        git: https://github.com/istio/ztunnel
+        auto: deps
+      pkg:
+        git: https://github.com/istio/pkg
+        auto: modules
+      client-go:
+        git: https://github.com/istio/client-go
+        branch: release-1.20
+      test-infra:
+        git: https://github.com/istio/test-infra
+        branch: master
+      tools:
+        git: https://github.com/istio/tools
+        branch: release-1.20
+      release-builder:
+        git: https://github.com/istio/release-builder
+        branch: release-1.20
+kind: ConfigMap
+metadata:
+  name: release-1.20-release-deps
+  namespace: test-pods
+---
+apiVersion: v1
+data:
+  dependencies: |2
+      istio:
+        git: https://github.com/istio-private/istio
+        branch: release-1.21
+      api:
+        git: https://github.com/istio/api
+        auto: modules
+      proxy:
+        git: https://github.com/istio-private/proxy
+        auto: deps
+      ztunnel:
+        git: https://github.com/istio/ztunnel
+        auto: deps
+      pkg:
+        git: https://github.com/istio/pkg
+        auto: modules
+      client-go:
+        git: https://github.com/istio/client-go
+        branch: release-1.21
+      test-infra:
+        git: https://github.com/istio/test-infra
+        branch: master
+      tools:
+        git: https://github.com/istio/tools
+        branch: release-1.21
+      release-builder:
+        git: https://github.com/istio/release-builder
+        branch: release-1.21
+kind: ConfigMap
+metadata:
+  name: release-1.21-release-deps
+  namespace: test-pods


### PR DESCRIPTION
The release-deps configmaps weren't created during branch cutting for 1.20 and 1.21. Add them to the istio-private cluster.