### PR TITLE
update Prow commit tag length to 9

### DIFF
--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -29,7 +29,7 @@ periodics:
       - --paths=prow/cluster/jobs/**/!(*test-infra*).yaml,prow/config/jobs/**/!(*test-infra*).yaml
       - --source=$AUTOMATOR_ROOT_DIR/prow/cluster/prow-controller-manager.yaml
       - --image=gcr.io/k8s-prow/.*
-      - --tag=v[0-9]{8}-[a-f0-9]{10}
+      - --tag=v[0-9]{8}-[a-f0-9]{9}
       - --var=image
       env:
       - name: AUTOMATOR_ORG

--- a/prow/config/jobs/test-infra.yaml
+++ b/prow/config/jobs/test-infra.yaml
@@ -80,7 +80,7 @@ jobs:
     - --paths=prow/cluster/jobs/**/!(*test-infra*).yaml,prow/config/jobs/**/!(*test-infra*).yaml
     - --source=$AUTOMATOR_ROOT_DIR/prow/cluster/prow-controller-manager.yaml
     - --image=gcr.io/k8s-prow/.*
-    - --tag=v[0-9]{8}-[a-f0-9]{10}
+    - --tag=v[0-9]{8}-[a-f0-9]{9}
     - --var=image
     requirements: [github-istio-testing]
     env:


### PR DESCRIPTION
There has been a failing `bump-k8s-prow-images` job for the last few days: 
  https://prow.istio.io/job-history/gs/istio-prow/logs/bump-k8s-prow-images_test-infra_periodic

Just before the failure we had an image update, where it seems the tag was shortened. This seems consistent with new PRs.

```
-        image: gcr.io/k8s-prow/cherrypicker:v20240405-c76de01869
 +       image: gcr.io/k8s-prow/cherrypicker:v20240418-4c9d8ca12
```