### PR TITLE
Manually update the build tools for release 1.23 to upgrade go to 1.23

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
@@ -23,7 +23,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -88,7 +88,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -152,7 +152,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -200,7 +200,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -252,7 +252,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -296,7 +296,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -342,7 +342,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -411,7 +411,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -466,7 +466,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.23.gen.yaml
@@ -27,7 +27,7 @@ postsubmits:
           value: "8"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -92,7 +92,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -155,7 +155,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -281,7 +281,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -344,7 +344,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -409,7 +409,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -470,7 +470,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -513,7 +513,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -566,7 +566,7 @@ presubmits:
           value: "8"
         - name: IP_FAMILY
           value: dual
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -634,7 +634,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -701,7 +701,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -768,7 +768,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -835,7 +835,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -902,7 +902,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -971,7 +971,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1036,7 +1036,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1082,7 +1082,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.23.gen.yaml
@@ -35,7 +35,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -391,7 +391,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -568,7 +568,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -653,7 +653,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -740,7 +740,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -823,7 +823,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -910,7 +910,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1001,7 +1001,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1090,7 +1090,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1179,7 +1179,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1268,7 +1268,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1359,7 +1359,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1450,7 +1450,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1541,7 +1541,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1624,7 +1624,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1709,7 +1709,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1798,7 +1798,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1887,7 +1887,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1972,7 +1972,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2055,7 +2055,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2144,7 +2144,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2229,7 +2229,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2312,7 +2312,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2397,7 +2397,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2486,7 +2486,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2571,7 +2571,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2654,7 +2654,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2738,7 +2738,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2809,7 +2809,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2880,7 +2880,7 @@ postsubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2947,7 +2947,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3015,7 +3015,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3090,7 +3090,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3176,7 +3176,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3251,7 +3251,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3347,7 +3347,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3442,7 +3442,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3532,7 +3532,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3623,7 +3623,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3709,7 +3709,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3802,7 +3802,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3890,7 +3890,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3980,7 +3980,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4066,7 +4066,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4156,7 +4156,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4242,7 +4242,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4335,7 +4335,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4428,7 +4428,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4517,7 +4517,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4604,7 +4604,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4696,7 +4696,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4785,7 +4785,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4872,7 +4872,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4960,7 +4960,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5053,7 +5053,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5142,7 +5142,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5228,7 +5228,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5311,7 +5311,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5379,7 +5379,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5444,7 +5444,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5517,7 +5517,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -5591,7 +5591,7 @@ presubmits:
               name: release-1.23-istio-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.23.gen.yaml
@@ -29,7 +29,7 @@ postsubmits:
           value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           requests:
@@ -96,7 +96,7 @@ postsubmits:
           value: istio-build-private
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ presubmits:
           value: "0"
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           requests:
@@ -227,7 +227,7 @@ presubmits:
           value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
           value: "0"
         - name: ENVOY_REPOSITORY
           value: https://github.com/istio-private/envoy
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           requests:
@@ -351,7 +351,7 @@ presubmits:
           value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -412,7 +412,7 @@ presubmits:
           value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.23.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
               name: release-1.23-release-deps
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -91,7 +91,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -199,7 +199,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -264,7 +264,7 @@ presubmits:
           value: istio-prerelease-private/charts
         - name: PRERELEASE_DOCKER_HUB
           value: us-docker.pkg.dev/istio-prow-private/istio-prow-private
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -310,7 +310,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -367,7 +367,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -424,7 +424,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/api/istio.api.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/api/istio.api.release-1.23.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -170,7 +170,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -214,7 +214,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -263,7 +263,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/client-go/istio.client-go.release-1.23.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -107,7 +107,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -259,7 +259,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -303,7 +303,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/common-files/istio.common-files.release-1.23.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -253,7 +253,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.23.gen.yaml
@@ -32,7 +32,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.23.gen.yaml
@@ -27,7 +27,7 @@ postsubmits:
           value: dual
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -92,7 +92,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -155,7 +155,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -218,7 +218,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -281,7 +281,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -344,7 +344,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -409,7 +409,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -470,7 +470,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -513,7 +513,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -564,7 +564,7 @@ presubmits:
           value: dual
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -630,7 +630,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -695,7 +695,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -760,7 +760,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -825,7 +825,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -890,7 +890,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -957,7 +957,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1020,7 +1020,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1064,7 +1064,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1120,7 +1120,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.23.gen.yaml
@@ -24,7 +24,7 @@ periodics:
         value: "0"
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+      image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
       name: ""
       resources:
         limits:
