### PR TITLE
remove node_count for prow node pool

### DIFF
--- a/infra/gcp/istio-testing/cluster-prow.tf
+++ b/infra/gcp/istio-testing/cluster-prow.tf
@@ -115,7 +115,6 @@ resource "google_container_node_pool" "prow_pool" {
     }
   }
 
-  node_count     = 4
   node_locations = ["us-west1-a"]
   project        = "istio-testing"
 


### PR DESCRIPTION
IDK how this wasn't a problem before, but terraform doesn't let me create a node pool with both a `node_count` and `initial_node_count`.it also doesnt make much sense
