### PR TITLE
nil check os.DirEntry before checking d.IsDir in callback

### DIFF
--- a/tools/prowgen/cmd/prowgen/main.go
+++ b/tools/prowgen/cmd/prowgen/main.go
@@ -44,7 +44,7 @@ var (
 	preprocessCommand   = flag.String("pre-process-command", "", "command to run to preprocess the meta config files")
 	postprocessCommand  = flag.String("post-process-command", "", "command to run to postprocess the generated config files")
 	longJobNamesAllowed = flag.Bool("allow-long-job-names", false, "allow job names that are longer than 63 characters")
-	skipGarTagging = flag.Bool("skip-gar-tagging", false, "skip tagging gar images since that is permitted by few folks")
+	skipGarTagging      = flag.Bool("skip-gar-tagging", false, "skip tagging gar images since that is permitted by few folks")
 )
 
 func main() {
@@ -68,7 +68,7 @@ func main() {
 
 	if os.Args[1] == "branch" {
 		if err := filepath.WalkDir(*inputDir, func(path string, d os.DirEntry, err error) error {
-			if !d.IsDir() {
+			if d != nil && !d.IsDir() {
 				return nil
 			}
 			if err != nil {
@@ -114,10 +114,10 @@ func main() {
 						// image for the new branch is updated.
 						newImage := fmt.Sprintf("%s:%s-%s", match[1], branch, match[3])
 						jobs.Image = newImage
-						if ! *skipGarTagging {
+						if !*skipGarTagging {
 							if err := exec.Command("gcloud", "container", "images", "add-tag", match[0], newImage).Run(); err != nil {
 								log.Fatalf("Unable to add image tag %q: %v", newImage, err)
-							} 
+							}
 						}
 					}
 					jobs.Branches = []string{branch}
@@ -161,7 +161,7 @@ func main() {
 		// In this way we can have multiple meta-config files for the same org/repo:branch
 		cachedOutput := map[ref]k8sProwConfig.JobConfig{}
 		if err := filepath.WalkDir(*inputDir, func(path string, d os.DirEntry, err error) error {
-			if !d.IsDir() {
+			if d != nil && !d.IsDir() {
 				return nil
 			}
 			if err != nil {


### PR DESCRIPTION
Under some circumstances, [WalkDirFunc](https://pkg.go.dev/io/fs#WalkDirFunc) will call the callback with a nil os.DirEntry argument.

Alternatively, moving the `err` check above the `d.IsDir()` check should also fix the issue, as `err` is set non-nil in both documented cases where `d` would be nil.

This is intended to avoid the [segfault](https://github.com/istio/istio/issues/54707) in release automation step 3.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1300a88]

goroutine 1 [running]:
main.main.func1({0x17715a1, 0x12}, {0x0?, 0x0?}, {0x1a75ae0, 0x40007660c0})
        /tmp/tmp.kuMqMgoaHb/branch/work/src/istio.io/test-infra/tools/prowgen/cmd/prowgen/main.go:71 +0x38
path/filepath.WalkDir({0x17715a1, 0x12}, 0x40006fbf18)
        /usr/local/go/src/path/filepath/path.go:398 +0xa0
main.main()
        /tmp/tmp.kuMqMgoaHb/branch/work/src/istio.io/test-infra/tools/prowgen/cmd/prowgen/main.go:70 +0x254
exit status 2
Error: failed to branch: failed to setup prow: failed to generate new prow config: exit status 1
exit status 1
```