### PR TITLE
Change prow-private ARM from t2a to c4a

### DIFF
--- a/infra/gcp/istio-prow-private/cluster.tf
+++ b/infra/gcp/istio-prow-private/cluster.tf
@@ -70,8 +70,8 @@ module "prow_node_arm" {
   }
 
   arm  = true
-  machine_type  = "t2a-standard-16"
-  # GCP is only allowing non-trivial quotas for t2a nodes using spot instances, so enable spot instances.
+  machine_type  = "c4a-standard-16"
+  # Spot instances are used as quota is capped for ARM nodes, and it's cheaper.
   spot = true
 
   service_account = module.prow_cluster.cluster_node_sa.email


### PR DESCRIPTION
Public infra uses c4a spot nodes for ARM, which has a performance increase from t2a. We're hitting long build times building Envoy on ARM, so let's try matching public infra before resorting to increasing timeouts or considering RBE caches since these are rarely used.

Ref: https://github.com/istio/test-infra/pull/5525