### PR TITLE
migrate test-infra pipelines to use r2

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - --kubernetes-blob-storage-workers=1
         - --slack-token-file=/etc/slack/token
         - --slack-workers=1
+        - --s3-credentials-file=/etc/r2-credentials/service-account.json
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
@@ -54,6 +55,9 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: r2-credentials
+          mountPath: /etc/r2-credentials
+          readOnly: true
       volumes:
       - name: oauth
         secret:
@@ -71,3 +75,6 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: r2-credentials
+        secret:
+          secretName: r2-credentials

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
         - --cookie-secret=/etc/cookie/secret
+        - --s3-credentials-file=/etc/r2-credentials/service-account.json
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
@@ -66,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/r2-credentials
+          name: r2-credentials
           readOnly: true
         livenessProbe:
           httpGet:
@@ -100,3 +104,6 @@ spec:
         configMap:
           defaultMode: 420
           name: kubeconfig
+      - name: r2-credentials
+        secret:
+          secretName: r2-credentials

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -46,3 +46,27 @@ spec:
   - key: github_istio-testing_pusher # Secret name in GSM
     name: oauth
 ---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: r2-credentials
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_credentials # Secret name in GSM
+    name: service-account.json
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: r2-credentials
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_credentials # Secret name in GSM
+    name: service-account.json
+---

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,6 +43,12 @@ plank:
     config:
       default_service_account_name: "prowjob-default-sa" # Use workload identity
       gcs_credentials_secret: ""                         # rather than service account key secret
+  - repo: istio/test-infra
+    config:
+      gcs_configuration:
+        bucket: "s3://istio-prow"
+        path_strategy: "explicit"
+      s3_credentials_secret: "r2-credentials"
 
 sinker:
   resync_period: 1m


### PR DESCRIPTION
This is nice because it lets us test the changes without messing around with istio/istio
