### PR TITLE
Run istio 1.26 and master on k8s 1.33.1

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1875,6 +1875,97 @@ postsubmits:
     - ^master$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-132_istio_postsubmit_pri
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.32.0
+        - --kind-config
+        - prow/config/modern.yaml
+        - test.integration.kube
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/istio-build-private/proxy
+        image: gcr.io/istio-testing/build-tools:master-9a50b34135f1aa16b04d56dcb89c5b91101a28aa
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: integ-pilot-cpp_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.26.gen.yaml
@@ -1784,6 +1784,97 @@ postsubmits:
     - ^release-1.26$
     cluster: private
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-132_istio_release-1.26_postsubmit_pri
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.32.0
+        - --kind-config
+        - prow/config/modern.yaml
+        - test.integration.kube
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: release-1.26-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/istio-build-private/proxy
+        image: gcr.io/istio-testing/build-tools:release-1.26-70fd8a76e8fc5feb19b8499f0fafb75f97325aee
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^release-1.26$
+    cluster: private
+    decorate: true
     name: integ-pilot-cpp_istio_release-1.26_postsubmit_pri
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1858,6 +1858,79 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-132_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.32.0
+        - --kind-config
+        - prow/config/modern.yaml
+        - test.integration.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-9a50b34135f1aa16b04d56dcb89c5b91101a28aa
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-pilot-cpp_istio_postsubmit
     path_alias: istio.io/istio
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.26.gen.yaml
@@ -1670,6 +1670,79 @@ postsubmits:
     branches:
     - ^release-1.26$
     decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    name: integ-k8s-132_istio_release-1.26_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --node-image
+        - gcr.io/istio-testing/kind-node:v1.32.0
+        - --kind-config
+        - prow/config/modern.yaml
+        - test.integration.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: ' --istio.test.retries=1 '
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:release-1.26-70fd8a76e8fc5feb19b8499f0fafb75f97325aee
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_release-1.26_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^release-1.26$
+    decorate: true
     name: integ-pilot-cpp_istio_release-1.26_postsubmit
     path_alias: istio.io/istio
     spec:

--- a/prow/config/jobs/istio-1.26.yaml
+++ b/prow/config/jobs/istio-1.26.yaml
@@ -7502,6 +7502,207 @@ jobs:
 - command:
   - entrypoint
   - prow/integ-suite-kind.sh
+  - --node-image
+  - gcr.io/istio-testing/kind-node:v1.32.0
+  - --kind-config
+  - prow/config/modern.yaml
+  - test.integration.kube
+  env:
+  - name: BUILD_WITH_CONTAINER
+    value: "0"
+  - name: INTEGRATION_TEST_FLAGS
+    value: ' --istio.test.retries=1 '
+  image: gcr.io/istio-testing/build-tools:release-1.26-70fd8a76e8fc5feb19b8499f0fafb75f97325aee
+  name: integ-k8s-132
+  node_selector:
+    testing: test-pool
+  requirement_presets:
+    build-base:
+      env:
+      - name: DOCKER_CONFIG
+        value: /var/run/ci/docker
+      podSpec:
+        containers: null
+        serviceAccountName: prowjob-release
+      secrets:
+      - file: /var/run/ci/docker/config.json
+        project: istio-prow-build
+        secret: release_docker_istio
+      - env: GH_TOKEN
+        project: istio-prow-build
+        secret: github_istio-testing_pusher
+    cache:
+      volumeMounts:
+      - mountPath: /home/prow/go/pkg
+        name: build-cache
+        subPath: gomod
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    cratescache:
+      podSpec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                - key: cloud.google.com/machine-family
+                  operator: In
+                  values:
+                  - c3
+              weight: 1
+        containers: null
+      volumeMounts:
+      - mountPath: /home/.cargo
+        name: build-cache
+        subPath: cargo
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    docker:
+      volumeMounts:
+      - mountPath: /var/lib/docker
+        name: docker-root
+      volumes:
+      - emptyDir: {}
+        name: docker-root
+    github-istio-testing:
+      podSpec:
+        containers: null
+        serviceAccountName: prowjob-github-istio-testing
+      secrets:
+      - env: GH_TOKEN
+        project: istio-prow-build
+        secret: github_istio-testing_pusher
+    github-organization:
+      volumeMounts:
+      - mountPath: /etc/github-token
+        name: github
+        readOnly: true
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token
+    github-readonly:
+      podSpec:
+        containers: null
+        serviceAccountName: prowjob-github-read
+      secrets:
+      - env: GH_TOKEN
+        project: istio-prow-build
+        secret: github-read_github_read
+    gocache:
+      volumeMounts:
+      - mountPath: /gocache
+        name: build-cache
+        subPath: gocache
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    kind:
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+        readOnly: true
+      - mountPath: /var/lib/docker
+        name: docker-root
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    release:
+      env:
+      - name: COSIGN_KEY
+        value: gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1
+      - name: DOCKER_CONFIG
+        value: /var/run/ci/docker
+      - name: GRAFANA_TOKEN_FILE
+        value: /var/run/ci/grafana/token
+      - name: GITHUB_TOKEN_FILE
+        value: /var/run/ci/github/token
+      podSpec:
+        containers: null
+        serviceAccountName: prowjob-release
+      secrets:
+      - file: /var/run/ci/docker/config.json
+        project: istio-prow-build
+        secret: release_docker_istio
+      - file: /var/run/ci/github/token
+        project: istio-prow-build
+        secret: release_github_istio-release
+      - file: /var/run/ci/grafana/token
+        project: istio-prow-build
+        secret: release_grafana_istio
+    rustccache:
+      env:
+      - name: RUST_CACHE_DIR
+        value: /var/run/rustc-cache
+      volumeMounts:
+      - mountPath: /var/run/rustc-cache
+        name: build-cache
+        subPath: rustc
+    tracing:
+      env:
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://collector.opentelemetry:4317
+      - name: OTEL_EXPORTER_OTLP_INSECURE
+        value: "true"
+  requirements:
+  - cache
+  - cache
+  - gocache
+  - kind
+  resources_presets:
+    dedicated:
+      limits:
+        memory: 24Gi
+      requests:
+        cpu: "15"
+        memory: 8Gi
+    default:
+      limits:
+        cpu: "5"
+        memory: 24Gi
+      requests:
+        cpu: "5"
+        memory: 3Gi
+    lint:
+      limits:
+        memory: 24Gi
+      requests:
+        cpu: "3"
+        memory: 16Gi
+    multicluster:
+      limits:
+        cpu: "8"
+        memory: 24Gi
+      requests:
+        cpu: "8"
+        memory: 3Gi
+  timeout: 4h0m0s
+  types:
+  - postsubmit
+- command:
+  - entrypoint
+  - prow/integ-suite-kind.sh
   - test.integration.kube
   env:
   - name: BUILD_WITH_CONTAINER

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -429,6 +429,22 @@ jobs:
       - name: INTEGRATION_TEST_FLAGS
         value: " --istio.test.retries=1 "
 
+  - name: integ-k8s-132
+    types: [postsubmit]
+    command:
+      - entrypoint
+      - prow/integ-suite-kind.sh
+      - --node-image
+      - gcr.io/istio-testing/kind-node:v1.32.0
+      - --kind-config
+      - prow/config/modern.yaml
+      - test.integration.kube
+    requirements: [kind]
+    timeout: 4h
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: " --istio.test.retries=1 "
+
   - name: integ-cni
     types: [postsubmit]
     command:


### PR DESCRIPTION
Depends on #5688. Goes back and tests 1.26 on k8s 1.33 so we can retroactively certify