### PR TITLE
Give service account secret access to r2 secrets

### DIFF
--- a/prow/cluster/arm/prowjob_service_accounts.yaml
+++ b/prow/cluster/arm/prowjob_service_accounts.yaml
@@ -8,6 +8,11 @@ metadata:
   namespace: test-pods
   # Default service account that only has permissions to access the GCS bucket for logging.
   name: prowjob-default-sa
+secrets:
+# Allows plank to mount R2 credentials into sidecar/initupload for jobs that
+# use s3:// artifact storage. The secret itself is synced by external-secrets
+# from GSM `cf_r2_istio-prow_credentials`.
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -9,6 +9,11 @@ metadata:
   namespace: test-pods
   # Default service account that only has permissions to access the GCS bucket for logging.
   name: prowjob-default-sa
+secrets:
+# Allows plank to mount R2 credentials into sidecar/initupload for jobs that
+# use s3:// artifact storage. The secret itself is synced by external-secrets
+# from GSM `cf_r2_istio-prow_credentials`.
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
TBH, I think a better option is to remove the `kubernetes.io/enforce-mountable-secrets: "true"`. We don't have any secrets and the annotation is deprecated https://kubernetes.io/docs/concepts/security/service-accounts/#enforce-mountable-secrets