### PR TITLE
revert envoy update branch to main for release-1.30

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.30.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.30.gen.yaml
@@ -30,7 +30,7 @@ periodics:
       - --labels=auto-merge
       - --modifier=update_envoy_dep
       - --token-env
-      - --cmd=UPDATE_BRANCH=release/v1.37 scripts/update_envoy.sh
+      - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
       env:
       - name: AUTOMATOR_ORG
         value: istio

--- a/prow/config/jobs/proxy-1.30.yaml
+++ b/prow/config/jobs/proxy-1.30.yaml
@@ -1466,7 +1466,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=update_envoy_dep
   - --token-env
-  - --cmd=UPDATE_BRANCH=release/v1.37 scripts/update_envoy.sh
+  - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"


### PR DESCRIPTION
Envoy release/v1.37 has incompatible API changes (routeSharedPtr removed, cel-cpp/abseil renamed). Stay on envoy main until release/v1.38 is cut. Ref https://github.com/istio/istio/issues/59425

analysis thread - https://istio.slack.com/archives/C0AL7LKQG7Q/p1776313017681539