### PR TITLE
Fix the default --input-dir and --cluster-dir for prowgen

### DIFF
--- a/tools/prowgen/cmd/prowgen/main.go
+++ b/tools/prowgen/cmd/prowgen/main.go
@@ -39,8 +39,8 @@ var (
 	// regex to match the test image tags.
 	tagRegex = regexp.MustCompile(`^(.+):(.+)-([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}|[0-9a-f]{40})$`)
 
-	inputDir            = flag.String("input-dir", "./prow/config/jobs", "directory of input jobs")
-	outputDir           = flag.String("output-dir", "./prow/cluster/jobs", "directory of output jobs")
+	inputDir            = flag.String("input-dir", "../../prow/config/jobs", "directory of input jobs")
+	outputDir           = flag.String("output-dir", "../../prow/cluster/jobs", "directory of output jobs")
 	preprocessCommand   = flag.String("pre-process-command", "", "command to run to preprocess the meta config files")
 	postprocessCommand  = flag.String("post-process-command", "", "command to run to postprocess the generated config files")
 	longJobNamesAllowed = flag.Bool("allow-long-job-names", false, "allow job names that are longer than 63 characters")


### PR DESCRIPTION
Release Automation Step 3 fails at this step as 

```
2025-01-30T21:47:06.126583Z	info	Running command: git tag --no-sign 1.25
2025-01-30T21:47:06.139620Z	info	Fetched all sources and setup working directory at /tmp/tmp.sXnNuBmun6/branch/work
2025-01-30T21:47:06.140969Z	info	*** Updating prow config for new branches.
2025-01-30T21:47:06.141009Z	info	Running command: go run ./cmd/prowgen/main.go branch 1.25 --skipGarTagging
2025/01/30 22:47:12 lstat ./prow/config/jobs: no such file or directory
```

The dir is actually `test-infra/prow/config/jobs` 