### PR TITLE
make ambient docs test job mandatory

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -686,7 +686,6 @@ presubmits:
     cluster: private
     decorate: true
     name: doc.test.profile-ambient_istio.io_pri
-    optional: true
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-ambient
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -805,7 +805,6 @@ presubmits:
     - ^master$
     decorate: true
     name: doc.test.profile-ambient_istio.io
-    optional: true
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.profile-ambient
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -35,7 +35,6 @@ jobs:
   - name: doc.test.profile-ambient
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-ambient]
     requirements: [kind]
-    modifiers: [presubmit_optional]
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 
   - name: doc.test.multicluster


### PR DESCRIPTION
This was previously added as optional for initial testing purpose, now let us make it mandatory.