### PR TITLE
Change Istio release registry from Docker to GCR

### DIFF
--- a/infra/cf/cncf-istio/main.tf
+++ b/infra/cf/cncf-istio/main.tf
@@ -12,7 +12,7 @@ variable "zone_id" {
 
 locals {
   istio_registry_mappings = {
-    release = "index.docker.io/istio"
+    release = "gcr.io/istio-release"
     testing = "gcr.io/istio-testing"
   }
 }


### PR DESCRIPTION
We get DDOS rate limited by docker. This caused some degredation of istio.io for ~4.5 starting today at noon EST until 4:30 EST