### PR TITLE
fix typo in proxy 1.30 envoy update branch

### DIFF
--- a/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.30.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.release-1.30.gen.yaml
@@ -30,7 +30,7 @@ periodics:
       - --labels=auto-merge
       - --modifier=update_envoy_dep
       - --token-env
-      - --cmd=UPDATE_BRANCH=release/v1.30 scripts/update_envoy.sh
+      - --cmd=UPDATE_BRANCH=release/v1.38 scripts/update_envoy.sh
       env:
       - name: AUTOMATOR_ORG
         value: istio

--- a/prow/config/jobs/proxy-1.30.yaml
+++ b/prow/config/jobs/proxy-1.30.yaml
@@ -1466,7 +1466,7 @@ jobs:
   - --labels=auto-merge
   - --modifier=update_envoy_dep
   - --token-env
-  - --cmd=UPDATE_BRANCH=release/v1.30 scripts/update_envoy.sh
+  - --cmd=UPDATE_BRANCH=release/v1.38 scripts/update_envoy.sh
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"


### PR DESCRIPTION
Small typo fix on top of #5899 - proxy 1.30 should track envoy release/v1.38, not release/v1.30 (which is EOL at v1.30.11). The bad branch made the daily envoy update job produce a year-old downgrade PR (istio/proxy#6993).