### PR TITLE
drop cgroup hostmount

### DIFF
--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -43,9 +43,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -60,10 +57,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )docs-test,?($|\s.*))|((?m)^/test( | .* )docs-test_sail-operator_main,?($|\s.*))
@@ -114,9 +107,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -131,10 +121,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_main,?($|\s.*))
@@ -181,9 +167,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -198,10 +181,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -249,9 +228,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -266,10 +242,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_main,?($|\s.*))
@@ -314,9 +286,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -331,10 +300,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_main,?($|\s.*))
@@ -573,9 +538,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -590,10 +552,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_main,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.1.gen.yaml
@@ -44,9 +44,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -61,10 +58,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-0.1,?($|\s.*))
@@ -109,9 +102,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -126,10 +116,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-0.1,?($|\s.*))
@@ -363,9 +349,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -380,10 +363,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-0.1,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.2.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-0.2.gen.yaml
@@ -48,9 +48,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -65,10 +62,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_release-0.2,?($|\s.*))
@@ -115,9 +108,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -132,10 +122,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -183,9 +169,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -200,10 +183,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-0.2,?($|\s.*))
@@ -248,9 +227,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -265,10 +241,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-0.2,?($|\s.*))
@@ -502,9 +474,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -519,10 +488,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-0.2,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.0.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.0.gen.yaml
@@ -48,9 +48,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -65,10 +62,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_release-1.0,?($|\s.*))
@@ -115,9 +108,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -132,10 +122,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -183,9 +169,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -200,10 +183,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-1.0,?($|\s.*))
@@ -248,9 +227,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -265,10 +241,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-1.0,?($|\s.*))
@@ -502,9 +474,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -519,10 +488,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-1.0,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.25.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.25.gen.yaml
@@ -48,9 +48,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -65,10 +62,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_release-1.25,?($|\s.*))
@@ -115,9 +108,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -132,10 +122,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -183,9 +169,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -200,10 +183,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-1.25,?($|\s.*))
@@ -248,9 +227,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -265,10 +241,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-1.25,?($|\s.*))
@@ -502,9 +474,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -519,10 +488,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-1.25,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.26.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.26.gen.yaml
@@ -43,9 +43,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -60,10 +57,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )docs-test,?($|\s.*))|((?m)^/test( | .* )docs-test_sail-operator_release-1.26,?($|\s.*))
@@ -114,9 +107,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -131,10 +121,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_release-1.26,?($|\s.*))
@@ -181,9 +167,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -198,10 +181,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -249,9 +228,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -266,10 +242,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-1.26,?($|\s.*))
@@ -314,9 +286,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -331,10 +300,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-1.26,?($|\s.*))
@@ -569,9 +534,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -586,10 +548,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-1.26,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.27.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.27.gen.yaml
@@ -43,9 +43,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -60,10 +57,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )docs-test,?($|\s.*))|((?m)^/test( | .* )docs-test_sail-operator_release-1.27,?($|\s.*))
@@ -114,9 +107,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -131,10 +121,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_release-1.27,?($|\s.*))
@@ -181,9 +167,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -198,10 +181,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -249,9 +228,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -266,10 +242,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-1.27,?($|\s.*))
@@ -314,9 +286,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -331,10 +300,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-1.27,?($|\s.*))
@@ -569,9 +534,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -586,10 +548,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-1.27,?($|\s.*))

