### PR TITLE
Fix upstream reference for prow autobump

### DIFF
--- a/prow/istio-autobump-config.yaml
+++ b/prow/istio-autobump-config.yaml
@@ -8,7 +8,7 @@ gitHubOrg: "istio"
 gitHubRepo: "test-infra"
 remoteName: "test-infra"
 headBranchName: "autobump-prow"
-upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/k8s.io/main"
 includedConfigPaths:
   - prow/cluster
 targetVersion: "upstream"
@@ -19,6 +19,6 @@ prefixes:
   - name: "Prow"
     prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     repo: "https://github.com/kubernetes-sigs/prow"
-    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    refConfigFile: "kubernetes/gke-prow/prow/deck.yaml"
     summarise: false
     consistentImages: true


### PR DESCRIPTION
It appears that the live prow config has moved to a subdirectory of the kubernetes/k8s.io repo.