### PR TITLE
Modernize node pools in GKE

### DIFF
--- a/infra/gcp/istio-io/providers.tf
+++ b/infra/gcp/istio-io/providers.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/istio-prerelease-testing/providers.tf
+++ b/infra/gcp/istio-prerelease-testing/providers.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/istio-prow-build/cluster-prow-arm.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow-arm.tf
@@ -130,3 +130,33 @@ module "prow_arm_test_spot" {
   service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
 
 }
+
+# This pool provides the actual ARM (t2a) instances for tests.
+module "prow_arm_test_spot_preview" {
+  source = "../modules/gke-nodepool"
+
+  name           = "c4a-spot"
+  project_name   = "istio-prow-build"
+  location       = "us-central1-f"
+  node_locations = ["us-central1-a"]
+  cluster_name   = "prow-arm"
+
+  # Currently, autoscaling is disabled due to ongoing networking issues on ARM.
+  min_count     = 1
+  max_count     = 1
+  initial_count = 0
+
+  disk_size_gb = 256
+  disk_type    = "hyperdisk-balanced"
+  labels = {
+    testing = "test-pool"
+  }
+
+  arm          = true
+  machine_type = "c4a-standard-16"
+  # Spot instances are used as quota is capped for ARM nodes, and its cheaper.
+  #spot = true
+
+  service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
+
+}

--- a/infra/gcp/istio-prow-build/cluster-prow-arm.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow-arm.tf
@@ -92,9 +92,7 @@ module "prow_arm_default" {
   location     = "us-central1-f"
   cluster_name = "prow-arm"
 
-  initial_count = 1
-  min_count     = 1
-  max_count     = 1
+  initial_count = 0
 
   disk_size_gb    = 100
   disk_type       = "pd-ssd"
@@ -131,11 +129,11 @@ module "prow_arm_test_spot" {
 
 }
 
-# This pool provides the actual ARM (t2a) instances for tests.
+# This pool provides the actual ARM (c4a) instances for tests.
 module "prow_arm_test_spot_preview" {
   source = "../modules/gke-nodepool"
 
-  name           = "c4a-spot"
+  name           = "c4a-16-spot"
   project_name   = "istio-prow-build"
   location       = "us-central1-f"
   node_locations = ["us-central1-a"]
@@ -143,7 +141,7 @@ module "prow_arm_test_spot_preview" {
 
   # Currently, autoscaling is disabled due to ongoing networking issues on ARM.
   min_count     = 1
-  max_count     = 1
+  max_count     = 8
   initial_count = 0
 
   disk_size_gb = 256
@@ -155,7 +153,7 @@ module "prow_arm_test_spot_preview" {
   arm          = true
   machine_type = "c4a-standard-16"
   # Spot instances are used as quota is capped for ARM nodes, and its cheaper.
-  #spot = true
+  spot = true
 
   service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
 

--- a/infra/gcp/istio-prow-build/cluster-prow-arm.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow-arm.tf
@@ -93,40 +93,13 @@ module "prow_arm_default" {
   cluster_name = "prow-arm"
 
   initial_count = 0
+  min_count     = 1
+  max_count     = 1
 
   disk_size_gb    = 100
   disk_type       = "pd-ssd"
   machine_type    = "n1-standard-8"
   service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
-}
-
-# This pool provides the actual ARM (t2a) instances for tests.
-module "prow_arm_test_spot" {
-  source = "../modules/gke-nodepool"
-
-  name         = "t2a-spot"
-  project_name = "istio-prow-build"
-  location     = "us-central1-f"
-  cluster_name = "prow-arm"
-
-  # Currently, autoscaling is disabled due to ongoing networking issues on ARM.
-  min_count     = 8
-  max_count     = 8
-  initial_count = 0
-
-  disk_size_gb = 256
-  disk_type    = "pd-ssd"
-  labels = {
-    testing = "test-pool"
-  }
-
-  arm          = true
-  machine_type = "t2a-standard-16"
-  # Spot instances are used as quota is capped for ARM nodes, and its cheaper.
-  spot = true
-
-  service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
-
 }
 
 # This pool provides the actual ARM (c4a) instances for tests.

--- a/infra/gcp/istio-prow-build/cluster-prow.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow.tf
@@ -203,3 +203,32 @@ module "prow_test_c3" {
     "testing" = "test-pool"
   }
 }
+
+# Prow 'test' node pool is used for most jobs
+# Consists of n4-16 nodes.
+# Note: despite the naming "build" vs "test", a lot of build jobs use the test pool.
+module "prow_test_n4" {
+  source = "../modules/gke-nodepool"
+
+  name         = "istio-test-pool-n4"
+  cluster_name = "prow"
+  location     = "us-west1-a"
+
+  machine_type  = "n4-standard-16"
+  initial_count = 1
+  max_count     = 10
+  min_count     = 1
+
+  # N4 are a bit expensive, so drop cut price by using spot instances
+  spot = true
+
+  disk_size_gb = 256
+  disk_type    = "hyperdisk-balanced"
+
+  project_name    = local.project_id
+  service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
+
+  labels = {
+    "testing" = "test-pool"
+  }
+}

--- a/infra/gcp/istio-prow-build/providers.tf
+++ b/infra/gcp/istio-prow-build/providers.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/istio-prow-build/services.tf
+++ b/infra/gcp/istio-prow-build/services.tf
@@ -7,7 +7,6 @@ resource "google_project_service" "project" {
     "cloudkms.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
-    "containerregistry.googleapis.com",
     "iam.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",

--- a/infra/gcp/istio-prow-private/providers.tf
+++ b/infra/gcp/istio-prow-private/providers.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
   required_version = ">= 0.13"

--- a/infra/gcp/istio-release/providers.tf
+++ b/infra/gcp/istio-release/providers.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/istio-testing/providers.tf
+++ b/infra/gcp/istio-testing/providers.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/modules/gke-cluster/versions.tf
+++ b/infra/gcp/modules/gke-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/modules/gke-nodepool/main.tf
+++ b/infra/gcp/modules/gke-nodepool/main.tf
@@ -19,6 +19,9 @@ resource "google_container_node_pool" "node_pool" {
 
   project  = var.project_name
   location = var.location
+
+  node_locations = length(var.node_locations) > 0 ? var.node_locations : null
+
   cluster  = var.cluster_name
 
   // Auto repair, and auto upgrade nodes to match the master version

--- a/infra/gcp/modules/gke-nodepool/variables.tf
+++ b/infra/gcp/modules/gke-nodepool/variables.tf
@@ -29,6 +29,12 @@ variable "location" {
   type        = string
 }
 
+variable "node_locations" {
+  description = "The GCP location (region or zone) where the node_pool should be located"
+  type        = list(string)
+  default     = []
+}
+
 variable "name" {
   description = "The name to use for this node_pool"
   type        = string

--- a/infra/gcp/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/modules/gke-nodepool/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }

--- a/infra/gcp/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/modules/workload-identity-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.20.0"
+      version = "~> 6.9.0"
     }
   }
 }


### PR DESCRIPTION
These changes have already been made for some time but were under NDA during preview so couldn't open the PR

* t2a -> c4a
* Add new n4 pool. We may move to only this pool, for now we will analyze its stability

These new nodes are only marginally more expensive (~10%), but way faster (~2x) -- this makes them cheaper overall, not to mention the dev productivity gains.