### PR TITLE
Make ambient-ipv6 mandatory presubmit job

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3217,7 +3217,7 @@ presubmits:
           secretName: netrc-secret
     trigger: ((?m)^/test( | .* )integ-ambient-calico,?($|\s.*))|((?m)^/test( | .*
       )integ-ambient-calico_istio,?($|\s.*))
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -3225,7 +3225,6 @@ presubmits:
     cluster: private
     decorate: true
     name: integ-ambient-ipv6_istio_pri
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-ipv6
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2837,14 +2837,13 @@ presubmits:
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-calico,?($|\s.*))|((?m)^/test( | .*
       )integ-ambient-calico_istio,?($|\s.*))
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:
     - ^master$
     decorate: true
     name: integ-ambient-ipv6_istio
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-ipv6
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -297,14 +297,13 @@ presubmits:
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-calico,?($|\s.*))|((?m)^/test( | .*
       )integ-ambient-calico_istio,?($|\s.*))
-  - always_run: false
+  - always_run: true
     annotations:
       testgrid-dashboards: istio_istio
     branches:
     - ^experimental-.*
     decorate: true
     name: integ-ambient-ipv6_istio_exp
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-ipv6
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -239,7 +239,6 @@ jobs:
     - test.integration.ambient.kube
 
   - name: integ-ambient-ipv6
-    modifiers: [presubmit_optional, presubmit_skipped]
     requirements: [kind]
     env:
     - name: INTEGRATION_TEST_FLAGS


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/51222

All tests seem to be passing as per https://github.com/istio/istio/pull/51765, so now we can make this a mandatory job