### PR TITLE
build base images if docker/iptables.yaml is also touched

### DIFF
--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -309,7 +309,7 @@ postsubmits:
       repo: release-builder
     name: build-base-images_istio_postsubmit
     path_alias: istio.io/istio
-    run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+    run_if_changed: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.25.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.25.gen.yaml
@@ -194,7 +194,7 @@ postsubmits:
       repo: release-builder
     name: build-base-images_istio_release-1.25_postsubmit
     path_alias: istio.io/istio
-    run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+    run_if_changed: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.26.gen.yaml
@@ -194,7 +194,7 @@ postsubmits:
       repo: release-builder
     name: build-base-images_istio_release-1.26_postsubmit
     path_alias: istio.io/istio
-    run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+    run_if_changed: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/cluster/jobs/istio/istio/istio.istio.release-1.27.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.release-1.27.gen.yaml
@@ -243,7 +243,7 @@ postsubmits:
       repo: release-builder
     name: build-base-images_istio_release-1.27_postsubmit
     path_alias: istio.io/istio
-    run_if_changed: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+    run_if_changed: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
     spec:
       automountServiceAccountToken: false
       containers:

--- a/prow/config/jobs/istio-1.25.yaml
+++ b/prow/config/jobs/istio-1.25.yaml
@@ -8490,7 +8490,7 @@ jobs:
   name: build-base-images
   node_selector:
     testing: test-pool
-  regex: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+  regex: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
   repos:
   - istio/release-builder@master
   requirement_presets:

--- a/prow/config/jobs/istio-1.26.yaml
+++ b/prow/config/jobs/istio-1.26.yaml
@@ -8691,7 +8691,7 @@ jobs:
   name: build-base-images
   node_selector:
     testing: test-pool
-  regex: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+  regex: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
   repos:
   - istio/release-builder@master
   requirement_presets:

--- a/prow/config/jobs/istio-1.27.yaml
+++ b/prow/config/jobs/istio-1.27.yaml
@@ -9090,7 +9090,7 @@ jobs:
   name: build-base-images
   node_selector:
     testing: test-pool
-  regex: ^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$
+  regex: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
   repos:
   - istio/release-builder@master
   requirement_presets:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -511,7 +511,7 @@ jobs:
   - name: build-base-images
     repos: [istio/release-builder@master]
     types: [postsubmit]
-    regex: '^(docker|pkg/.*)/Dockerfile.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?$'
+    regex: ^((docker|pkg/.*)/Dockerfile\.([a-zA-Z0-9_]+_)?base(_[a-zA-Z0-9_]+)?|docker/iptables\.yaml)$
     env:
     - name: VERSION
       value: "master"


### PR DESCRIPTION
In istio/istio, if docker/iptables.yaml is touched, the base images are not rebuilt... only if the Dockerfile.* is changed.