### PR TITLE
Add windowsbuildcheck

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -5639,3 +5639,72 @@ presubmits:
             path: .netrc
           secretName: netrc-secret
     trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
+    name: windowsbuildcheck_istio_pri
+    path_alias: istio.io/istio
+    rerun_command: /test windowsbuildcheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - make
+        - -e
+        - TARGET_OS=windows
+        - build-cni
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/istio-build-private/proxy
+        image: gcr.io/istio-testing/build-tools:master-f765f42b0bbcfbfffc112630404904784118a25b
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+    trigger: ((?m)^/test( | .* )windowsbuildcheck,?($|\s.*))|((?m)^/test( | .* )windowsbuildcheck_istio,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -4757,3 +4757,52 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: windowsbuildcheck_istio
+    path_alias: istio.io/istio
+    rerun_command: /test windowsbuildcheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - make
+        - -e
+        - TARGET_OS=windows
+        - build-cni
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-f765f42b0bbcfbfffc112630404904784118a25b
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )windowsbuildcheck,?($|\s.*))|((?m)^/test( | .* )windowsbuildcheck_istio,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -2011,3 +2011,52 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )unit-tests,?($|\s.*))|((?m)^/test( | .* )unit-tests_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^experimental-.*
+    decorate: true
+    name: windowsbuildcheck_istio_exp
+    path_alias: istio.io/istio
+    rerun_command: /test windowsbuildcheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - make
+        - -e
+        - TARGET_OS=windows
+        - build-cni
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-f765f42b0bbcfbfffc112630404904784118a25b
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )windowsbuildcheck,?($|\s.*))|((?m)^/test( | .* )windowsbuildcheck_istio,?($|\s.*))

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -481,9 +481,9 @@ jobs:
     types: [presubmit]
     command: [make, -e, "TARGET_OS=darwin", build]
 
-  - name: windowscnibuildcheck
+  - name: windowsbuildcheck
     types: [presubmit]
-    command: [make, -e, "TARGET_OS=windows", build-cni]
+    command: [make, -e, "TARGET_OS=windows", build-cni] # TODO: build more once we've refactored
 
   - name: update-go-control-plane
     types: [periodic]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -481,6 +481,10 @@ jobs:
     types: [presubmit]
     command: [make, -e, "TARGET_OS=darwin", build]
 
+  - name: windowscnibuildcheck
+    types: [presubmit]
+    command: [make, -e, "TARGET_OS=windows", build-cni]
+
   - name: update-go-control-plane
     types: [periodic]
     cron: "0 2 * * 0" # run each Sunday at 02:00AM UTC


### PR DESCRIPTION
Now that we're splitting out the linux specific builds to separate files, we need to add a build check for a non linux OS. Windows seems like a good choice