### PR TITLE
prow: protect all branches in repos

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -148,17 +148,23 @@ branch-protection:
   protect: false
   orgs:
     istio:
+      # Enable protection for all repos
+      protect: true
+      # Every repo requires CLA to pass
       required_status_checks:
         contexts:
         - EasyCLA
-      required_pull_request_reviews: &protection_required_pull_request_reviews
+      # By default, required 1 approval from a CODEOWNER
+      required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
-      restrictions: &protection_restrictions
+      # Repo admins are allowed to merge directly; typically the robot does all merging.
+      restrictions:
         teams:
         - repo-admins
-      repos: &protection_repos
+      repos:
         api:
+          # As API reviews are sensitive, require 2 approvals
           required_pull_request_reviews:
             required_approving_review_count: 2
           branches: &blocked_branches
@@ -314,6 +320,7 @@ branch-protection:
           branches: *blocked_branches
         community:
           branches: *blocked_branches
+          # Community is sensitive, as merges impact the org. Dismiss stale reviews to avoid unexpected changes post-approval.
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             dismissal_restrictions:

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -111,11 +111,10 @@ func TestConfig(t *testing.T) {
 			codeOwners: &yes,
 		},
 		{
-			name:        "istio unprotected by default",
-			org:         "istio",
-			repo:        "istio",
-			branch:      "something-random",
-			unprotected: true,
+			name:   "istio protected by default",
+			org:    "istio",
+			repo:   "istio",
+			branch: "something-random",
 		},
 		{
 			name:   "api release 1.0 requires admin merge",
@@ -175,11 +174,10 @@ func TestConfig(t *testing.T) {
 			branch: "release-1.1",
 		},
 		{
-			name:        "all istio repos define a policy",
-			org:         "istio",
-			repo:        "random-repo",
-			branch:      "master",
-			unprotected: true,
+			name:   "all istio repos get a policy",
+			org:    "istio",
+			repo:   "random-repo",
+			branch: "master",
 		},
 		{
 			name:        "all istio-ecosystem repos define a policy",


### PR DESCRIPTION
This changes our configuration to protect *all* branches in repos, not
just release ones.

This means users will need to work in forks. When operating from the UI,
GitHub should automatically do this for them. For development with
standard CLI tooling, users will need to adopt their workflows to
accomodate.

The `branches` config should not be required anymore, but I left it just
in case this doesn't work how I expect it to. Once we validate it, we
can remove those as well.
