### PR TITLE
Fixup ambient multicluster tests with a new topology

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -289,7 +289,8 @@ postsubmits:
         - --kind-config
         - prow/config/ambient-sc.yaml
         - --topology
-        - MULTICLUSTER
+        - AMBIENT_MULTICLUSTER
+        - --topology-config prow/config/topology/ambient-multicluster.json
         - test.integration.ambient.kube
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE
@@ -3705,7 +3706,8 @@ presubmits:
         - --kind-config
         - prow/config/ambient-sc.yaml
         - --topology
-        - MULTICLUSTER
+        - AMBIENT_MULTICLUSTER
+        - --topology-config prow/config/topology/ambient-multicluster.json
         - test.integration.ambient.kube
         env:
         - name: BAZEL_BUILD_RBE_INSTANCE

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -546,7 +546,8 @@ postsubmits:
         - --kind-config
         - prow/config/ambient-sc.yaml
         - --topology
-        - MULTICLUSTER
+        - AMBIENT_MULTICLUSTER
+        - --topology-config prow/config/topology/ambient-multicluster.json
         - test.integration.ambient.kube
         env:
         - name: BUILD_WITH_CONTAINER
@@ -3230,7 +3231,8 @@ presubmits:
         - --kind-config
         - prow/config/ambient-sc.yaml
         - --topology
-        - MULTICLUSTER
+        - AMBIENT_MULTICLUSTER
+        - --topology-config prow/config/topology/ambient-multicluster.json
         - test.integration.ambient.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -516,7 +516,8 @@ presubmits:
         - --kind-config
         - prow/config/ambient-sc.yaml
         - --topology
-        - MULTICLUSTER
+        - AMBIENT_MULTICLUSTER
+        - --topology-config prow/config/topology/ambient-multicluster.json
         - test.integration.ambient.kube
         env:
         - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -262,7 +262,8 @@ jobs:
     - --kind-config
     - prow/config/ambient-sc.yaml
     - --topology
-    - MULTICLUSTER
+    - AMBIENT_MULTICLUSTER
+    - --topology-config prow/config/topology/ambient-multicluster.json
     - test.integration.ambient.kube
 
   - name: integ-ambient-dual


### PR DESCRIPTION
Tested this locally and tests seem to be running. The issue is that the existing multicluster topology requires a classic east west gateway for istiod remote. To get around this, I created a more basic multinetwork/multicluster topology for ambient