### PR TITLE
Adding multicluster testing to sail operator

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -73,6 +73,74 @@ presubmits:
     branches:
     - ^main$
     decorate: true
+    name: e2e-kind-multicluster_sail-operator_main
+    rerun_command: /test e2e-kind-multicluster
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - MULTICLUSTER=true
+        - test.e2e.kind
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-688c4823afae1884e0a8faef2eeefd70af9d5e5c
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
+      )e2e-kind-multicluster_sail-operator_main,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
     name: e2e-kind-olm_sail-operator_main
     rerun_command: /test e2e-kind-olm
     spec:

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -35,6 +35,11 @@ jobs:
     command: [entrypoint, make, -e, "OLM=true", test.e2e.kind]
     requirements: [kind]
 
+  - name: e2e-kind-multicluster
+    types: [presubmit]
+    command: [entrypoint, make, -e, "MULTICLUSTER=true", test.e2e.kind]
+    requirements: [kind]
+
   - name: scorecard
     types: [presubmit]
     command: [entrypoint, make, test.scorecard]


### PR DESCRIPTION
Related to: https://github.com/istio-ecosystem/sail-operator/issues/91

Adding a new test job to run specific multicluster e2e tests in the sail-operator repo