### PR TITLE
Add new job for sail operator ci to validate olm deploy of the operator

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -73,6 +73,73 @@ presubmits:
     branches:
     - ^main$
     decorate: true
+    name: e2e-kind-olm_sail-operator_main
+    rerun_command: /test e2e-kind-olm
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - OLM=true
+        - test.e2e.kind
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-8584ca511549c1cd96d9cb8b900297de83f4cb64
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_main,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
     name: e2e-kind_sail-operator_main
     rerun_command: /test e2e-kind
     spec:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
@@ -7,6 +7,73 @@ presubmits:
     branches:
     - ^release-0.1$
     decorate: true
+    name: e2e-kind-olm_sail-operator_release-0.1
+    rerun_command: /test e2e-kind-olm
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - OLM=true
+        - test.e2e.kind
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:release-1.23-d82829888b6f4a2b2b2644fe481d72ced2e402aa
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-0.1,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_release-0.1_sail-operator
+    branches:
+    - ^release-0.1$
+    decorate: true
     name: e2e-kind_sail-operator_release-0.1
     rerun_command: /test e2e-kind
     spec:

--- a/prow/config/jobs/sail-operator-release-0.1.yaml
+++ b/prow/config/jobs/sail-operator-release-0.1.yaml
@@ -30,6 +30,11 @@ jobs:
     command: [entrypoint, make, test.e2e.kind]
     requirements: [kind]
 
+  - name: e2e-kind-olm
+    types: [presubmit]
+    command: [entrypoint, make, -e, "OLM=true", test.e2e.kind]
+    requirements: [kind]
+
   - name: scorecard
     types: [presubmit]
     command: [entrypoint, make, test.scorecard]

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -30,6 +30,11 @@ jobs:
     command: [entrypoint, make, test.e2e.kind]
     requirements: [kind]
 
+  - name: e2e-kind-olm
+    types: [presubmit]
+    command: [entrypoint, make, -e, "OLM=true", test.e2e.kind]
+    requirements: [kind]
+
   - name: scorecard
     types: [presubmit]
     command: [entrypoint, make, test.scorecard]


### PR DESCRIPTION
Adding a new ci job for the Sail Operator project. Is part of the work for this [issue](https://github.com/istio-ecosystem/sail-operator/issues/296)

Depends on: https://github.com/istio-ecosystem/sail-operator/pull/313