### PR TITLE
Always keep 1 node in the nodepool for istio/proxy jobs

### DIFF
--- a/infra/gcp/istio-prow-build/cluster-prow.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow.tf
@@ -87,7 +87,7 @@ resource "google_container_cluster" "prow" {
 resource "google_container_node_pool" "prow_build" {
   autoscaling {
     max_node_count = 10
-    min_node_count = 0
+    min_node_count = 1
   }
 
   cluster            = "prow"


### PR DESCRIPTION
We're seeing a ton of jobs time out on istio/proxy due to momentary lack of capacity in our region. So, despite the 3x cost, we should always keep 1 node around, at least until the 1.29 release is over