@@ -106,7 +106,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+      image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
       name: ""
       resources:
         limits:
@@ -155,7 +155,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -214,7 +214,7 @@ postsubmits:
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -272,7 +272,7 @@ postsubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -345,7 +345,7 @@ postsubmits:
           value: dual
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -418,7 +418,7 @@ postsubmits:
           value: ipv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -487,7 +487,7 @@ postsubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -556,7 +556,7 @@ postsubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -622,7 +622,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -698,7 +698,7 @@ postsubmits:
           value: -flaky
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -765,7 +765,7 @@ postsubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -834,7 +834,7 @@ postsubmits:
           value: dual
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -899,7 +899,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -968,7 +968,7 @@ postsubmits:
           value: ipv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1041,7 +1041,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1112,7 +1112,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1183,7 +1183,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1254,7 +1254,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1327,7 +1327,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1400,7 +1400,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1473,7 +1473,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1538,7 +1538,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1605,7 +1605,7 @@ postsubmits:
           value: grpctesting/istio_echo_cpp
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1676,7 +1676,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1747,7 +1747,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1814,7 +1814,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1879,7 +1879,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -1950,7 +1950,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2017,7 +2017,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2082,7 +2082,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2149,7 +2149,7 @@ postsubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2220,7 +2220,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2287,7 +2287,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2352,7 +2352,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2414,7 +2414,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2468,7 +2468,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2521,7 +2521,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2568,7 +2568,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2616,7 +2616,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2677,7 +2677,7 @@ presubmits:
           value: "true"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2743,7 +2743,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2798,7 +2798,7 @@ presubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2874,7 +2874,7 @@ presubmits:
           value: dual
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -2949,7 +2949,7 @@ presubmits:
           value: ipv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3019,7 +3019,7 @@ presubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3090,7 +3090,7 @@ presubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3157,7 +3157,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3230,7 +3230,7 @@ presubmits:
           value: ' --istio.test.istio.enableCNI=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3298,7 +3298,7 @@ presubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3368,7 +3368,7 @@ presubmits:
           value: dual
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3434,7 +3434,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3504,7 +3504,7 @@ presubmits:
           value: ipv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3570,7 +3570,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3643,7 +3643,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3716,7 +3716,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3785,7 +3785,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3852,7 +3852,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3924,7 +3924,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -3993,7 +3993,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4060,7 +4060,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4128,7 +4128,7 @@ presubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4201,7 +4201,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4270,7 +4270,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4336,7 +4336,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4399,7 +4399,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4447,7 +4447,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4498,7 +4498,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4544,7 +4544,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4598,7 +4598,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -4652,7 +4652,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.23.gen.yaml
@@ -40,7 +40,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "64"
-      image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+      image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
       name: ""
       resources:
         limits:
@@ -91,7 +91,7 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           requests:
@@ -143,7 +143,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -210,7 +210,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -260,7 +260,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           requests:
@@ -308,7 +308,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -355,7 +355,7 @@ presubmits:
           value: arm64
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           requests:
@@ -403,7 +403,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -449,7 +449,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.23.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "8"
-      image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+      image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
       name: ""
       resources:
         limits:
@@ -78,7 +78,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -170,7 +170,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -213,7 +213,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -266,7 +266,7 @@ postsubmits:
           value: /var/run/ci/github/token
         - name: GCP_SECRETS
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -359,7 +359,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -402,7 +402,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -449,7 +449,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -493,7 +493,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -538,7 +538,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -582,7 +582,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/tools/istio.tools.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/tools/istio.tools.release-1.23.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -68,7 +68,7 @@ postsubmits:
         - name: MANIFEST_ARCH
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -144,7 +144,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -192,7 +192,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -235,7 +235,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -370,7 +370,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -426,7 +426,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -562,7 +562,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.23.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.23.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -74,7 +74,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -122,7 +122,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -171,7 +171,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:
@@ -219,7 +219,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+        image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/api-1.23.yaml
+++ b/prow/config/jobs/api-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: build
   node_selector:
     testing: test-pool
@@ -161,7 +161,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: gencheck
   node_selector:
     testing: test-pool
@@ -320,7 +320,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: update-api-dep-client-go
   node_selector:
     testing: test-pool
