### PR TITLE
Add a job to verify MacOS builds still work

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -4959,6 +4959,75 @@ presubmits:
     - ^master$
     cluster: private
     decorate: true
+    name: macbuildcheck_istio_pri
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test macbuildcheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - TARGET_OS=darwin
+        - make
+        - build
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/istio-build-private/proxy
+        image: gcr.io/istio-testing/build-tools:master-30750b44971f0d66b92a8bcd681096a5f5e487f1
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+    trigger: ((?m)^/test( | .* )macbuildcheck,?($|\s.*))|((?m)^/test( | .* )macbuildcheck_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: release-test_istio_pri
     path_alias: istio.io/istio
     rerun_command: /test release-test

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -4967,8 +4967,9 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
-        - TARGET_OS=darwin
         - make
+        - -e
+        - TARGET_OS=darwin
         - build
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -4183,8 +4183,9 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
-        - TARGET_OS=darwin
         - make
+        - -e
+        - TARGET_OS=darwin
         - build
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -4175,6 +4175,55 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    name: macbuildcheck_istio
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test macbuildcheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - TARGET_OS=darwin
+        - make
+        - build
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-30750b44971f0d66b92a8bcd681096a5f5e487f1
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )macbuildcheck,?($|\s.*))|((?m)^/test( | .* )macbuildcheck_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
     name: release-notes_istio
     path_alias: istio.io/istio
     rerun_command: /test release-notes

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -1789,8 +1789,9 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
-        - TARGET_OS=darwin
         - make
+        - -e
+        - TARGET_OS=darwin
         - build
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -1781,6 +1781,55 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
+    name: macbuildcheck_istio_exp
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test macbuildcheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - TARGET_OS=darwin
+        - make
+        - build
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-30750b44971f0d66b92a8bcd681096a5f5e487f1
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )macbuildcheck,?($|\s.*))|((?m)^/test( | .* )macbuildcheck_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^experimental-.*
+    decorate: true
     name: release-test_istio_exp
     path_alias: istio.io/istio
     rerun_command: /test release-test

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -402,6 +402,12 @@ jobs:
     regex: '^samples/bookinfo/src/'
     requirements: [docker]
 
+  # Try to create the Mac binaries. Ocassionally a change breaks the ability to build on MacOS.
+  - name: macbuildcheck
+    types: [presubmit]
+    modifiers: [presubmit_optional]
+    command: [TARGET_OS=darwin, make, build]
+
   - name: update-go-control-plane
     types: [periodic]
     cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -406,7 +406,7 @@ jobs:
   - name: macbuildcheck
     types: [presubmit]
     modifiers: [presubmit_optional]
-    command: [TARGET_OS=darwin, make, build]
+    command: [make, -e, "TARGET_OS=darwin", build]
 
   - name: update-go-control-plane
     types: [periodic]


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/49879

Initially make the test optional. Will make required once it's verified to pass.