### PR TITLE
temporarily skip helm tests

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3858,6 +3858,7 @@ presubmits:
     cluster: private
     decorate: true
     name: integ-helm_istio_pri
+    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -3338,6 +3338,7 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-helm_istio
+    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -798,6 +798,7 @@ presubmits:
     - ^experimental-.*
     decorate: true
     name: integ-helm_istio_exp
+    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -256,6 +256,7 @@ jobs:
     - test.integration.ambient.kube
 
   - name: integ-helm
+    modifiers: [presubmit_optional]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.helm.kube]
     requirements: [kind]
 


### PR DESCRIPTION
For ~1 day, between current state (1.22.2 is partially released) and
tomorrow (1.22.2 is fully released).
