### PR TITLE
Extend branchprotector job timeout to 4 hours

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -38,6 +38,8 @@ periodics:
   labels:
     app: branchprotector
   decorate: true
+  decoration_config:
+    timeout: 4h
   extra_refs:
   - org: istio
     repo: test-infra


### PR DESCRIPTION
I notice the `ci-test-infra-branchprotector` job has been failing since the config was updated with an error that the job is taking over 2 hours (normal is about 1h22m): See https://prow.istio.io/job-history/gs/istio-prow/logs/ci-test-infra-branchprotector

Looking at the jobs, it seems that the new config is causing protection to be run on additional branches which is taking more time. Subsequent runs have a shorter duration for branches that were processed in earlier runs. So in subsequent runs we run against additional branches (not touched in earlier job as it timed out), each of these being longer duration for the first time, and then those branches have a shorter duration in later runs. 

At some point, we will likely be able to get through all the branches so the run will complete in the 2 hrs.

This PR extends the timeout to 4 hrs. Hopefully this will allow more branches to be processed each time and we will get back to a more normal job duration more quickly.

