### PR TITLE
Fix build.tools image for sail operator release 1.27

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.27.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.27.gen.yaml
@@ -22,7 +22,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -93,7 +93,7 @@ presubmits:
           value: dual
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -160,7 +160,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -228,7 +228,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -293,7 +293,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -357,7 +357,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -405,7 +405,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -457,7 +457,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -501,7 +501,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -548,7 +548,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -617,7 +617,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:
@@ -672,7 +672,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+        image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
         name: ""
         resources:
           limits:

--- a/prow/config/jobs/sail-operator-release-1.27.yaml
+++ b/prow/config/jobs/sail-operator-release-1.27.yaml
@@ -4,7 +4,7 @@ branches:
   - release-1.27
 
 support_release_branching: false
-image: gcr.io/istio-testing/build-tools:release-1.27-672e6089ff843019a2b28cf9e87754c7b74358ea
+image: gcr.io/istio-testing/build-tools:release-1.27-56a42ed008b9070d88166dbec82e798d9eca43de
 jobs:
   - name: unit-tests
     types: [presubmit]


### PR DESCRIPTION
Hi, we need to fix the build-tool image for the release. For some reason, I push in the previous PR a wrong image tag