### PR TITLE
Add lifecycle hook to cosign keys to prevent replacement

### DIFF
--- a/infra/gcp/istio-testing/keys.tf
+++ b/infra/gcp/istio-testing/keys.tf
@@ -6,7 +6,7 @@ resource "google_kms_key_ring" "istio_cosign_keyring" {
   project  = "istio-testing"
 }
 resource "google_kms_crypto_key" "istio_cosign_key" {
-  destroy_scheduled_duration = "86400s"
+  destroy_scheduled_duration = "2592000s"
   key_ring                   = "projects/istio-testing/locations/global/keyRings/istio-cosign-keyring"
   name                       = "istio-cosign-key"
   purpose                    = "ASYMMETRIC_SIGN"
@@ -14,5 +14,9 @@ resource "google_kms_crypto_key" "istio_cosign_key" {
   version_template {
     algorithm        = "EC_SIGN_P256_SHA256"
     protection_level = "SOFTWARE"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }


### PR DESCRIPTION
Cosign keys cannot be updated, they can only be destroyed and regenerated and we really don't want to do this this adds a lifecyle attribute to stop the destruction of these keys because they are kinda irrecoverable (https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key).

Also, our tf config drifted from our GCP state, which caused terrafrom to want to replace the cosign key. This PR reconciles the state in the terraform config.