### PR TITLE
bump to cgroupv2

### DIFF
--- a/infra/gcp/modules/gke-nodepool/main.tf
+++ b/infra/gcp/modules/gke-nodepool/main.tf
@@ -72,8 +72,7 @@ resource "google_container_node_pool" "node_pool" {
     }
 
     linux_node_config {
-      // We cannot currently run prow on Cgroupsv2
-      cgroup_mode = "CGROUP_MODE_V1"
+      cgroup_mode = "CGROUP_MODE_V2"
     }
   }
 

--- a/tools/prowgen/Dockerfile
+++ b/tools/prowgen/Dockerfile
@@ -22,6 +22,8 @@ ENV CGO_ENABLED=0
 
 WORKDIR /go/src/istio/tools/prowgen/cmd/prowgen
 
+# We do not need to pin a version of our own packages
+# hadolint ignore=DL3062
 RUN go install .
 
 RUN go install github.com/mikefarah/yq/v4@v4.16.2


### PR DESCRIPTION
Our limit was kind, which now supports cgroupv2 and has gone so far as to refuse to start when cgroupv1 https://github.com/kubernetes/kubernetes/pull/134298. https://docs.cloud.google.com/kubernetes-engine/docs/how-to/migrate-cgroupv2 Our nodepools are already 1.33, so GKE could bump us at any point. To be able to test Kubernetes 1.35, we need to bump to cgroupv2.

Closes #5486 