### PR TITLE
Add new job for sail operator: automated docs testing

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -7,6 +7,71 @@ presubmits:
     branches:
     - ^main$
     decorate: true
+    name: docs-test_sail-operator_main
+    rerun_command: /test docs-test
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test.docs
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-fcd42145fc132acd1e8f607e9e7aca15058e9fb9
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )docs-test,?($|\s.*))|((?m)^/test( | .* )docs-test_sail-operator_main,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
     name: e2e-kind-dualstack_sail-operator_main
     rerun_command: /test e2e-kind-dualstack
     spec:

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -55,6 +55,11 @@ jobs:
     command: [entrypoint, make, test.scorecard]
     requirements: [kind]
 
+  - name: docs-test
+    types: [presubmit]
+    command: [entrypoint, make, test.docs]
+    requirements: [kind]
+
 resources_presets:
   default:
     requests:


### PR DESCRIPTION
Fixes https://github.com/istio-ecosystem/sail-operator/issues/780

Adding a new job to run automatic tests over the documentation steps in the docs located under /docs folder in the sail operator repository