### PR TITLE
Use custom domain

### DIFF
--- a/infra/cf/cncf-istio/workers.tf
+++ b/infra/cf/cncf-istio/workers.tf
@@ -24,8 +24,9 @@ resource "cloudflare_workers_script" "registry_redirect_istio" {
   }]
 }
 
-resource "cloudflare_workers_route" "registry_redirect_istio" {
-  zone_id    = var.zone_id
-  pattern    = "registry.istio.io/*"
-  script     = cloudflare_workers_script.registry_redirect_istio.id
+resource "cloudflare_workers_custom_domain" "registry_redirect_istio_custom_domain" {
+  account_id = var.account_id
+  hostname = "registry.istio.io"
+  service = cloudflare_workers_script.registry_redirect_istio.script_name
+  zone_id = var.zone_id
 }


### PR DESCRIPTION
If we use a route instead of a subdomain, we need an "orange" dns record for it

https://developers.cloudflare.com/workers/configuration/routing/routes/

> A DNS record set up for the domain or subdomain proxied by Cloudflare (also known as orange-clouded) you would like to route to.

We would have to create a dummy record, which is not ideal.

We should use a subdomain instead, which will automatically create the DNS record.
https://developers.cloudflare.com/workers/configuration/routing/custom-domains/
