### PR TITLE
Split unit and integration test on sail-operator ci jobs

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -183,6 +183,106 @@ presubmits:
       testgrid-dashboards: istio-ecosystem_main_sail-operator
     branches:
     - ^main$
+    cluster: prow-arm
+    decorate: true
+    name: integ-tests-arm64_sail-operator_main
+    rerun_command: /test integ-tests-arm64
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test.integration
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-4e0da7275ef5243296e248dc86716a8d804bcbb0
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )integ-tests-arm64,?($|\s.*))|((?m)^/test( | .* )integ-tests-arm64_sail-operator_main,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
+    name: integ-tests_sail-operator_main
+    rerun_command: /test integ-tests
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test.integration
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-4e0da7275ef5243296e248dc86716a8d804bcbb0
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )integ-tests,?($|\s.*))|((?m)^/test( | .* )integ-tests_sail-operator_main,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
     decorate: true
     name: lint_sail-operator_main
     rerun_command: /test lint
@@ -304,7 +404,7 @@ presubmits:
         - -e
         - T=-v -count=1
         - build
-        - test
+        - test.unit
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -359,7 +459,7 @@ presubmits:
         - -e
         - T=-v -count=1
         - build
-        - test
+        - test.unit
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
@@ -117,6 +117,106 @@ presubmits:
       testgrid-dashboards: istio-ecosystem_release-0.1_sail-operator
     branches:
     - ^release-0.1$
+    cluster: prow-arm
+    decorate: true
+    name: integ-tests-arm64_sail-operator_release-0.1
+    rerun_command: /test integ-tests-arm64
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test.integration
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:release-1.22-46fce460ef8547fb88a20de8494683bfb3bfa8e5
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        testing: test-pool
+      tolerations:
+      - effect: NoSchedule
+        key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )integ-tests-arm64,?($|\s.*))|((?m)^/test( | .* )integ-tests-arm64_sail-operator_release-0.1,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_release-0.1_sail-operator
+    branches:
+    - ^release-0.1$
+    decorate: true
+    name: integ-tests_sail-operator_release-0.1
+    rerun_command: /test integ-tests
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test.integration
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:release-1.22-46fce460ef8547fb88a20de8494683bfb3bfa8e5
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )integ-tests,?($|\s.*))|((?m)^/test( | .* )integ-tests_sail-operator_release-0.1,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_release-0.1_sail-operator
+    branches:
+    - ^release-0.1$
     decorate: true
     name: lint_sail-operator_release-0.1
     rerun_command: /test lint
@@ -238,7 +338,7 @@ presubmits:
         - -e
         - T=-v -count=1
         - build
-        - test
+        - test.unit
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -293,7 +393,7 @@ presubmits:
         - -e
         - T=-v -count=1
         - build
-        - test
+        - test.unit
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/config/jobs/sail-operator-release-0.1.yaml
+++ b/prow/config/jobs/sail-operator-release-0.1.yaml
@@ -9,7 +9,12 @@ jobs:
   - name: unit-tests
     types: [presubmit]
     architectures: [amd64, arm64]
-    command: [entrypoint, make, -e, "T=-v -count=1", build, test]
+    command: [entrypoint, make, -e, "T=-v -count=1", build, test.unit]
+
+  - name: integ-tests
+    types: [presubmit]
+    architectures: [amd64, arm64]
+    command: [entrypoint, make, test.integration]
 
   - name: gencheck
     types: [presubmit]

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -9,7 +9,12 @@ jobs:
   - name: unit-tests
     types: [presubmit]
     architectures: [amd64, arm64]
-    command: [entrypoint, make, -e, "T=-v -count=1", build, test]
+    command: [entrypoint, make, -e, "T=-v -count=1", build, test.unit]
+
+  - name: integ-tests
+    types: [presubmit]
+    architectures: [amd64, arm64]
+    command: [entrypoint, make, test.integration]
 
   - name: gencheck
     types: [presubmit]


### PR DESCRIPTION
We were calling an endpoint called `make test` that internally runs `make test.unit` and `make test.integration`. This PR split the jobs to call each target independently