@@ -477,7 +477,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/config/jobs/client-go-1.23.yaml
+++ b/prow/config/jobs/client-go-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: build
   node_selector:
     testing: test-pool
@@ -161,7 +161,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: lint
   node_selector:
     testing: test-pool
@@ -311,7 +311,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: gencheck
   node_selector:
     testing: test-pool
@@ -472,7 +472,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: update-client-go-dep
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/common-files-1.23.yaml
+++ b/prow/config/jobs/common-files-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: lint
   node_selector:
     testing: test-pool
@@ -171,7 +171,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: update-common
   node_selector:
     testing: test-pool
@@ -336,7 +336,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -505,7 +505,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/enhancements-1.23.yaml
+++ b/prow/config/jobs/enhancements-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh
@@ -12,7 +12,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/config/jobs/istio-1.23.yaml
+++ b/prow/config/jobs/istio-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - architectures:
   - amd64
@@ -19,7 +19,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -190,7 +190,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release-test
   node_selector:
     testing: test-pool
@@ -364,7 +364,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release
   node_selector:
     testing: test-pool
@@ -540,7 +540,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -718,7 +718,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: benchmark-report
   node_selector:
     testing: test-pool
@@ -894,7 +894,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -1068,7 +1068,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -1242,7 +1242,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.peer_metadata_discovery
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-telemetry-discovery
   node_selector:
     testing: test-pool
@@ -1416,7 +1416,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-telemetry-mc
   node_selector:
     testing: test-pool
@@ -1595,7 +1595,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
@@ -1774,7 +1774,7 @@ jobs:
     value: --istio.test.ambient
   - name: KUBERNETES_CNI
     value: calico
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -1951,7 +1951,7 @@ jobs:
     value: "0"
   - name: VARIANT
     value: distroless
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -2125,7 +2125,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -2308,7 +2308,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-ipv6
   node_selector:
     testing: test-pool
@@ -2484,7 +2484,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: dual
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-ds
   node_selector:
     testing: test-pool
@@ -2658,7 +2658,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-basic
   node_selector:
     testing: test-pool
@@ -2830,7 +2830,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-operator-controller
   node_selector:
     testing: test-pool
@@ -3002,7 +3002,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -3176,7 +3176,7 @@ jobs:
     value: "0"
   - name: GRPC_ECHO_IMAGE
     value: grpctesting/istio_echo_cpp
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-pilot-cpp
   node_selector:
     testing: test-pool
@@ -3352,7 +3352,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -3531,7 +3531,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
@@ -3710,7 +3710,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
@@ -3883,7 +3883,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-security
   node_selector:
     testing: test-pool
@@ -4056,7 +4056,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -4232,7 +4232,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -4411,7 +4411,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-security-istiodremote
   node_selector:
     testing: test-pool
@@ -4588,7 +4588,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.ambient
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-ambient
   node_selector:
     testing: test-pool
@@ -4768,7 +4768,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: ipv6
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -4951,7 +4951,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: dual
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -5126,7 +5126,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -5304,7 +5304,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-123
   node_selector:
     testing: test-pool
@@ -5483,7 +5483,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-124
   node_selector:
     testing: test-pool
@@ -5662,7 +5662,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-125
   node_selector:
     testing: test-pool
@@ -5841,7 +5841,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-126
   node_selector:
     testing: test-pool
@@ -6022,7 +6022,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-127
   node_selector:
     testing: test-pool
@@ -6203,7 +6203,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-128
   node_selector:
     testing: test-pool
@@ -6384,7 +6384,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-k8s-129
   node_selector:
     testing: test-pool
@@ -6563,7 +6563,7 @@ jobs:
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -6740,7 +6740,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -6915,7 +6915,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: lint
   node_selector:
     testing: test-pool
@@ -7088,7 +7088,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: gencheck
   node_selector:
     testing: test-pool
@@ -7262,7 +7262,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release-notes
   node_selector:
     testing: test-pool
@@ -7439,7 +7439,7 @@ jobs:
     value: master
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: build-base-images
   node_selector:
     testing: test-pool
@@ -7617,7 +7617,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: bookinfo-build
   node_selector:
     testing: test-pool
@@ -7793,7 +7793,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: macbuildcheck
   node_selector:
     testing: test-pool
@@ -7974,7 +7974,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   interval: 24h
   name: update-ztunnel
   node_selector:

--- a/prow/config/jobs/istio.io-1.23.yaml
+++ b/prow/config/jobs/istio.io-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: lint
   node_selector:
     testing: test-pool
