### PR TITLE
sail-operator: only run scorecard test on bundle change

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -480,7 +480,7 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_sail-operator_main,?($|\s.*))
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio-ecosystem_main_sail-operator
     branches:
@@ -488,6 +488,7 @@ presubmits:
     decorate: true
     name: scorecard_sail-operator_main
     rerun_command: /test scorecard
+    run_if_changed: ^bundle/
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.26.gen.yaml
@@ -527,7 +527,7 @@ presubmits:
           type: DirectoryOrCreate
         name: build-cache
     trigger: ((?m)^/test( | .* )lint,?($|\s.*))|((?m)^/test( | .* )lint_sail-operator_release-1.26,?($|\s.*))
-  - always_run: true
+  - always_run: false
     annotations:
       testgrid-dashboards: istio-ecosystem_release-1.26_sail-operator
     branches:
@@ -535,6 +535,7 @@ presubmits:
     decorate: true
     name: scorecard_sail-operator_release-1.26
     rerun_command: /test scorecard
+    run_if_changed: ^bundle/
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/config/jobs/sail-operator-release-1.26.yaml
+++ b/prow/config/jobs/sail-operator-release-1.26.yaml
@@ -54,6 +54,7 @@ jobs:
     types: [presubmit]
     command: [entrypoint, make, test.scorecard]
     requirements: [kind]
+    regex: ^bundle/
 
   - name: docs-test
     types: [presubmit]

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -54,6 +54,7 @@ jobs:
     types: [presubmit]
     command: [entrypoint, make, test.scorecard]
     requirements: [kind]
+    regex: ^bundle/
 
   - name: docs-test
     types: [presubmit]


### PR DESCRIPTION
Fixes https://github.com/istio-ecosystem/sail-operator/issues/602