### PR TITLE
update Envoy to pull from release/v1.33 branch for Istio 1.25

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.25.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.25.gen.yaml
@@ -30,7 +30,7 @@ periodics:
       - --labels=auto-merge
       - --modifier=update_envoy_dep
       - --token-env
-      - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
+      - --cmd=UPDATE_BRANCH=release/v1.33 scripts/update_envoy.sh
       env:
       - name: AUTOMATOR_ORG
         value: istio

--- a/prow/config/jobs/proxy-1.25.yaml
+++ b/prow/config/jobs/proxy-1.25.yaml
@@ -1466,7 +1466,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=update_envoy_dep
   - --token-env
-  - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
+  - --cmd=UPDATE_BRANCH=release/v1.33 scripts/update_envoy.sh
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"


### PR DESCRIPTION
Like #5517 but for Istio 1.25

https://www.envoyproxy.io/docs/envoy/v1.33.0/version_history/version_history.html