@@ -175,7 +175,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: gencheck
   node_selector:
     testing: test-pool
@@ -340,7 +340,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.profile-default
   node_selector:
     testing: test-pool
@@ -508,7 +508,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.profile-demo
   node_selector:
     testing: test-pool
@@ -675,7 +675,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.profile-none
   node_selector:
     testing: test-pool
@@ -843,7 +843,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.profile-minimal
   node_selector:
     testing: test-pool
@@ -1010,7 +1010,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.profile-ambient
   node_selector:
     testing: test-pool
@@ -1179,7 +1179,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -1350,7 +1350,7 @@ jobs:
     value: "true"
   - name: IP_FAMILY
     value: dual
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: doc.test.dualstack
   node_selector:
     testing: test-pool
@@ -1522,7 +1522,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/config/jobs/proxy-1.23.yaml
+++ b/prow/config/jobs/proxy-1.23.yaml
@@ -3,14 +3,14 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: test
   node_selector:
     testing: build-pool
@@ -167,7 +167,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: test-asan
   node_selector:
     testing: build-pool
@@ -328,7 +328,7 @@ jobs:
     value: "0"
   - name: ARCH_SUFFIX
     value: $(params.arch)
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: test-arm
   node_selector:
     testing: test-pool
@@ -486,7 +486,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release-test
   node_selector:
     testing: build-pool
@@ -649,7 +649,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release-test
   node_selector:
     testing: test-pool
@@ -808,7 +808,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release
   node_selector:
     testing: build-pool
@@ -973,7 +973,7 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release
   node_selector:
     testing: test-pool
@@ -1143,7 +1143,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1312,7 +1312,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/config/jobs/release-builder-1.23.yaml
+++ b/prow/config/jobs/release-builder-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: lint
   node_selector:
     testing: test-pool
@@ -174,7 +174,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: test
   node_selector:
     testing: test-pool
@@ -337,7 +337,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: gencheck
   node_selector:
     testing: test-pool
@@ -500,7 +500,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: dry-run
   node_selector:
     testing: test-pool
@@ -665,7 +665,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -832,7 +832,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -1000,7 +1000,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: build-release
   node_selector:
     testing: test-pool
@@ -1169,7 +1169,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   max_concurrency: 1
   name: publish-release
   node_selector:
@@ -1342,7 +1342,7 @@ jobs:
     value: "0"
   - name: VERSION
     value: "1.23"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/sail-operator-release-0.1.yaml
+++ b/prow/config/jobs/sail-operator-release-0.1.yaml
@@ -4,7 +4,7 @@ branches:
   - release-0.1
 
 support_release_branching: false
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
   - name: unit-tests
     types: [presubmit]

--- a/prow/config/jobs/tools-1.23.yaml
+++ b/prow/config/jobs/tools-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: build
   node_selector:
     testing: test-pool
@@ -168,7 +168,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: lint
   node_selector:
     testing: test-pool
@@ -325,7 +325,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: test
   node_selector:
     testing: test-pool
@@ -482,7 +482,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: gencheck
   node_selector:
     testing: test-pool
@@ -650,7 +650,7 @@ jobs:
     value: arm64 amd64
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: containers
   node_selector:
     testing: test-pool
@@ -821,7 +821,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   - name: MANIFEST_ARCH
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: containers
   node_selector:
     testing: test-pool
@@ -985,7 +985,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: containers-test
   node_selector:
     testing: test-pool
@@ -1150,7 +1150,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: containers-test
   node_selector:
     testing: test-pool

--- a/prow/config/jobs/ztunnel-1.23.yaml
+++ b/prow/config/jobs/ztunnel-1.23.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
 jobs:
 - command:
   - entrypoint
@@ -12,7 +12,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: test
   node_selector:
     testing: test-pool
@@ -163,7 +163,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -322,7 +322,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.23-d2ac9017a4c8dfb928bbfddd064833427afc0524
+  image: gcr.io/istio-testing/build-tools:release-1.23-e9f6190ae4240f32b09ae17d9ba10dedca34728b
   name: release
   node_selector:
     testing: test-pool


### PR DESCRIPTION
Postsubmit build tools job failed when updating test infra because of go version disparity. So opening up the PR manually

Context: https://istio.slack.com/archives/C078Q0ZLFLK/p1742236284514479

build tools go update PR https://github.com/istio/tools/pull/3170/files