### PR TITLE
Indicate new expiration date for token

### DIFF
--- a/infra/gcp/istio-prow-build/secrets.tf
+++ b/infra/gcp/istio-prow-build/secrets.tf
@@ -6,7 +6,7 @@ locals {
     # Access token for "istio" dockerhub account
     "release_docker_istio",
     # Fine grained PAT in the Istio org, "github/istio-release/release". Has write access to "Contents" and "Workflows".
-    # Expires 6/26/2025.
+    # Expires 7/29/2026.
     "release_github_istio-release",
     # Access token for Grafana for the "Istio" org. Named "release-pipeline-token" in Grafana, with role "Editor".
     "release_grafana_istio",


### PR DESCRIPTION
No terraform change needed, this is pulling from GCP secret manager which we write outside TF