### PR TITLE
Adding a new job on sail repo to run dependencies script

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -597,6 +597,54 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_main,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio-ecosystem_main_sail-operator
+    branches:
+    - ^main$
+    decorate: true
+    name: tools-hack-check_sail-operator_main
+    rerun_command: /test tools-hack-check
+    run_if_changed: ^(hack/|tools/)
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - update-deps
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-8dcf63149d5bdaa83d1407a121098e8e8d1626dd
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+    trigger: ((?m)^/test( | .* )tools-hack-check,?($|\s.*))|((?m)^/test( | .* )tools-hack-check_sail-operator_main,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio-ecosystem_main_sail-operator

--- a/prow/config/jobs/sail-operator.yaml
+++ b/prow/config/jobs/sail-operator.yaml
@@ -68,6 +68,11 @@ jobs:
     requirements: [github-readonly]
     modifiers: [presubmit_skipped] # Remove once testing is done
 
+  - name: tools-hack-check
+    types: [presubmit]
+    command: [entrypoint, make, update-deps]
+    regex: ^(hack/|tools/)
+
 resources_presets:
   default:
     requests:


### PR DESCRIPTION
The job will run the dependencies script on every change over the hack and tools folder to ensure that nothing is broken on a change on the scripts under those folders

Depends on https://github.com/istio-ecosystem/sail-operator/pull/1405