### PR TITLE
remove readonly from /sys/fs/cgroup

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -45,7 +45,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -116,7 +115,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -183,7 +181,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -251,7 +248,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -316,7 +312,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -575,7 +570,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
@@ -46,7 +46,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -111,7 +110,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -365,7 +363,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.2.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.2.gen.yaml
@@ -50,7 +50,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -117,7 +116,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -185,7 +183,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -250,7 +247,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -504,7 +500,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.0.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.0.gen.yaml
@@ -50,7 +50,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -117,7 +116,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -185,7 +183,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -250,7 +247,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -504,7 +500,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.25.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.25.gen.yaml
@@ -50,7 +50,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -117,7 +116,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -185,7 +183,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -250,7 +247,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -504,7 +500,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.26.gen.yaml
@@ -45,7 +45,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -116,7 +115,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -183,7 +181,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -251,7 +248,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -316,7 +312,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -571,7 +566,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.27.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.27.gen.yaml
@@ -45,7 +45,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -116,7 +115,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -183,7 +181,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -251,7 +248,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -316,7 +312,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -571,7 +566,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.28.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.28.gen.yaml
@@ -45,7 +45,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -116,7 +115,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -183,7 +181,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -251,7 +248,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -316,7 +312,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -571,7 +566,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -47,7 +47,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -112,7 +111,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -175,7 +173,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -238,7 +235,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -301,7 +297,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -364,7 +359,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -429,7 +423,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -586,7 +579,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -654,7 +646,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -721,7 +712,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -788,7 +778,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -855,7 +844,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -922,7 +910,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -991,7 +978,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -58,7 +58,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -149,7 +148,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -240,7 +238,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -331,7 +328,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -418,7 +414,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -506,7 +501,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -593,7 +587,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -680,7 +673,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -763,7 +755,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -857,7 +848,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -942,7 +932,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1029,7 +1018,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1112,7 +1100,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1199,7 +1186,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1290,7 +1276,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1379,7 +1364,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1468,7 +1452,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1557,7 +1540,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1648,7 +1630,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1739,7 +1720,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1830,7 +1810,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1921,7 +1900,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2012,7 +1990,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2103,7 +2080,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2194,7 +2170,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2285,7 +2260,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2370,7 +2344,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2459,7 +2432,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2548,7 +2520,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2633,7 +2604,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2716,7 +2686,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2805,7 +2774,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2890,7 +2858,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2973,7 +2940,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3058,7 +3024,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3147,7 +3112,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3232,7 +3196,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3315,7 +3278,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3751,7 +3713,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3980,7 +3941,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4075,7 +4035,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4169,7 +4128,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4264,7 +4222,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4355,7 +4312,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4448,7 +4404,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4539,7 +4494,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4630,7 +4584,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4716,7 +4669,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4809,7 +4761,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4897,7 +4848,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4987,7 +4937,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5073,7 +5022,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5163,7 +5111,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5255,7 +5202,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5348,7 +5294,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5437,7 +5382,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5524,7 +5468,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5616,7 +5559,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5705,7 +5647,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5792,7 +5733,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5880,7 +5820,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5973,7 +5912,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -6062,7 +6000,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -6148,7 +6085,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -171,7 +171,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -236,7 +235,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -299,7 +297,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -362,7 +359,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -425,7 +421,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -488,7 +483,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -553,7 +547,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -708,7 +701,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -774,7 +766,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -839,7 +830,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -904,7 +894,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -969,7 +958,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1034,7 +1022,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1101,7 +1088,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -96,7 +96,6 @@ periodics:
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
-        readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
     nodeSelector:
@@ -410,7 +409,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -483,7 +481,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -556,7 +553,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -629,7 +625,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -698,7 +693,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -768,7 +762,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -837,7 +830,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -906,7 +898,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -972,7 +963,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1048,7 +1038,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1115,7 +1104,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1184,7 +1172,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1249,7 +1236,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1318,7 +1304,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1391,7 +1376,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1462,7 +1446,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1533,7 +1516,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1604,7 +1586,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1677,7 +1658,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1750,7 +1730,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1823,7 +1802,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1896,7 +1874,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1969,7 +1946,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2042,7 +2018,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2115,7 +2090,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2188,7 +2162,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2255,7 +2228,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2326,7 +2298,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2397,7 +2368,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2464,7 +2434,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2529,7 +2498,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2600,7 +2568,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2667,7 +2634,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2732,7 +2698,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2799,7 +2764,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2870,7 +2834,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2937,7 +2900,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3002,7 +2964,6 @@ postsubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3327,7 +3288,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3496,7 +3456,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3571,7 +3530,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3645,7 +3603,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3720,7 +3677,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3791,7 +3747,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3864,7 +3819,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3935,7 +3889,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4006,7 +3959,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4073,7 +4025,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4146,7 +4097,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4214,7 +4164,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4284,7 +4233,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4350,7 +4298,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4420,7 +4367,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4492,7 +4438,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4565,7 +4510,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4634,7 +4578,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4701,7 +4644,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4773,7 +4715,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4842,7 +4783,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4909,7 +4849,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4977,7 +4916,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -5050,7 +4988,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -5119,7 +5056,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -5185,7 +5121,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -204,7 +204,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -373,7 +372,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -448,7 +446,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -522,7 +519,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -597,7 +593,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -668,7 +663,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -741,7 +735,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -812,7 +805,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -883,7 +875,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -950,7 +941,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1023,7 +1013,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1091,7 +1080,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1161,7 +1149,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1227,7 +1214,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1297,7 +1283,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1369,7 +1354,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1442,7 +1426,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1511,7 +1494,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1578,7 +1560,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1650,7 +1631,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1719,7 +1699,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1786,7 +1765,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1854,7 +1832,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1927,7 +1904,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1996,7 +1972,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2062,7 +2037,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -38,7 +38,6 @@ requirement_presets:
       readOnly: true
     - mountPath: /sys/fs/cgroup
       name: cgroup
-      readOnly: true
     - mountPath: /var/lib/docker
       name: docker-root
     volumes:


### PR DESCRIPTION
I'm not aware of the historical reason we have /sys/fs/cgroup mounts marked as read only. During my tests, removing this hasn't been an issue, and is required for cgroupsv2. See #5486 and #5795 for some more context.

DNM pending review by @howardjohn who likely has the context on why this was marked readonly prior.