### PR TITLE
sail-operator: make docs-test job optional

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -8,6 +8,7 @@ presubmits:
     - ^main$
     decorate: true
     name: docs-test_sail-operator_main
+    optional: true
     rerun_command: /test docs-test
     spec:
       automountServiceAccountToken: false

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -59,6 +59,7 @@ jobs:
     types: [presubmit]
     command: [entrypoint, make, test.docs]
     requirements: [kind]
+    modifiers: [presubmit_optional]
 
 resources_presets:
   default:


### PR DESCRIPTION
Until https://github.com/istio-ecosystem/sail-operator/issues/820 is resolved