### PR TITLE
Rename Sail Operator dualStack job

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -7,8 +7,8 @@ presubmits:
     branches:
     - ^main$
     decorate: true
-    name: e2e-kind-ds_sail-operator_main
-    rerun_command: /test e2e-kind-ds
+    name: e2e-kind-dualstack_sail-operator_main
+    rerun_command: /test e2e-kind-dualstack
     spec:
       automountServiceAccountToken: false
       containers:
@@ -71,7 +71,7 @@ presubmits:
         name: cgroup
       - emptyDir: {}
         name: docker-root
-    trigger: ((?m)^/test( | .* )e2e-kind-ds,?($|\s.*))|((?m)^/test( | .* )e2e-kind-ds_sail-operator_main,?($|\s.*))
+    trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_main,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio-ecosystem_main_sail-operator

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -40,7 +40,7 @@ jobs:
     command: [entrypoint, make, -e, "MULTICLUSTER=true", test.e2e.kind]
     requirements: [kind]
 
-  - name: e2e-kind-ds
+  - name: e2e-kind-dualstack
     types: [presubmit]
     command: [entrypoint, make, -e, "IP_FAMILY=dual", test.e2e.kind]
     requirements: [kind]


### PR DESCRIPTION
This PR expands "ds" in the dualStack job to make it clear that the job is trying to validate dualStack clusters.

Related to: https://github.com/istio-ecosystem/sail-operator/issues/372
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>