### PR TITLE
Remove the ENVOY_REPOSITORY override in private repo

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -25,8 +25,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         image: gcr.io/istio-testing/build-tools-proxy:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd
@@ -90,8 +88,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         - name: GOMAXPROCS
@@ -162,8 +158,6 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd
         name: ""
         resources:
@@ -223,8 +217,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd
@@ -286,8 +278,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd
         name: ""
         resources:
@@ -347,8 +337,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd
@@ -408,8 +396,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.26.gen.yaml
@@ -25,8 +25,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         image: gcr.io/istio-testing/build-tools-proxy:release-1.26-80a1b41acf1fe5b60c2b49153f6d3f9ed3a82a0d
@@ -90,8 +88,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         - name: GOMAXPROCS
@@ -162,8 +158,6 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.26-80a1b41acf1fe5b60c2b49153f6d3f9ed3a82a0d
         name: ""
         resources:
@@ -223,8 +217,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.26-80a1b41acf1fe5b60c2b49153f6d3f9ed3a82a0d
@@ -286,8 +278,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.26-80a1b41acf1fe5b60c2b49153f6d3f9ed3a82a0d
         name: ""
         resources:
@@ -347,8 +337,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.26-80a1b41acf1fe5b60c2b49153f6d3f9ed3a82a0d
@@ -408,8 +396,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.26-80a1b41acf1fe5b60c2b49153f6d3f9ed3a82a0d

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.27.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.27.gen.yaml
@@ -25,8 +25,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         image: gcr.io/istio-testing/build-tools-proxy:release-1.27-0ef669e3326567c47323402f8af247931fce234f
@@ -90,8 +88,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         - name: GOMAXPROCS
@@ -162,8 +158,6 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.27-0ef669e3326567c47323402f8af247931fce234f
         name: ""
         resources:
@@ -223,8 +217,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.27-0ef669e3326567c47323402f8af247931fce234f
@@ -286,8 +278,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.27-0ef669e3326567c47323402f8af247931fce234f
         name: ""
         resources:
@@ -347,8 +337,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.27-0ef669e3326567c47323402f8af247931fce234f
@@ -408,8 +396,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.27-0ef669e3326567c47323402f8af247931fce234f

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.28.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.28.gen.yaml
@@ -25,8 +25,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         image: gcr.io/istio-testing/build-tools-proxy:release-1.28-4d8a6668b6d46b3becc35f9b24467f841bbb020a
@@ -90,8 +88,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         - name: GOMAXPROCS
@@ -162,8 +158,6 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.28-4d8a6668b6d46b3becc35f9b24467f841bbb020a
         name: ""
         resources:
@@ -223,8 +217,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.28-4d8a6668b6d46b3becc35f9b24467f841bbb020a
@@ -286,8 +278,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.28-4d8a6668b6d46b3becc35f9b24467f841bbb020a
         name: ""
         resources:
@@ -347,8 +337,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.28-4d8a6668b6d46b3becc35f9b24467f841bbb020a
@@ -408,8 +396,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.28-4d8a6668b6d46b3becc35f9b24467f841bbb020a

--- a/prow/config/istio-private_jobs/proxy-1.26.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.26.yaml
@@ -7,14 +7,11 @@ defaults:
 org: istio
 repo: proxy
 transforms:
-- env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-  job-type:
+- job-type:
   - presubmit
   labels:
     preset-enable-netrc: "true"
 - env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     GCS_BUILD_BUCKET: istio-build-private
   job-denylist:
   - update-istio_proxy_release-1.26

--- a/prow/config/istio-private_jobs/proxy-1.27.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.27.yaml
@@ -7,14 +7,11 @@ defaults:
 org: istio
 repo: proxy
 transforms:
-- env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-  job-type:
+- job-type:
   - presubmit
   labels:
     preset-enable-netrc: "true"
 - env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     GCS_BUILD_BUCKET: istio-build-private
   job-denylist:
   - update-istio_proxy_release-1.27

--- a/prow/config/istio-private_jobs/proxy-1.28.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.28.yaml
@@ -7,14 +7,11 @@ defaults:
 org: istio
 repo: proxy
 transforms:
-- env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-  job-type:
+- job-type:
   - presubmit
   labels:
     preset-enable-netrc: "true"
 - env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     GCS_BUILD_BUCKET: istio-build-private
   job-denylist:
   - update-istio_proxy_release-1.28

--- a/prow/config/istio-private_jobs/proxy.yaml
+++ b/prow/config/istio-private_jobs/proxy.yaml
@@ -10,16 +10,13 @@ defaults:
 transforms:
 
 # istio/proxy master test jobs(s) - presubmit(s)
-- env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-  labels:
+- labels:
     preset-enable-netrc: "true"
   job-type: [presubmit]
 
 # istio/proxy master build jobs(s) - postsubmit(s)
 - env:
     GCS_BUILD_BUCKET: istio-build-private
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
   labels:
     preset-enable-netrc: "true"
   job-type: [postsubmit]


### PR DESCRIPTION
We are migrating to using the patch attribute of http_archive to change envoy. Will provide better traceability of code changes and remove the need to chase down commit hashes. This requires us to pull envoyproxy/envoy directory to then apply our patches on top. See PSWG Slack discussion (https://istio.slack.com/archives/GN5R9MGD8/p1763597921977279).