### PR TITLE
remove old ENVOY_REPOSITORY from 1.29

### DIFF
--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.29.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.29.gen.yaml
@@ -25,8 +25,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         image: gcr.io/istio-testing/build-tools-proxy:release-1.29-48686f08d4dc58cbcc68335f8f71c76fca6cac9e
@@ -90,8 +88,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         - name: GOMAXPROCS
@@ -162,8 +158,6 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.29-48686f08d4dc58cbcc68335f8f71c76fca6cac9e
         name: ""
         resources:
@@ -223,8 +217,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.29-48686f08d4dc58cbcc68335f8f71c76fca6cac9e
@@ -286,8 +278,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         image: gcr.io/istio-testing/build-tools-proxy:release-1.29-48686f08d4dc58cbcc68335f8f71c76fca6cac9e
         name: ""
         resources:
@@ -347,8 +337,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.29-48686f08d4dc58cbcc68335f8f71c76fca6cac9e
@@ -408,8 +396,6 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: ENVOY_REPOSITORY
-          value: https://github.com/istio-private/envoy
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.29-48686f08d4dc58cbcc68335f8f71c76fca6cac9e

--- a/prow/config/istio-private_jobs/proxy-1.29.yaml
+++ b/prow/config/istio-private_jobs/proxy-1.29.yaml
@@ -7,14 +7,11 @@ defaults:
 org: istio
 repo: proxy
 transforms:
-- env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
-  job-type:
+- job-type:
   - presubmit
   labels:
     preset-enable-netrc: "true"
 - env:
-    ENVOY_REPOSITORY: https://github.com/istio-private/envoy
     GCS_BUILD_BUCKET: istio-build-private
   job-denylist:
   - update-istio_proxy_release-1.29


### PR DESCRIPTION
We don't use this anymore.. trying to trace where in the prepare steps this is getting added by default.