### PR TITLE
Publish v-prefix tags from public builds

### DIFF
--- a/prow/cluster/private/release-deps.yaml
+++ b/prow/cluster/private/release-deps.yaml
@@ -9,6 +9,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -18,6 +19,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: master
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -41,6 +43,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -50,6 +53,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: master
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -73,6 +77,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -85,6 +90,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.19
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -108,6 +114,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -120,6 +127,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.19
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -143,6 +151,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -152,6 +161,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.20
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -175,6 +185,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -184,6 +195,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.20
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -207,6 +219,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -216,6 +229,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.20
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master
@@ -239,6 +253,7 @@ data:
       api:
         git: https://github.com/istio/api
         auto: modules
+        goversionenabled: true
       proxy:
         git: https://github.com/istio-private/proxy
         auto: deps
@@ -248,6 +263,7 @@ data:
       client-go:
         git: https://github.com/istio/client-go
         branch: release-1.21
+        goversionenabled: true
       test-infra:
         git: https://github.com/istio/test-infra
         branch: master


### PR DESCRIPTION
The public builds have this, but not the private ones

https://github.com/istio/api/issues/2178#issuecomment-1961291984