--- a/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.28.gen.yaml
+++ b/prow/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.release-1.28.gen.yaml
@@ -43,9 +43,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -60,10 +57,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )docs-test,?($|\s.*))|((?m)^/test( | .* )docs-test_sail-operator_release-1.28,?($|\s.*))
@@ -114,9 +107,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -131,10 +121,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-dualstack,?($|\s.*))|((?m)^/test( | .* )e2e-kind-dualstack_sail-operator_release-1.28,?($|\s.*))
@@ -181,9 +167,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -198,10 +181,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -249,9 +228,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -266,10 +242,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind-olm,?($|\s.*))|((?m)^/test( | .* )e2e-kind-olm_sail-operator_release-1.28,?($|\s.*))
@@ -314,9 +286,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -331,10 +300,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )e2e-kind,?($|\s.*))|((?m)^/test( | .* )e2e-kind_sail-operator_release-1.28,?($|\s.*))
@@ -569,9 +534,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -586,10 +548,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )scorecard,?($|\s.*))|((?m)^/test( | .* )scorecard_sail-operator_release-1.28,?($|\s.*))

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -45,9 +45,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -62,10 +59,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -110,9 +103,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -127,10 +117,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -173,9 +159,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -190,10 +173,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -236,9 +215,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -253,10 +229,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -299,9 +271,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -316,10 +285,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -362,9 +327,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -379,10 +341,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -427,9 +385,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -444,10 +399,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -584,9 +535,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -601,10 +549,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.dualstack,?($|\s.*))|((?m)^/test( | .* )doc.test.dualstack_istio.io,?($|\s.*))
@@ -652,9 +596,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -669,10 +610,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -719,9 +656,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -736,10 +670,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-ambient,?($|\s.*))|((?m)^/test( |
@@ -786,9 +716,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -803,10 +730,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
@@ -853,9 +776,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -870,10 +790,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
@@ -920,9 +836,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -937,10 +850,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-minimal,?($|\s.*))|((?m)^/test( |
@@ -989,9 +898,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1006,10 +912,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -56,9 +56,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -77,10 +74,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -147,9 +140,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -168,10 +158,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -238,9 +224,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -259,10 +242,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -329,9 +308,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -350,10 +326,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -416,9 +388,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -437,10 +406,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -504,9 +469,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -525,10 +487,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -591,9 +549,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -612,10 +567,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -678,9 +629,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -699,10 +647,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -761,9 +705,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -787,10 +728,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -855,9 +792,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -876,10 +810,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -940,9 +870,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -961,10 +888,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1027,9 +950,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1048,10 +968,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1110,9 +1026,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1131,10 +1044,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1197,9 +1106,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1218,10 +1124,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1288,9 +1190,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1309,10 +1208,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1377,9 +1272,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1398,10 +1290,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1466,9 +1354,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1487,10 +1372,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1555,9 +1436,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1576,10 +1454,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1646,9 +1520,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1667,10 +1538,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1737,9 +1604,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1758,10 +1622,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1828,9 +1688,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1849,10 +1706,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -1919,9 +1772,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -1940,10 +1790,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2010,9 +1856,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2031,10 +1874,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2101,9 +1940,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2122,10 +1958,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2192,9 +2024,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2213,10 +2042,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2283,9 +2108,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2304,10 +2126,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2368,9 +2186,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2389,10 +2204,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2457,9 +2268,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2478,10 +2286,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2546,9 +2350,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2567,10 +2368,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2631,9 +2428,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2652,10 +2446,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2714,9 +2504,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2735,10 +2522,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2803,9 +2586,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2824,10 +2604,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2888,9 +2664,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2909,10 +2682,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -2971,9 +2740,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -2992,10 +2758,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -3056,9 +2818,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3077,10 +2836,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -3145,9 +2900,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3166,10 +2918,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -3230,9 +2978,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3251,10 +2996,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -3313,9 +3054,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3334,10 +3072,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -3749,9 +3483,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3770,10 +3501,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -3978,9 +3705,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -3999,10 +3723,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4073,9 +3793,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4094,10 +3811,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4167,9 +3880,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4188,10 +3898,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4262,9 +3968,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4283,10 +3986,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4353,9 +4052,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4374,10 +4070,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4446,9 +4138,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4467,10 +4156,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4537,9 +4222,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4558,10 +4240,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4628,9 +4306,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4649,10 +4324,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4714,9 +4385,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4740,10 +4408,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4807,9 +4471,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4828,10 +4489,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4895,9 +4552,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -4916,10 +4570,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -4985,9 +4635,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5006,10 +4653,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5071,9 +4714,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5092,10 +4732,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5161,9 +4797,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5182,10 +4815,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5253,9 +4882,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5274,10 +4900,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5346,9 +4968,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5367,10 +4986,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5435,9 +5050,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5456,10 +5068,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5522,9 +5130,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5543,10 +5148,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5614,9 +5215,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5635,10 +5233,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5703,9 +5297,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5724,10 +5315,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5790,9 +5377,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5811,10 +5395,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5878,9 +5458,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5899,10 +5476,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -5971,9 +5544,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -5992,10 +5562,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -6060,9 +5626,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -6081,10 +5644,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc
@@ -6146,9 +5705,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
         - mountPath: /home/.netrc
@@ -6167,10 +5723,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
       - name: netrc

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -169,9 +169,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -186,10 +183,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -234,9 +227,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -251,10 +241,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -297,9 +283,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -314,10 +297,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -360,9 +339,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -377,10 +353,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -423,9 +395,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -440,10 +409,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -486,9 +451,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -503,10 +465,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -551,9 +509,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -568,10 +523,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -706,9 +657,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -723,10 +671,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.dualstack,?($|\s.*))|((?m)^/test( | .* )doc.test.dualstack_istio.io,?($|\s.*))
@@ -772,9 +716,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -789,10 +730,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.multicluster,?($|\s.*))|((?m)^/test( | .*
@@ -837,9 +774,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -854,10 +788,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-ambient,?($|\s.*))|((?m)^/test( |
@@ -902,9 +832,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -919,10 +846,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-default,?($|\s.*))|((?m)^/test( |
@@ -967,9 +890,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -984,10 +904,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-demo,?($|\s.*))|((?m)^/test( | .*
@@ -1032,9 +948,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1049,10 +962,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-minimal,?($|\s.*))|((?m)^/test( |
@@ -1099,9 +1008,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1116,10 +1022,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.profile-none,?($|\s.*))|((?m)^/test( | .*

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -94,9 +94,6 @@ periodics:
       - mountPath: /lib/modules
         name: modules
         readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-        readOnly: true
       - mountPath: /var/lib/docker
         name: docker-root
     nodeSelector:
@@ -111,10 +108,6 @@ periodics:
         path: /lib/modules
         type: Directory
       name: modules
-    - hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-      name: cgroup
     - emptyDir: {}
       name: docker-root
 - annotations:
@@ -408,9 +401,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -425,10 +415,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -481,9 +467,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -498,10 +481,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -554,9 +533,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -571,10 +547,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -627,9 +599,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -644,10 +613,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -696,9 +661,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -713,10 +675,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -766,9 +724,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -783,10 +738,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -835,9 +786,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -852,10 +800,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -904,9 +848,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -921,10 +862,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -970,9 +907,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -992,10 +926,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1046,9 +976,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1063,10 +990,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1113,9 +1036,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1130,10 +1050,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1182,9 +1098,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1199,10 +1112,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1247,9 +1156,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1264,10 +1170,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1316,9 +1218,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1333,10 +1232,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1389,9 +1284,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1406,10 +1298,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1460,9 +1348,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1477,10 +1362,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1531,9 +1412,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1548,10 +1426,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1602,9 +1476,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1619,10 +1490,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1675,9 +1542,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1692,10 +1556,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1748,9 +1608,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1765,10 +1622,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1821,9 +1674,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1838,10 +1688,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1894,9 +1740,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1911,10 +1754,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -1967,9 +1806,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1984,10 +1820,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2040,9 +1872,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2057,10 +1886,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2113,9 +1938,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2130,10 +1952,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2186,9 +2004,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2203,10 +2018,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2253,9 +2064,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2270,10 +2078,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2324,9 +2128,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2341,10 +2142,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2395,9 +2192,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2412,10 +2206,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2462,9 +2252,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2479,10 +2266,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2527,9 +2310,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2544,10 +2324,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2598,9 +2374,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2615,10 +2388,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2665,9 +2434,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2682,10 +2448,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2730,9 +2492,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2747,10 +2506,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2797,9 +2552,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2814,10 +2566,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2868,9 +2616,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2885,10 +2630,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -2935,9 +2676,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2952,10 +2690,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -3000,9 +2734,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3017,10 +2748,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -3325,9 +3052,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3342,10 +3066,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )experimental-tracing,?($|\s.*))|((?m)^/test( | .*
@@ -3494,9 +3214,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3511,10 +3228,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-calico,?($|\s.*))|((?m)^/test( | .*
@@ -3569,9 +3282,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3586,10 +3296,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-dual,?($|\s.*))|((?m)^/test( | .* )integ-ambient-dual_istio,?($|\s.*))
@@ -3643,9 +3349,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3660,10 +3363,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ambient-ipv6_istio,?($|\s.*))
@@ -3718,9 +3417,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3735,10 +3431,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-mc,?($|\s.*))|((?m)^/test( | .* )integ-ambient-mc_istio,?($|\s.*))
@@ -3789,9 +3481,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3806,10 +3495,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-nftables,?($|\s.*))|((?m)^/test( | .*
@@ -3862,9 +3547,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3879,10 +3561,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-owned-cni,?($|\s.*))|((?m)^/test( |
@@ -3933,9 +3611,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -3950,10 +3625,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient,?($|\s.*))|((?m)^/test( | .* )integ-ambient_istio,?($|\s.*))
@@ -4004,9 +3675,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4021,10 +3689,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio,?($|\s.*))
@@ -4071,9 +3735,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4093,10 +3754,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio,?($|\s.*))
@@ -4144,9 +3801,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4161,10 +3815,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio,?($|\s.*))
@@ -4212,9 +3862,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4229,10 +3876,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio,?($|\s.*))
@@ -4282,9 +3925,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4299,10 +3939,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ds,?($|\s.*))|((?m)^/test( | .* )integ-ds_istio,?($|\s.*))
@@ -4348,9 +3984,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4365,10 +3998,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio,?($|\s.*))
@@ -4418,9 +4047,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4435,10 +4061,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio,?($|\s.*))
@@ -4490,9 +4112,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4507,10 +4126,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
@@ -4563,9 +4178,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4580,10 +4192,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
@@ -4632,9 +4240,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4649,10 +4254,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
@@ -4699,9 +4300,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4716,10 +4314,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio,?($|\s.*))
@@ -4771,9 +4365,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4788,10 +4379,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
@@ -4840,9 +4427,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4857,10 +4441,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
@@ -4907,9 +4487,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4924,10 +4501,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio,?($|\s.*))
@@ -4975,9 +4548,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -4992,10 +4562,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry-discovery,?($|\s.*))|((?m)^/test(
@@ -5048,9 +4614,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -5065,10 +4628,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
@@ -5117,9 +4676,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -5134,10 +4690,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio,?($|\s.*))
@@ -5183,9 +4735,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -5200,10 +4749,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio,?($|\s.*))

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -202,9 +202,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -219,10 +216,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )experimental-tracing,?($|\s.*))|((?m)^/test( | .*
@@ -371,9 +364,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -388,10 +378,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-calico,?($|\s.*))|((?m)^/test( | .*
@@ -446,9 +432,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -463,10 +446,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-dual,?($|\s.*))|((?m)^/test( | .* )integ-ambient-dual_istio,?($|\s.*))
@@ -520,9 +499,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -537,10 +513,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ambient-ipv6_istio,?($|\s.*))
@@ -595,9 +567,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -612,10 +581,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-mc,?($|\s.*))|((?m)^/test( | .* )integ-ambient-mc_istio,?($|\s.*))
@@ -666,9 +631,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -683,10 +645,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-nftables,?($|\s.*))|((?m)^/test( | .*
@@ -739,9 +697,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -756,10 +711,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-owned-cni,?($|\s.*))|((?m)^/test( |
@@ -810,9 +761,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -827,10 +775,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient,?($|\s.*))|((?m)^/test( | .* )integ-ambient_istio,?($|\s.*))
@@ -881,9 +825,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -898,10 +839,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-assertion,?($|\s.*))|((?m)^/test( | .* )integ-assertion_istio,?($|\s.*))
@@ -948,9 +885,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -970,10 +904,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-basic-arm64,?($|\s.*))|((?m)^/test( | .* )integ-basic-arm64_istio,?($|\s.*))
@@ -1021,9 +951,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1038,10 +965,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-cni,?($|\s.*))|((?m)^/test( | .* )integ-cni_istio,?($|\s.*))
@@ -1089,9 +1012,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1106,10 +1026,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-distroless,?($|\s.*))|((?m)^/test( | .* )integ-distroless_istio,?($|\s.*))
@@ -1159,9 +1075,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1176,10 +1089,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ds,?($|\s.*))|((?m)^/test( | .* )integ-ds_istio,?($|\s.*))
@@ -1225,9 +1134,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1242,10 +1148,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-helm,?($|\s.*))|((?m)^/test( | .* )integ-helm_istio,?($|\s.*))
@@ -1295,9 +1197,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1312,10 +1211,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ipv6_istio,?($|\s.*))
@@ -1367,9 +1262,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1384,10 +1276,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot-istiodremote-mc,?($|\s.*))|((?m)^/test(
@@ -1440,9 +1328,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1457,10 +1342,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot-istiodremote,?($|\s.*))|((?m)^/test( |
@@ -1509,9 +1390,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1526,10 +1404,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot-multicluster,?($|\s.*))|((?m)^/test( |
@@ -1576,9 +1450,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1593,10 +1464,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-pilot,?($|\s.*))|((?m)^/test( | .* )integ-pilot_istio,?($|\s.*))
@@ -1648,9 +1515,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1665,10 +1529,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-security-istiodremote,?($|\s.*))|((?m)^/test(
@@ -1717,9 +1577,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1734,10 +1591,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-security-multicluster,?($|\s.*))|((?m)^/test(
@@ -1784,9 +1637,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1801,10 +1651,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-security,?($|\s.*))|((?m)^/test( | .* )integ-security_istio,?($|\s.*))
@@ -1852,9 +1698,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1869,10 +1712,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry-discovery,?($|\s.*))|((?m)^/test(
@@ -1925,9 +1764,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -1942,10 +1778,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry-istiodremote,?($|\s.*))|((?m)^/test(
@@ -1994,9 +1826,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2011,10 +1840,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry-mc,?($|\s.*))|((?m)^/test( | .* )integ-telemetry-mc_istio,?($|\s.*))
@@ -2060,9 +1885,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -2077,10 +1899,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-telemetry,?($|\s.*))|((?m)^/test( | .* )integ-telemetry_istio,?($|\s.*))

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -36,9 +36,6 @@ requirement_presets:
     - mountPath: /lib/modules
       name: modules
       readOnly: true
-    - mountPath: /sys/fs/cgroup
-      name: cgroup
-      readOnly: true
     - mountPath: /var/lib/docker
       name: docker-root
     volumes:
@@ -46,10 +43,6 @@ requirement_presets:
         path: /lib/modules
         type: Directory
       name: modules
-    - hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-      name: cgroup
     - emptyDir: {}
       name: docker-root
   docker:


### PR DESCRIPTION
After talking with @howardjohn, we noticed upstream Kubernetes also dropped this mount on GKE.