### PR TITLE
Make ambient multi-cluster tests mandatory

### DIFF
--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3916,7 +3916,6 @@ presubmits:
     cluster: private
     decorate: true
     name: integ-ambient-mc_istio_pri
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-mc
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -3373,7 +3373,6 @@ presubmits:
     - ^master$
     decorate: true
     name: integ-ambient-mc_istio
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-mc
     spec:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -523,7 +523,6 @@ presubmits:
     - ^experimental-.*
     decorate: true
     name: integ-ambient-mc_istio_exp
-    optional: true
     path_alias: istio.io/istio
     rerun_command: /test integ-ambient-mc
     spec:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -277,7 +277,6 @@ jobs:
     - test.integration.ambient.kube
 
   - name: integ-ambient-mc
-    modifiers: [presubmit_optional]
     requirements: [kind]
     env:
     - name: INTEGRATION_TEST_FLAGS


### PR DESCRIPTION
Ambient multi-network multicluster feature is now in beta, so we want to make the integration tests covering it mandatory.

We've fixed all the known issues with the enabled tests and also reduced flakiness of the ambient tests for both multi-cluster and single-cluster cases.

At this point, I believe that additional tests will not introduce any additional significant burden on the community and will help to prevent degradation of a beta feature in the future.

+cc @grnmeira @keithmattix @therealmitchconnors 