### PR TITLE
Fix failing update-go-control-plane job

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -96,8 +96,8 @@ periodics:
       - --labels=auto-merge,release-notes-none
       - --modifier=update_deps
       - --token-env
-      - --cmd=go get github.com/envoyproxy/go-control-plane/envoy@main && go mod tidy
-        && make gen
+      - --cmd=go get github.com/envoyproxy/go-control-plane/envoy@main && go get github.com/envoyproxy/go-control-plane/contrib@main
+        && go mod tidy && make gen
       env:
       - name: AUTOMATOR_ORG
         value: istio

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -96,8 +96,8 @@ periodics:
       - --labels=auto-merge,release-notes-none
       - --modifier=update_deps
       - --token-env
-      - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy &&
-        make gen
+      - --cmd=go get github.com/envoyproxy/go-control-plane/envoy@main && go mod tidy
+        && make gen
       env:
       - name: AUTOMATOR_ORG
         value: istio

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -493,7 +493,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_deps
     - --token-env
-    - --cmd=go get github.com/envoyproxy/go-control-plane@main && go mod tidy && make gen
+    - --cmd=go get github.com/envoyproxy/go-control-plane/envoy@main && go mod tidy && make gen
     disable_release_branching: true
     requirements: [github-istio-testing]
     repos: [istio/test-infra@master]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -493,7 +493,7 @@ jobs:
     - --labels=auto-merge,release-notes-none
     - --modifier=update_deps
     - --token-env
-    - --cmd=go get github.com/envoyproxy/go-control-plane/envoy@main && go mod tidy && make gen
+    - --cmd=go get github.com/envoyproxy/go-control-plane/envoy@main && go get github.com/envoyproxy/go-control-plane/contrib@main && go mod tidy && make gen
     disable_release_branching: true
     requirements: [github-istio-testing]
     repos: [istio/test-infra@master]


### PR DESCRIPTION
https://prow.istio.io/job-history/gs/istio-prow/logs/update-go-control-plane_istio_periodic this seems to have failed since Dec 8

Inputs from @keithmattix 


"I suspect this release is to blame for the go-control-plane issues: https://github.com/envoyproxy/go-control-plane/releases/tag/v0.13.2

[10:50](https://istio.slack.com/archives/C08418YPW5D/p1737582616412769?thread_ts=1737571568.695119&cid=C08418YPW5D)
Specifically:
The go-control-plane repository is now released as multiple independent packages:
[github.com/envoyproxy/go-control-plane](http://github.com/envoyproxy/go-control-plane) (this release), including the core components such as cache and server
[github.com/envoyproxy/go-control-plane/envoy](http://github.com/envoyproxy/go-control-plane/envoy) and [github.com/envoyproxy/go-control-plane/contrib](http://github.com/envoyproxy/go-control-plane/contrib) for envoy API go generated files
[github.com/envoyproxy/go-control-plane/ratelimit](http://github.com/envoyproxy/go-control-plane/ratelimit) and [github.com/envoyproxy/go-control-plane/xdsmatcher](http://github.com/envoyproxy/go-control-plane/xdsmatcher) as independent components for specific use-cases
[10:51](https://istio.slack.com/archives/C08418YPW5D/p1737582688548419?thread_ts=1737571568.695119&cid=C08418YPW5D)
So we actually probably need to make a PR to istio/istio to change the way our deps are organized"


Wait for the corresponding PRs from @keithmattix or @howardjohn in istio repo.

https://github.com/istio/istio/pull/54804
https://github.com/istio/istio/pull/54803