### PR TITLE
Revert "temporarily skip helm tests"

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3858,7 +3858,6 @@ presubmits:
     cluster: private
     decorate: true
     name: integ-helm_istio_pri
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -3338,7 +3338,6 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-helm_istio
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -798,7 +798,6 @@ presubmits:
     - ^experimental-.*
     decorate: true
     name: integ-helm_istio_exp
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-helm
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -256,7 +256,6 @@ jobs:
     - test.integration.ambient.kube
 
   - name: integ-helm
-    modifiers: [presubmit_optional]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.helm.kube]
     requirements: [kind]
 


### PR DESCRIPTION
Reverts istio/test-infra#5414 now that we've got the release fixed. Adding DNM label until we actually fix it