### PR TITLE
Add additional branch protection rules for istio-ecosystem/authservice

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -403,11 +403,15 @@ branch-protection:
       repos:
         authservice:
           required_pull_request_reviews:
-            required_approving_review_count: 0
+            required_approving_review_count: 1
             require_code_owner_reviews: false
           restrictions:
           branches:
             master:
+              protect: true
+            main:
+              protect: true
+            v0-c++:
               protect: true
         sail-operator:
           required_pull_request_reviews:


### PR DESCRIPTION
Configure the istio-ecosystem/authservice to require approval and add branch protection for the `main` branch.