### PR TITLE
Remove operations from Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,15 @@
 *                                    @istio/wg-test-and-release-maintainers
-.prow.yaml                           @istio/wg-test-and-release-maintainers @istio/operations-maintainers
-/authentikos/                        @istio/wg-test-and-release-maintainers @istio/operations-maintainers
-/prow/                               @istio/operations-maintainers
+.prow.yaml                           @istio/wg-test-and-release-maintainers
+/authentikos/                        @istio/wg-test-and-release-maintainers
+/prow/                               @istio/wg-test-and-release-maintainers
 /prow/config/                        @istio/wg-test-and-release-maintainers
-/prow/config/jobs/test-infra.yaml    @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+/prow/config/jobs/test-infra.yaml    @istio/wg-test-and-release-maintainers
 # Build clusters have dual ownership
-/prow/cluster/arm/                   @istio/wg-test-and-release-maintainers @istio/operations-maintainers
-/prow/cluster/build/                 @istio/wg-test-and-release-maintainers @istio/operations-maintainers
-/prow/cluster/private/               @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+/prow/cluster/arm/                   @istio/wg-test-and-release-maintainers
+/prow/cluster/build/                 @istio/wg-test-and-release-maintainers
+/prow/cluster/private/               @istio/wg-test-and-release-maintainers
 /prow/cluster/jobs/                  @istio/wg-test-and-release-maintainers
-/prow/cluster/jobs/istio/test-infra/ @istio/wg-test-and-release-maintainers @istio/operations-maintainers
+/prow/cluster/jobs/istio/test-infra/ @istio/wg-test-and-release-maintainers
 /tools/prowtrans/                    @istio/wg-test-and-release-maintainers
 /tools/prowgen/                      @istio/wg-test-and-release-maintainers
 /tools/generate-transform-jobs/      @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
The group is effectively defunct; test and release now owns everything