### PR TITLE
Make docs dual stack job mandatory

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -546,7 +546,6 @@ presubmits:
     cluster: private
     decorate: true
     name: doc.test.dualstack_istio.io_pri
-    optional: true
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.dualstack
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -669,7 +669,6 @@ presubmits:
     - ^master$
     decorate: true
     name: doc.test.dualstack_istio.io
-    optional: true
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.dualstack
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -56,7 +56,6 @@ jobs:
       - name: IP_FAMILY
         value: "dual"
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
-    modifiers: [presubmit_optional]
 
   - name: update-ref-docs-dry-run
     types: [presubmit]


### PR DESCRIPTION
This was supposed to be made mandatory after the initial runs. But I think we forgot to do the same 