### PR TITLE
Add release-notes PR check job to Sail Operator

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -486,6 +486,57 @@ presubmits:
     branches:
     - ^main$
     decorate: true
+    name: release-notes_sail-operator_main
+    rerun_command: /test release-notes
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - gen-release-notes
+        - --checkLabel
+        - --validateOnly
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-17c2b235c898c60c83dccb2303cdd50067a6e58d
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      serviceAccountName: prowjob-github-read
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )release-notes,?($|\s.*))|((?m)^/test( | .* )release-notes_sail-operator_main,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
     name: scorecard_sail-operator_main
     rerun_command: /test scorecard
     run_if_changed: ^bundle/

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -62,6 +62,12 @@ jobs:
     requirements: [kind]
     modifiers: [presubmit_optional]
 
+  - name: release-notes
+    types: [presubmit]
+    command: [entrypoint, gen-release-notes, --checkLabel, --validateOnly]
+    requirements: [github-readonly]
+    modifiers: [presubmit_skipped] # Remove once testing is done
+
 resources_presets:
   default:
     requests:


### PR DESCRIPTION
Add release-notes job to Sail Operator.
Currently add it in testing mode.