### PR TITLE
Exclude copilot from branch protections

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -153,6 +153,8 @@ branch-protection:
       required_status_checks:
         contexts:
         - EasyCLA
+      exclude:
+        "copilot/" # Exclude copilot created branches from branch protection
       # By default, required 1 approval from a CODEOWNER
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -153,8 +153,6 @@ branch-protection:
       required_status_checks:
         contexts:
         - EasyCLA
-      exclude:
-      - "copilot/" # Exclude copilot created branches from branch protection
       # By default, required 1 approval from a CODEOWNER
       required_pull_request_reviews:
         required_approving_review_count: 1
@@ -290,49 +288,27 @@ branch-protection:
                   - release-managers-1.20
             release-1.21: &release121
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.21
             release-1.22: &release122
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.22
             release-1.23: &release123
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.23
             release-1.24: &release124
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.24
             release-1.25: &release125
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.25
             release-1.26: &release126
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.26
             release-1.27: &release127
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.27
             release-1.28: &release128
               protect: true
-              restrictions:
-                teams:
-                  - release-managers-1.28
             release-1.29: &release129
               protect: true
+            copilot|dependabot/:
+              protect: true
               restrictions:
-                teams:
-                  - release-managers-1.29
+                users:
+                
         operator:
           branches: *blocked_branches
         istio.io:
@@ -344,7 +320,7 @@ branch-protection:
         pkg:
           branches: *blocked_branches
         get-istioctl:
-          branches: *blocked_branches
+          branches: *blocked_branchescopilot
         cri:
           branches: *blocked_branches
         client-go:
@@ -366,8 +342,8 @@ branch-protection:
             dismiss_stale_reviews: true
             dismissal_restrictions:
               teams:
-              - steering-committee
-              - repo-admins
+              - istio/steering-committee
+              - istio/repo-admins
         release-builder:
           branches: *blocked_branches
         ztunnel:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -308,7 +308,7 @@ branch-protection:
               protect: true
               restrictions:
                 users:
-                
+
         operator:
           branches: *blocked_branches
         istio.io:
@@ -320,7 +320,7 @@ branch-protection:
         pkg:
           branches: *blocked_branches
         get-istioctl:
-          branches: *blocked_branchescopilot
+          branches: *blocked_branches
         cri:
           branches: *blocked_branches
         client-go:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -154,7 +154,7 @@ branch-protection:
         contexts:
         - EasyCLA
       exclude:
-        "copilot/" # Exclude copilot created branches from branch protection
+      - "copilot/" # Exclude copilot created branches from branch protection
       # By default, required 1 approval from a CODEOWNER
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
Don't activate branch protections for copilot branches. We will still require explicit approval for GH actions and prow to execute though