### PR TITLE
add govulncheck to prowjob

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3411,6 +3411,74 @@ presubmits:
     - ^master$
     cluster: private
     decorate: true
+    name: govulncheck_istio_pri
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test govulncheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - govulncheck
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/istio-build-private/proxy
+        image: gcr.io/istio-testing/build-tools:master-01f7536c929d3fafece5d92ce0f2d321205937f1
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+    trigger: ((?m)^/test( | .* )govulncheck,?($|\s.*))|((?m)^/test( | .* )govulncheck_istio,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: integ-ambient-calico_istio_pri
     optional: true
     path_alias: istio.io/istio

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -11,6 +11,55 @@ periodics:
     org: istio
     path_alias: istio.io/istio
     repo: istio
+  name: govulncheck_istio_periodic
+  spec:
+    automountServiceAccountToken: false
+    containers:
+    - command:
+      - entrypoint
+      - govulncheck
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
+      - name: GOMAXPROCS
+        value: "5"
+      image: gcr.io/istio-testing/build-tools:master-01f7536c929d3fafece5d92ce0f2d321205937f1
+      name: ""
+      resources:
+        limits:
+          cpu: "5"
+          memory: 24Gi
+        requests:
+          cpu: "5"
+          memory: 3Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /home/prow/go/pkg
+        name: build-cache
+        subPath: gomod
+      - mountPath: /gocache
+        name: build-cache
+        subPath: gocache
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      testing: test-pool
+    volumes:
+    - hostPath:
+        path: /var/tmp/prow/cache
+        type: DirectoryOrCreate
+      name: build-cache
+- annotations:
+    testgrid-alert-email: istio-oncall@googlegroups.com
+    testgrid-dashboards: istio_istio_periodic
+    testgrid-num-failures-to-alert: "1"
+  cron: 0 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: master
+    org: istio
+    path_alias: istio.io/istio
+    repo: istio
   name: integ-security-fuzz_istio_periodic
   spec:
     automountServiceAccountToken: false
@@ -2990,6 +3039,54 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )gencheck,?($|\s.*))|((?m)^/test( | .* )gencheck_istio,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: govulncheck_istio
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test govulncheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - govulncheck
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-01f7536c929d3fafece5d92ce0f2d321205937f1
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )govulncheck,?($|\s.*))|((?m)^/test( | .* )govulncheck_istio,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -280,6 +280,54 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
+    name: govulncheck_istio_exp
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test govulncheck
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - govulncheck
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-01f7536c929d3fafece5d92ce0f2d321205937f1
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )govulncheck,?($|\s.*))|((?m)^/test( | .* )govulncheck_istio,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^experimental-.*
+    decorate: true
     name: integ-ambient-calico_istio_exp
     optional: true
     path_alias: istio.io/istio

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -461,6 +461,12 @@ jobs:
     command: [make, lint]
     resources: lint
 
+  - name: govulncheck
+    types: [periodic, presubmit]
+    modifiers: [presubmit_optional, presubmit_skipped]
+    cron: "0 7 * * *" # starts every day at 07:00AM UTC
+    command: [entrypoint, govulncheck]
+
   - name: gencheck
     types: [presubmit]
     command: [make, gen-check]


### PR DESCRIPTION
Related to this [issue](https://github.com/istio/istio/issues/40828)

Adds a job to istio/istio repo that runs govulncheck daily and on demand in presubmit.