### PR TITLE
actually update branched image tag in all jobs, not just parent config

### DIFF
--- a/tools/prowgen/cmd/prowgen/main.go
+++ b/tools/prowgen/cmd/prowgen/main.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -84,7 +83,7 @@ func main() {
 
 			imagesToTag := make(map[string]string)
 
-			files, _ := ioutil.ReadDir(path)
+			files, _ := os.ReadDir(path)
 			for _, file := range files {
 				if file.IsDir() {
 					continue
@@ -144,7 +143,7 @@ func main() {
 					}
 
 					// Writes the job yaml
-					if err := ioutil.WriteFile(dst, bytes, 0o644); err != nil {
+					if err := os.WriteFile(dst, bytes, 0o644); err != nil {
 						log.Fatalf("Error writing branches config: %v", err)
 					}
 				}
@@ -190,7 +189,7 @@ func main() {
 			}
 			cli := pkg.Client{BaseConfig: baseConfig, LongJobNamesAllowed: *longJobNamesAllowed}
 
-			files, _ := ioutil.ReadDir(path)
+			files, _ := os.ReadDir(path)
 			for _, file := range files {
 				if file.IsDir() {
 					continue

--- a/tools/prowgen/cmd/prowgen/main.go
+++ b/tools/prowgen/cmd/prowgen/main.go
@@ -82,6 +82,8 @@ func main() {
 			}
 			cli := pkg.Client{BaseConfig: baseConfig, LongJobNamesAllowed: *longJobNamesAllowed}
 
+			imagesToTag := make(map[string]string)
+
 			files, _ := ioutil.ReadDir(path)
 			for _, file := range files {
 				if file.IsDir() {
@@ -113,6 +115,8 @@ func main() {
 						if err := exec.Command("gcloud", "container", "images", "add-tag", matchedImage, newImage).Run(); err != nil {
 							log.Fatalf("Unable to add image tag %q: %v", newImage, err)
 						}
+					} else {
+						imagesToTag[matchedImage] = newImage
 					}
 
 					for index, job := range cfg.Jobs {
@@ -143,6 +147,12 @@ func main() {
 					if err := ioutil.WriteFile(dst, bytes, 0o644); err != nil {
 						log.Fatalf("Error writing branches config: %v", err)
 					}
+				}
+			}
+
+			if *skipGarTagging {
+				for matchedImage, newImage := range imagesToTag {
+					log.Printf("Please find a maintainer with sufficient permissions and have them run `gcloud container image add-tag %s %s`", matchedImage, newImage)
 				}
 			}
 


### PR DESCRIPTION
This appears to be an oversight where the image was not being updated to the branched tag in all jobs, only in the parent config. I believe this should replace the need for the following manual part of Step 3 as described in https://github.com/istio/istio/issues/54707

> In the job configs prow/**/*-1.25.yaml, replace any image build-tools(-centos|-proxy):master with build-tools(-centos|-proxy):release-1.25. This is easy to do in VSCode, like this:

Additionally, filters out duplicate env vars in all jobs to replace the need for the following other manual part of Step 3, 
refs https://pkg.go.dev/k8s.io/api/core/v1#EnvVar

> Remove duplicated env entries of the following in the configs (you can use a similar search in VSCode as above, but beware, it'll only match the indentation level that you specify if you have strict matching enabled.):
```
- name: BUILD_WITH_CONTAINER
  value: "0"
```

Finally, adds logging for commands needed to retag images when running with `--skip-gar-tagging` and updates some minor deprecated filesystem calls.

/cc @kfaseela @dhawton 