### PR TITLE
release-1.25: update testgrid/config.yaml

### DIFF
--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -25,6 +25,28 @@ dashboards:
 - name: istio_ztunnel
 - name: istio_ztunnel_postsubmit
 - name: istio_release-builder_periodic
+- name: istio_release-1.25_istio
+- name: istio_release-1.25_api
+- name: istio_release-1.25_client-go
+- name: istio_release-1.25_common-files
+- name: istio_release-1.25_istio.io
+- name: istio_release-1.25_proxy
+- name: istio_release-1.25_tools
+- name: istio_release-1.25_release-builder
+- name: istio_release-1.25_istio_postsubmit
+- name: istio_release-1.25_client-go_postsubmit
+- name: istio_release-1.25_common-files_postsubmit
+- name: istio_release-1.25_istio.io_postsubmit
+- name: istio_release-1.25_proxy_periodic
+- name: istio_release-1.25_proxy_postsubmit
+- name: istio_release-1.25_api_postsubmit
+- name: istio_release-1.25_tools_postsubmit
+- name: istio_release-1.25_release-builder_postsubmit
+- name: istio_release-1.25_release-builder_periodic
+- name: istio_release-1.25_istio_periodic
+- name: istio_release-1.25_enhancements
+- name: istio_release-1.25_ztunnel
+- name: istio_release-1.25_ztunnel_postsubmit
 - name: istio_release-1.24_istio
 - name: istio_release-1.24_api
 - name: istio_release-1.24_client-go
@@ -104,6 +126,30 @@ dashboards:
 - name: istio-ecosystem_release-1.0_sail-operator
 # Group all dashboards
 dashboard_groups:
+- name: istio_release-1.25
+  dashboard_names:
+  - istio_release-1.25_api
+  - istio_release-1.25_api_postsubmit
+  - istio_release-1.25_client-go
+  - istio_release-1.25_client-go_postsubmit
+  - istio_release-1.25_common-files
+  - istio_release-1.25_common-files_postsubmit
+  - istio_release-1.25_enhancements
+  - istio_release-1.25_istio
+  - istio_release-1.25_istio.io
+  - istio_release-1.25_istio.io_postsubmit
+  - istio_release-1.25_istio_periodic
+  - istio_release-1.25_istio_postsubmit
+  - istio_release-1.25_proxy
+  - istio_release-1.25_proxy_periodic
+  - istio_release-1.25_proxy_postsubmit
+  - istio_release-1.25_release-builder
+  - istio_release-1.25_release-builder_periodic
+  - istio_release-1.25_release-builder_postsubmit
+  - istio_release-1.25_tools
+  - istio_release-1.25_tools_postsubmit
+  - istio_release-1.25_ztunnel_postsubmit
+  - istio_release-1.25_ztunnel
 - name: istio_release-1.24
   dashboard_names:
   - istio_release-1.24_api


### PR DESCRIPTION
I believe this is the last part of step 3 (aside from Google Artifact Registry image tagging) that must still be done manually after updates in https://github.com/istio/test-infra/pull/5592 and https://github.com/istio/release-builder/pull/2026

I'm guessing the images should be tagged and an updated version of the automation PR should be merged before this.

/hold

@kfaseela @dhawton 