### PR TITLE
Make ambient-ipv6 job back to optional

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3403,7 +3403,7 @@ presubmits:
             path: .netrc
           secretName: netrc-secret
     trigger: ((?m)^/test( | .* )integ-ambient-dual,?($|\s.*))|((?m)^/test( | .* )integ-ambient-dual_istio,?($|\s.*))
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-create-test-group: "false"
     branches:
@@ -3411,6 +3411,7 @@ presubmits:
     cluster: private
     decorate: true
     name: integ-ambient-ipv6_istio_pri
+    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-ipv6
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2985,13 +2985,14 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-dual,?($|\s.*))|((?m)^/test( | .* )integ-ambient-dual_istio,?($|\s.*))
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
     branches:
     - ^master$
     decorate: true
     name: integ-ambient-ipv6_istio
+    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-ipv6
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -372,13 +372,14 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-dual,?($|\s.*))|((?m)^/test( | .* )integ-ambient-dual_istio,?($|\s.*))
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio_istio
     branches:
     - ^experimental-.*
     decorate: true
     name: integ-ambient-ipv6_istio_exp
+    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-ipv6
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -239,6 +239,7 @@ jobs:
     - test.integration.ambient.kube
 
   - name: integ-ambient-ipv6
+    modifiers: [presubmit_optional, presubmit_skipped]
     requirements: [kind]
     env:
     - name: INTEGRATION_TEST_FLAGS


### PR DESCRIPTION
Reverts https://github.com/istio/test-infra/pull/5416

As the actual run of the test https://github.com/istio/istio/pull/51858 has failures, and we need to carefully fix them one by one, before making this job mandatory