### PR TITLE
Support IPv6 in ztunnel

### DIFF
--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -114,6 +114,7 @@ postsubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - make
         - presubmit
         env:
@@ -163,6 +164,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - ./scripts/benchtest.sh
         env:
         - name: BUILD_WITH_CONTAINER
@@ -209,6 +211,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - command:
+        - entrypoint
         - make
         - presubmit
         env:

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -5,11 +5,11 @@ support_release_branching: true
 
 jobs:
   - name: test
-    command: [make, presubmit]
+    command: [entrypoint, make, presubmit]
     requirements: [cratescache]
 
   - name: bench
-    command: [./scripts/benchtest.sh]
+    command: [entrypoint, ./scripts/benchtest.sh]
     modifiers: [presubmit_optional, presubmit_skipped]
     types: [presubmit]
     requirements: [cratescache]


### PR DESCRIPTION
Without this, we don't trigger the prow-entrypoint.sh which is what
turns on IPv6