### PR TITLE
Add dualStack tests in Sail Operator

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -73,6 +73,77 @@ presubmits:
     branches:
     - ^main$
     decorate: true
+    name: e2e-kind-ds_sail-operator_main
+    rerun_command: /test e2e-kind-ds
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - -e
+        - IP_FAMILY=dual
+        - test.e2e.kind
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILY
+          value: dual
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-8463430ba963638b35745d773045701f6d02014d
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )e2e-kind-ds,?($|\s.*))|((?m)^/test( | .* )e2e-kind-ds_sail-operator_main,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
     name: e2e-kind-multicluster_sail-operator_main
     rerun_command: /test e2e-kind-multicluster
     spec:

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -40,6 +40,16 @@ jobs:
     command: [entrypoint, make, -e, "MULTICLUSTER=true", test.e2e.kind]
     requirements: [kind]
 
+  - name: e2e-kind-ds
+    types: [presubmit]
+    command: [entrypoint, make, -e, "IP_FAMILY=dual", test.e2e.kind]
+    requirements: [kind]
+    env:
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+        value: "true"
+      - name: IP_FAMILY
+        value: "dual"
+
   - name: scorecard
     types: [presubmit]
     command: [entrypoint, make, test.scorecard]


### PR DESCRIPTION
This PR adds a new job to run Sail Operator e2e ds tests on a dualStack Kind cluster.

Related to: https://github.com/istio-ecosystem/sail-operator/issues/372
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>