### PR TITLE
Cloudflare secret rotation

### DIFF
--- a/infra/gcp/istio-prow-build/iam.tf
+++ b/infra/gcp/istio-prow-build/iam.tf
@@ -102,9 +102,7 @@ module "prowjob_testing_write_account" {
     { bucket = "istio-build", role = "OWNER" },
   ]
   secrets = [
-    { name = "cf_r2_access_key_id", project = "istio-testing" },
-    { name = "cf_r2_access_key_secret", project = "istio-testing" },
-    { name = "cf_r2_access_token", project = "istio-testing" },
+    { name = "cf_r2_istio-build_credentials", project = "istio-testing" },
   ]
   project_roles = [
     { role = "roles/remotebuildexecution.actionCacheWriter", project = "istio-testing" },

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -151,24 +151,13 @@ module "cloudflare_rotator_account" {
   // secretAccessor (read) on the permanent admin token and on the
   secrets = [
     { name = "cf_r2_admin_token" },
-    { name = "cf_r2_istio-prow_access_key_id" },
   ]
 }
 
-// secretVersionManager (add new versions + enable/disable/destroy old ones)
-// on the per-bucket ephemeral secrets. Manager is needed (rather than the
-// append-only secretVersionAdder) because the rotator disables prior versions
-// after each successful upload to keep stale credentials from being read.
-//
-// Note: cf_r2_istio-prow_access_key_id is intentionally omitted. Cloudflare's
-// temp-access-credentials endpoint returns the parent's accessKeyId unchanged,
-// so that secret only needs to be read (granted via the module above) and is
-// never rewritten by the rotator.
 locals {
   cloudflare_rotator_writable_secrets = toset([
-    "cf_r2_istio-prow_access_key_secret",
     "cf_r2_istio-prow_credentials",
-    "cf_r2_istio-prow_session_token",
+    "cf_r2_istio-build_credentials",
   ])
 }
 

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -139,16 +139,16 @@ resource "google_project_iam_member" "owners" {
 }
 
 // GSA used by the cloudflare-rotator CronJob in the trusted cluster.
-// The KSA is "cloudflare-rotator" in the "default" namespace.
+// The KSA is "cloudflare-rotator" in the "cloudflare-secret-rotation" namespace.
 module "cloudflare_rotator_account" {
   source            = "../modules/workload-identity-service-account"
   project_id        = local.project_id
   name              = "cloudflare-rotator"
   description       = "Rotates ephemeral Cloudflare R2 credentials in GSM."
-  cluster_namespace = "default"
+  cluster_namespace = "cloudflare-secret-rotation"
   prowjob           = false
 
-  // secretAccessor (read) on the permanent admin token and on the
+  // secretAccessor (read) on the permanent admin token
   secrets = [
     { name = "cf_r2_admin_token" },
   ]

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -138,3 +138,44 @@ resource "google_project_iam_member" "owners" {
   member   = "user:${each.key}"
 }
 
+// GSA used by the cloudflare-rotator CronJob in the trusted cluster.
+// The KSA is "cloudflare-rotator" in the "default" namespace.
+module "cloudflare_rotator_account" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "cloudflare-rotator"
+  description       = "Rotates ephemeral Cloudflare R2 credentials in GSM."
+  cluster_namespace = "default"
+  prowjob           = false
+
+  // secretAccessor (read) on the permanent admin token and on the
+  secrets = [
+    { name = "cf_r2_admin_token" },
+    { name = "cf_r2_istio-prow_access_key_id" },
+  ]
+}
+
+// secretVersionManager (add new versions + enable/disable/destroy old ones)
+// on the per-bucket ephemeral secrets. Manager is needed (rather than the
+// append-only secretVersionAdder) because the rotator disables prior versions
+// after each successful upload to keep stale credentials from being read.
+//
+// Note: cf_r2_istio-prow_access_key_id is intentionally omitted. Cloudflare's
+// temp-access-credentials endpoint returns the parent's accessKeyId unchanged,
+// so that secret only needs to be read (granted via the module above) and is
+// never rewritten by the rotator.
+locals {
+  cloudflare_rotator_writable_secrets = toset([
+    "cf_r2_istio-prow_access_key_secret",
+    "cf_r2_istio-prow_credentials",
+    "cf_r2_istio-prow_session_token",
+  ])
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudflare_rotator_version_adder" {
+  for_each  = local.cloudflare_rotator_writable_secrets
+  project   = local.project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretVersionManager"
+  member    = "serviceAccount:${module.cloudflare_rotator_account.email}"
+}

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudflare-rotator
+  namespace: default
+data:
+  rotate.sh: |
+    #!/usr/bin/env bash
+    # Inputs (env): CF_ACCOUNT_ID, GCP_PROJECT
+    set -euo pipefail
+    buckets=(
+      "istio-prow"
+    )
+    echo "Setting up gcloud"
+    gcloud config set project "$GCP_PROJECT"
+
+    # Append a new version of $1 with value $2, then disable all previously-enabled
+    # versions of that secret. Keeps GSM tidy so consumers can't accidentally
+    # pick up a stale credential.
+    upload_and_prune() {
+      local secret=$1
+      local value=$2
+      local new
+      new=$(printf '%s' "$value" | gcloud secrets versions add "$secret" --data-file=- --format='value(name)')
+      new=${new##*/}
+      gcloud secrets versions list "$secret" --filter="state:ENABLED" --format='value(name)' \
+        | while read -r v; do
+            if [[ -n "$v" && "$v" != "$new" ]]; then
+              gcloud secrets versions disable "$v" --secret="$secret"
+            fi
+          done
+    }
+    echo "Fetching latest version of admin token"
+    admin_secret_version=$(gcloud secrets versions describe latest --secret=cf_r2_admin_token --format='value(name)')
+    echo "Fetching admin token value"
+    admin_token=$(gcloud secrets versions access "$admin_secret_version" | tr -d '\n\r')
+    for bucket in "${buckets[@]}"; do
+      echo "Fetching secret key for bucket"
+      key_id_version=$(gcloud secrets versions describe latest --secret="cf_r2_${bucket}_access_key_id" --format='value(name)')
+      key_id=$(gcloud secrets versions access "$key_id_version" | tr -d '\n\r')
+      echo "Rotating credentials for bucket $bucket"
+      body=$(jq -n \
+        --arg bucket "$bucket" \
+        --arg parent "$key_id" \
+        '{bucket: $bucket, parentAccessKeyId: $parent, permission: "object-read-write", ttlSeconds: 86400}')
+      response=$( \
+        curl -XPOST \
+        --retry 3 \
+        --retry-delay 1 \
+        --retry-all-errors \
+        -sSL \
+        "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/r2/temp-access-credentials" \
+        -H "Authorization: Bearer ${admin_token}" \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+      )
+
+      if ! echo "$response" | jq -e '.success' > /dev/null; then
+        echo "Cloudflare API error: $response"
+        exit 1
+      fi
+
+      if ! creds=$(echo "$response" | jq -e '.result | {accessKeyId, secretAccessKey, sessionToken} | select(.accessKeyId and .secretAccessKey and .sessionToken)'); then
+        echo "Cloudflare API error: missing fields in response: $response"
+        exit 1
+      fi
+      access_key_id=$(echo "$creds" | jq -r '.accessKeyId')
+      access_key_secret=$(echo "$creds" | jq -r '.secretAccessKey')
+      session_token=$(echo "$creds" | jq -r '.sessionToken')
+
+      # Cloudflare's temp-access-credentials endpoint returns the parent's
+      # accessKeyId unchanged, so cf_r2_${bucket}_access_key_id never needs
+      # to be rewritten -- it was seeded once with the parent value and stays
+      # valid across rotations. Only the secret_access_key and session_token
+      # change each run.
+      echo "Uploading secretAccessKey for bucket $bucket"
+      upload_and_prune "cf_r2_${bucket}_access_key_secret" "$access_key_secret"
+      echo "Uploading sessionToken for bucket $bucket"
+      upload_and_prune "cf_r2_${bucket}_session_token" "$session_token"
+      echo "Uploading credentials JSON for bucket $bucket"
+      credentials_json=$(jq -n \
+        --arg ak "$access_key_id" \
+        --arg sk "$access_key_secret" \
+        --arg st "$session_token" \
+        --arg ep "https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+        '{access_key: $ak, secret_key: $sk, session_token: $st, endpoint: $ep, s3_force_path_style: true, region: "auto"}')
+      upload_and_prune "cf_r2_${bucket}_credentials" "$credentials_json"
+    done

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloudflare-rotator
-  namespace: default
+  namespace: cloudflare-secret-rotation
 data:
   rotate.sh: |
     #!/usr/bin/env bash

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -36,8 +36,8 @@ data:
     admin_token=$(gcloud secrets versions access "${admin_secret_version}" | tr -d '\n\r')
     for bucket in "${buckets[@]}"; do
       echo "Fetching secret key for bucket"
-      key_id_version=$(gcloud secrets versions describe latest --secret="cf_r2_${bucket}_access_key_id" --format='value(name)')
-      key_id=$(gcloud secrets versions access "${key_id_version}" | tr -d '\n\r')
+      key_credentials_version=$(gcloud secrets versions describe latest --secret="cf_r2_${bucket}_credentials" --format='value(name)')
+      key_id=$(gcloud secrets versions access "${key_credentials_version}" | jq -r '.access_key' | tr -d '\n\r')
       echo "Rotating credentials for bucket ${bucket}"
       body=$(jq -n \
         --arg bucket "${bucket}" \
@@ -69,13 +69,7 @@ data:
       session_token=$(echo "${creds}" | jq -r '.sessionToken')
 
       # Cloudflare's temp-access-credentials endpoint returns the parent's
-      # accessKeyId unchanged, so cf_r2_${bucket}_access_key_id never needs
-      # to be rewritten.
-      echo "Uploading secretAccessKey for bucket ${bucket}"
-      upload_and_prune "cf_r2_${bucket}_access_key_secret" "${access_key_secret}"
-      echo "Uploading sessionToken for bucket ${bucket}"
-      upload_and_prune "cf_r2_${bucket}_session_token" "${session_token}"
-      echo "Uploading credentials JSON for bucket ${bucket}"
+      # accessKeyId unchanged, so the "access_key" value stays unchanged
       credentials_json=$(jq -n \
         --arg ak "${access_key_id}" \
         --arg sk "${access_key_secret}" \

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -10,79 +10,77 @@ data:
     set -euo pipefail
     buckets=(
       "istio-prow"
+      "istio-build"
     )
     echo "Setting up gcloud"
-    gcloud config set project "$GCP_PROJECT"
+    gcloud config set project "${GCP_PROJECT}"
 
     # Append a new version of $1 with value $2, then disable all previously-enabled
-    # versions of that secret. Keeps GSM tidy so consumers can't accidentally
-    # pick up a stale credential.
+    # versions of that secret.
     upload_and_prune() {
       local secret=$1
       local value=$2
       local new
-      new=$(printf '%s' "$value" | gcloud secrets versions add "$secret" --data-file=- --format='value(name)')
-      new=${new##*/}
-      gcloud secrets versions list "$secret" --filter="state:ENABLED" --format='value(name)' \
+      new=$(printf '%s' "${value}" | gcloud secrets versions add "${secret}" --data-file=- --format='value(name)')
+      new=${new##*/}  # Strip "projects/*/secrets/*/versions/" prefix, leaving just the version number
+      gcloud secrets versions list "${secret}" --filter="state:ENABLED" --format='value(name)' \
         | while read -r v; do
-            if [[ -n "$v" && "$v" != "$new" ]]; then
-              gcloud secrets versions disable "$v" --secret="$secret"
+            if [[ -n "${v}" && "${v}" != "${new}" ]]; then
+              gcloud secrets versions disable "${v}" --secret="${secret}"
             fi
           done
     }
     echo "Fetching latest version of admin token"
     admin_secret_version=$(gcloud secrets versions describe latest --secret=cf_r2_admin_token --format='value(name)')
     echo "Fetching admin token value"
-    admin_token=$(gcloud secrets versions access "$admin_secret_version" | tr -d '\n\r')
+    admin_token=$(gcloud secrets versions access "${admin_secret_version}" | tr -d '\n\r')
     for bucket in "${buckets[@]}"; do
       echo "Fetching secret key for bucket"
       key_id_version=$(gcloud secrets versions describe latest --secret="cf_r2_${bucket}_access_key_id" --format='value(name)')
-      key_id=$(gcloud secrets versions access "$key_id_version" | tr -d '\n\r')
-      echo "Rotating credentials for bucket $bucket"
+      key_id=$(gcloud secrets versions access "${key_id_version}" | tr -d '\n\r')
+      echo "Rotating credentials for bucket ${bucket}"
       body=$(jq -n \
-        --arg bucket "$bucket" \
-        --arg parent "$key_id" \
+        --arg bucket "${bucket}" \
+        --arg parent "${key_id}" \
         '{bucket: $bucket, parentAccessKeyId: $parent, permission: "object-read-write", ttlSeconds: 86400}')
       response=$( \
         curl -XPOST \
         --retry 3 \
         --retry-delay 1 \
         --retry-all-errors \
-        -sSL \
+        -sS \
         "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/r2/temp-access-credentials" \
         -H "Authorization: Bearer ${admin_token}" \
         -H "Content-Type: application/json" \
-        -d "$body" \
+        -d "${body}" \
       )
 
-      if ! echo "$response" | jq -e '.success' > /dev/null; then
-        echo "Cloudflare API error: $response"
+      if ! echo "${response}" | jq -e '.success' > /dev/null; then
+        echo "Cloudflare API error: ${response}"
         exit 1
       fi
 
-      if ! creds=$(echo "$response" | jq -e '.result | {accessKeyId, secretAccessKey, sessionToken} | select(.accessKeyId and .secretAccessKey and .sessionToken)'); then
-        echo "Cloudflare API error: missing fields in response: $response"
+      if ! creds=$(echo "${response}" | jq -e '.result | {accessKeyId, secretAccessKey, sessionToken} | select(.accessKeyId and .secretAccessKey and .sessionToken)'); then
+        echo "Cloudflare API error: missing fields in response: ${response}"
         exit 1
       fi
-      access_key_id=$(echo "$creds" | jq -r '.accessKeyId')
-      access_key_secret=$(echo "$creds" | jq -r '.secretAccessKey')
-      session_token=$(echo "$creds" | jq -r '.sessionToken')
+      access_key_id=$(echo "${creds}" | jq -r '.accessKeyId')
+      access_key_secret=$(echo "${creds}" | jq -r '.secretAccessKey')
+      session_token=$(echo "${creds}" | jq -r '.sessionToken')
 
       # Cloudflare's temp-access-credentials endpoint returns the parent's
       # accessKeyId unchanged, so cf_r2_${bucket}_access_key_id never needs
-      # to be rewritten -- it was seeded once with the parent value and stays
-      # valid across rotations. Only the secret_access_key and session_token
-      # change each run.
-      echo "Uploading secretAccessKey for bucket $bucket"
-      upload_and_prune "cf_r2_${bucket}_access_key_secret" "$access_key_secret"
-      echo "Uploading sessionToken for bucket $bucket"
-      upload_and_prune "cf_r2_${bucket}_session_token" "$session_token"
-      echo "Uploading credentials JSON for bucket $bucket"
+      # to be rewritten.
+      echo "Uploading secretAccessKey for bucket ${bucket}"
+      upload_and_prune "cf_r2_${bucket}_access_key_secret" "${access_key_secret}"
+      echo "Uploading sessionToken for bucket ${bucket}"
+      upload_and_prune "cf_r2_${bucket}_session_token" "${session_token}"
+      echo "Uploading credentials JSON for bucket ${bucket}"
       credentials_json=$(jq -n \
-        --arg ak "$access_key_id" \
-        --arg sk "$access_key_secret" \
-        --arg st "$session_token" \
+        --arg ak "${access_key_id}" \
+        --arg sk "${access_key_secret}" \
+        --arg st "${session_token}" \
         --arg ep "https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com" \
         '{access_key: $ak, secret_key: $sk, session_token: $st, endpoint: $ep, s3_force_path_style: true, region: "auto"}')
-      upload_and_prune "cf_r2_${bucket}_credentials" "$credentials_json"
+      upload_and_prune "cf_r2_${bucket}_credentials" "${credentials_json}"
     done

--- a/prow/cluster/cloudflare_rotator_cronjob.yaml
+++ b/prow/cluster/cloudflare_rotator_cronjob.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cloudflare-rotator
+  namespace: default
+spec:
+  schedule: "0 */12 * * *" 
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 600
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          serviceAccountName: cloudflare-rotator
+          restartPolicy: Never
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          containers:
+            - name: rotator
+              image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/bash", "/scripts/rotate.sh"]
+              env:
+                - name: CF_ACCOUNT_ID
+                  value: "1eb8152ceed73d3ee6f66c3557819d4c"
+                - name: GCP_PROJECT
+                  value: "istio-testing"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+          volumes:
+            - name: scripts
+              configMap:
+                name: cloudflare-rotator
+                defaultMode: 0755
+                items:
+                  - key: rotate.sh
+                    path: rotate.sh

--- a/prow/cluster/cloudflare_rotator_cronjob.yaml
+++ b/prow/cluster/cloudflare_rotator_cronjob.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cloudflare-rotator
-  namespace: default
+  namespace: cloudflare-secret-rotation
 spec:
   schedule: "0 * * * *"  # every hour while debugging; switch back to "0 */12 * * *" once stable. 
   concurrencyPolicy: Forbid

--- a/prow/cluster/cloudflare_rotator_cronjob.yaml
+++ b/prow/cluster/cloudflare_rotator_cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudflare-rotator
   namespace: default
 spec:
-  schedule: "0 */12 * * *" 
+  schedule: "0 * * * *"  # every hour while debugging; switch back to "0 */12 * * *" once stable. 
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/prow/cluster/cloudflare_rotator_namespace.yaml
+++ b/prow/cluster/cloudflare_rotator_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflare-secret-rotation

--- a/prow/cluster/cloudflare_rotator_serviceaccount.yaml
+++ b/prow/cluster/cloudflare_rotator_serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloudflare-rotator
-  namespace: default
+  namespace: cloudflare-secret-rotation
   annotations:
     iam.gke.io/gcp-service-account: cloudflare-rotator@istio-testing.iam.gserviceaccount.com

--- a/prow/cluster/cloudflare_rotator_serviceaccount.yaml
+++ b/prow/cluster/cloudflare_rotator_serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudflare-rotator
+  namespace: default
+  annotations:
+    iam.gke.io/gcp-service-account: cloudflare-rotator@istio-testing.iam.gserviceaccount.com

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2833,7 +2833,7 @@ postsubmits:
         - name: CF_ACCOUNT_ID
           value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_access_key_id","project":"istio-testing","env":"CF_ACCESS_KEY_ID"},{"secret":"cf_r2_access_key_secret","project":"istio-testing","env":"CF_ACCESS_KEY_SECRET"}]'
+          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -23,7 +23,7 @@ postsubmits:
         - name: CF_ACCOUNT_ID
           value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_access_key_id","project":"istio-testing","env":"CF_ACCESS_KEY_ID"},{"secret":"cf_r2_access_key_secret","project":"istio-testing","env":"CF_ACCESS_KEY_SECRET"}]'
+          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -207,7 +207,7 @@ postsubmits:
         - name: CF_ACCOUNT_ID
           value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_access_key_id","project":"istio-testing","env":"CF_ACCESS_KEY_ID"},{"secret":"cf_r2_access_key_secret","project":"istio-testing","env":"CF_ACCESS_KEY_SECRET"}]'
+          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -79,7 +79,7 @@ postsubmits:
         - name: CF_ACCOUNT_ID
           value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_access_key_id","project":"istio-testing","env":"CF_ACCESS_KEY_ID"},{"secret":"cf_r2_access_key_secret","project":"istio-testing","env":"CF_ACCESS_KEY_SECRET"}]'
+          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "64"
         image: gcr.io/istio-testing/build-tools-proxy:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -101,7 +101,7 @@ postsubmits:
         - name: CF_ACCOUNT_ID
           value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_access_key_id","project":"istio-testing","env":"CF_ACCESS_KEY_ID"},{"secret":"cf_r2_access_key_secret","project":"istio-testing","env":"CF_ACCESS_KEY_SECRET"}]'
+          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -173,7 +173,7 @@ postsubmits:
         - name: CF_ACCOUNT_ID
           value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_access_key_id","project":"istio-testing","env":"CF_ACCESS_KEY_ID"},{"secret":"cf_r2_access_key_secret","project":"istio-testing","env":"CF_ACCESS_KEY_SECRET"}]'
+          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -132,17 +132,14 @@ requirement_presets:
       - secret: github_istio-testing_pusher
         project: istio-prow-build
         env: GH_TOKEN
-  cf-r2-auth:
+  cf-r2-istio-build-auth:
     env:
       - name: CF_ACCOUNT_ID
         value: "1eb8152ceed73d3ee6f66c3557819d4c"
     secrets:
-      - secret: cf_r2_access_key_id
+      - secret: cf_r2_istio-build_credentials
         project: istio-testing
-        env: CF_ACCESS_KEY_ID
-      - secret: cf_r2_access_key_secret
-        project: istio-testing
-        env: CF_ACCESS_KEY_SECRET
+        env: CF_CREDENTIALS
   # build-base has access to push to dockerhub and to push as istio-testing github. Only for use with base image building
   build-base:
     env:

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -18,7 +18,7 @@ jobs:
     service_account_name: prowjob-testing-write
     types: [postsubmit]
     command: [entrypoint, prow/release-commit.sh]
-    requirements: [docker, cf-r2-auth]
+    requirements: [docker, cf-r2-istio-build-auth]
     resources: dedicated
 
   - name: benchmark

--- a/prow/config/jobs/proxy.yaml
+++ b/prow/config/jobs/proxy.yaml
@@ -58,7 +58,7 @@ jobs:
   service_account_name: prowjob-testing-write
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
-  requirements: [docker, cf-r2-auth]
+  requirements: [docker, cf-r2-istio-build-auth]
   timeout: 6h
 - name: release
   architectures: [arm64]

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -24,7 +24,7 @@ jobs:
     service_account_name: prowjob-testing-write
     types: [postsubmit]
     command: [entrypoint, make, release]
-    requirements: [cratescache, cf-r2-auth]
+    requirements: [cratescache, cf-r2-istio-build-auth]
 
 resources_presets:
   # Rust jobs are CPU intensive. Bump up defaults (from 1/3) to 3/8 to speed up jobs.

--- a/tools/automator/scripts/update-images.sh
+++ b/tools/automator/scripts/update-images.sh
@@ -25,7 +25,7 @@ source "$ROOT/../utils.sh"
 # Defaults
 image='gcr.io/istio-testing/build-tools.*'
 tag='$AUTOMATOR_SRC_BRANCH-\([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}\|[0-9a-f]{40}\)'
-paths='$AUTOMATOR_REPO_DIR/prow/cluster/jobs/**/*.yaml,$AUTOMATOR_REPO_DIR/prow/config/jobs/**/*.yaml'
+paths='$AUTOMATOR_REPO_DIR/prow/cluster/jobs/**/*.yaml,$AUTOMATOR_REPO_DIR/prow/config/jobs/**/*.yaml,$AUTOMATOR_REPO_DIR/prow/cluster/cloudflare_rotator_cronjob.yaml'
 key="image"
 var="IMAGE_VERSION"
 source='$AUTOMATOR_ROOT_DIR/files/common/scripts/setup_env.sh'


### PR DESCRIPTION
Ok, after a few too many PRs and some WG meeting discussion I think I've settled on a good way to do secrets.

We have one set of admin api credientials in google secret manager that has read write access to all buckets in cloudflare (Cloudflare doesn't have bucket-level granularity for admin credentials; also, only admin credential keys can create temp credential keys which are scoped). 

Now, we have a secret rotator that runs in our trusted cluster. This cronjob reads the admin api credentials and creates temp read-write credentials (24h) for each bucket we care about (right now, istio-prow and istio-build). The secret rotator uploads these secrets to Google Secret Manager in the form

```
{
  "access_key": ...
  "secret_key": ...
  "session_token": ...
  "endpoint": ...
  "s3_force_path_style": true,
  "region": auto
}
```

this is the format prow expects and by putting all our sesitive values in one secret, we have fewer secrets to worry about. We have more control over non-prow jobs, so we can have those jobs parse secrets as necessary.

I'll also put this in the parent issue.