### PR TITLE
Seperate IstioOwnedCNI flag to avoid helmValues read

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -387,7 +387,8 @@ postsubmits:
         - name: GOMAXPROCS
           value: "5"
         - name: INTEGRATION_TEST_FLAGS
-          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient '
+          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig
+            --istio.test.ambient '
         - name: DEPENDENCIES
           valueFrom:
             configMapKeyRef:
@@ -4054,7 +4055,8 @@ presubmits:
         - name: GOMAXPROCS
           value: "5"
         - name: INTEGRATION_TEST_FLAGS
-          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient '
+          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig
+            --istio.test.ambient '
         - name: DEPENDENCIES
           valueFrom:
             configMapKeyRef:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -672,7 +672,8 @@ postsubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
-          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient '
+          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig
+            --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
         image: gcr.io/istio-testing/build-tools:master-5b65c620f39f8a750e68465dc49b6753926d0b0b
@@ -3549,7 +3550,8 @@ presubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
-          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient '
+          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig
+            --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
         image: gcr.io/istio-testing/build-tools:master-5b65c620f39f8a750e68465dc49b6753926d0b0b

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -642,7 +642,8 @@ presubmits:
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: INTEGRATION_TEST_FLAGS
-          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient '
+          value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig
+            --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
         image: gcr.io/istio-testing/build-tools:master-5b65c620f39f8a750e68465dc49b6753926d0b0b

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -239,7 +239,7 @@ jobs:
     requirements: [kind]
     env:
     - name: INTEGRATION_TEST_FLAGS
-      value: "--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient "
+      value: "--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig --istio.test.ambient "
     command:
     - entrypoint
     - prow/integ-suite-kind.sh


### PR DESCRIPTION
HelmValues are challenging to read in istio tests to determine whether or not to skip a test. Adding a separate setting makes this check easier with our current design.