### PR TITLE
Sync more secrets for cf/r2 migration

### DIFF
--- a/infra/gcp/istio-prow-private/iam.tf
+++ b/infra/gcp/istio-prow-private/iam.tf
@@ -53,3 +53,21 @@ resource "google_project_iam_member" "owners" {
   role     = "roles/owner"
   member   = "user:${each.key}"
 }
+
+# SA used by the kubernetes-external-secrets operator running in the private build
+# clusters.
+#
+# When adding a new ExternalSecret under prow/cluster/private
+# add the corresponding GSM secret to the `secrets`
+# list below so the operator can fetch it.
+module "kubernetes_external_secrets_account" {
+  source            = "../modules/workload-identity-service-account"
+  project_id        = local.project_id
+  name              = "kubernetes-external-secrets-sa-private"
+  description       = "Service account used by kubernetes-external-secrets operator on the private clusters."
+  cluster_namespace = "default"
+  secrets = [
+    { name = "cf_r2_istio-prow-private_credentials", project = "istio-testing" },
+  ]
+  prowjob = false
+}

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -141,8 +141,13 @@ resource "google_project_iam_member" "owners" {
 // We need to read from these secrets to get the key id, which lets us get new ephemeral credentials and refresh the secrets.
 locals {
   cloudflare_rotator_r2_secrets = toset([
-    "cf_r2_istio-prow_credentials",
     "cf_r2_istio-build_credentials",
+    "cf_r2_istio-build-private_credentials",
+    "cf_r2_istio-prerelease_credentials",
+    "cf_r2_istio-prerelease-private_credentials",
+    "cf_r2_istio-prow_credentials",
+    "cf_r2_istio-prow-private_credentials",
+    "cf_r2_istio-testgrid_credentials",
   ])
 }
 

--- a/prow/cluster/arm/prowjob_service_accounts.yaml
+++ b/prow/cluster/arm/prowjob_service_accounts.yaml
@@ -1,4 +1,8 @@
 ---
+# The `cf-r2-istio-prow-credentials` secret listed under each ServiceAccount
+# allows plank to mount R2 credentials into sidecar/initupload for jobs that
+# use s3:// artifact storage. The secret itself is synced by external-secrets
+# from GSM `cf_r2_istio-prow_credentials`.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,9 +13,6 @@ metadata:
   # Default service account that only has permissions to access the GCS bucket for logging.
   name: prowjob-default-sa
 secrets:
-# Allows plank to mount R2 credentials into sidecar/initupload for jobs that
-# use s3:// artifact storage. The secret itself is synced by external-secrets
-# from GSM `cf_r2_istio-prow_credentials`.
 - name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
@@ -24,6 +25,8 @@ metadata:
   # Service account that has permissions for release jobs.
   # This should ONLY be used for release jobs.
   name: prowjob-release
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -34,6 +37,8 @@ metadata:
   namespace: test-pods
   # Service account that has permissions for RBE access. For use by istio/proxy
   name: prowjob-rbe
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -44,6 +49,8 @@ metadata:
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and to push PRs as istio-testing account.
   name: prowjob-build-tools
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -54,3 +61,5 @@ metadata:
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build.
   name: prowjob-testing-write
+secrets:
+- name: cf-r2-istio-prow-credentials

--- a/prow/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/cluster/build/prowjob_service_accounts.yaml
@@ -1,4 +1,8 @@
 ---
+# The `cf-r2-istio-prow-credentials` secret listed under each ServiceAccount
+# allows plank to mount R2 credentials into sidecar/initupload for jobs that
+# use s3:// artifact storage. The secret itself is synced by external-secrets
+# from GSM `cf_r2_istio-prow_credentials`.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,9 +14,6 @@ metadata:
   # Default service account that only has permissions to access the GCS bucket for logging.
   name: prowjob-default-sa
 secrets:
-# Allows plank to mount R2 credentials into sidecar/initupload for jobs that
-# use s3:// artifact storage. The secret itself is synced by external-secrets
-# from GSM `cf_r2_istio-prow_credentials`.
 - name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
@@ -25,6 +26,8 @@ metadata:
   # Service account that has permissions for release jobs.
   # This should ONLY be used for release jobs.
   name: prowjob-release
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -35,6 +38,8 @@ metadata:
   namespace: test-pods
   # Service account that has permissions for RBE access. For use by istio/proxy, currently.
   name: prowjob-rbe
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -45,6 +50,8 @@ metadata:
   namespace: test-pods
   # Service account that has permissions for GitHub read-only (public) access. For use by release-notes jobs, currently.
   name: prowjob-github-read
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -56,6 +63,8 @@ metadata:
   # Service account that has permissions for GitHub from istio-testing account. Has permissions to push PRs. For use by automation
   # that creates PRs.
   name: prowjob-github-istio-testing
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -66,6 +75,8 @@ metadata:
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and to push PRs as istio-testing account.
   name: prowjob-build-tools
+secrets:
+- name: cf-r2-istio-prow-credentials
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -76,3 +87,5 @@ metadata:
   namespace: test-pods
   # Service account that has permissions to push to gcr.io/istio-testing and gs://istio-build.
   name: prowjob-testing-write
+secrets:
+- name: cf-r2-istio-prow-credentials

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -9,8 +9,13 @@ data:
     # Inputs (env): CF_ACCOUNT_ID, GCP_PROJECT
     set -euo pipefail
     buckets=(
-      "istio-prow"
       "istio-build"
+      "istio-build-private"
+      "istio-prerelease"
+      "istio-prerelease-private"
+      "istio-prow"
+      "istio-prow-private"
+      "istio-testgrid"
     )
     echo "Setting up gcloud"
     gcloud config set project "${GCP_PROJECT}"

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -58,3 +58,16 @@ spec:
   - key: cf_r2_istio-prow_credentials # Secret name in GSM
     name: service-account.json
 ---
+# Mounted by sidecar/initupload for jobs that use s3:// artifact storage.
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cf-r2-istio-prow-credentials
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_istio-prow_credentials # Secret name in GSM
+    name: service-account.json
+---

--- a/prow/cluster/private/kubernetes-external-secrets_crd.yaml
+++ b/prow/cluster/private/kubernetes-external-secrets_crd.yaml
@@ -1,0 +1,238 @@
+---
+# From https://github.com/external-secrets/kubernetes-external-secrets/blob/master/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: externalsecrets.kubernetes-client.io
+  annotations:
+    # for helm v2 backwards compatibility
+    helm.sh/hook: crd-install
+    # used in e2e testing
+    app.kubernetes.io/managed-by: helm
+spec:
+  group: kubernetes-client.io
+  scope: Namespaced
+
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          required:
+            - spec
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                controllerId:
+                  description: The ID of controller instance that manages this ExternalSecret.
+                    This is needed in case there is more than a KES controller instances within the cluster.
+                  type: string
+                type:
+                  type: string
+                  description: >-
+                    DEPRECATED: Use spec.template.type
+                template:
+                  description: Template which will be deep merged without mutating
+                    any existing fields. into generated secret, can be used to
+                    set for example annotations or type on the generated secret
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                backendType:
+                  description: >-
+                    Determines which backend to use for fetching secrets
+                  type: string
+                  enum:
+                    - secretsManager
+                    - systemManager
+                    - vault
+                    - azureKeyVault
+                    - gcpSecretsManager
+                    - alicloudSecretsManager
+                    - ibmcloudSecretsManager
+                    - akeyless
+                vaultRole:
+                  description: >-
+                    Used by: vault
+                  type: string
+                vaultMountPoint:
+                  description: >-
+                    Used by: vault
+                  type: string
+                kvVersion:
+                  description: Vault K/V version either 1 or 2, default = 2
+                  type: integer
+                  minimum: 1
+                  maximum: 2
+                keyVaultName:
+                  description: >-
+                    Used by: azureKeyVault
+                  type: string
+                dataFrom:
+                  type: array
+                  items:
+                    type: string
+                dataFromWithOptions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    required:
+                    - key
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      name:
+                        description: Name set for this key in the generated secret
+                        type: string
+                      property:
+                        description: Property to extract if secret in backend is a JSON object
+                        type: string
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                      path:
+                        description: >-
+                          Path from SSM to scrape secrets
+                          This will fetch all secrets and use the key from the secret as variable name
+                        type: string
+                      recursive:
+                        description: Allow to recurse thru all child keys on a given path, default false
+                        type: boolean
+                      secretType:
+                        description: >-
+                          Used by: ibmcloudSecretsManager
+                          Type of secret - one of username_password, iam_credentials or arbitrary
+                        type: string
+                      version:
+                        description: >-
+                          Used by: gcpSecretsManager
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    oneOf:
+                      - required:
+                          - key
+                          - name
+                      - required:
+                          - path
+                roleArn:
+                  type: string
+                  description: >-
+                    Used by: alicloudSecretsManager, secretsManager, systemManager
+                region:
+                  type: string
+                  description: >-
+                    Used by: secretsManager, systemManager
+                projectId:
+                  type: string
+                  description: >-
+                    Used by: gcpSecretsManager
+                keyByName:
+                  type: boolean
+                  description: >-
+                    Whether to interpret the key as a secret name (if true) or ID (the default).
+                    Used by: ibmcloudSecretsManager
+              oneOf:
+                - properties:
+                    backendType:
+                      enum:
+                        - secretsManager
+                        - systemManager
+                - properties:
+                    backendType:
+                      enum:
+                        - vault
+                - properties:
+                    backendType:
+                      enum:
+                        - azureKeyVault
+                  required:
+                    - keyVaultName
+                - properties:
+                    backendType:
+                      enum:
+                        - gcpSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - alicloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - ibmcloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - akeyless
+              anyOf:
+                - required:
+                    - data
+                - required:
+                    - dataFrom
+                - required:
+                    - dataFromWithOptions
+            status:
+              type: object
+              properties:
+                lastSync:
+                  type: string
+                status:
+                  type: string
+                observedGeneration:
+                  type: number
+      additionalPrinterColumns:
+        - jsonPath: .status.lastSync
+          name: Last Sync
+          type: date
+        - jsonPath: .status.status
+          name: status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+
+  names:
+    shortNames:
+      - es
+    kind: ExternalSecret
+    plural: externalsecrets
+    singular: externalsecret

--- a/prow/cluster/private/kubernetes-external-secrets_deployment.yaml
+++ b/prow/cluster/private/kubernetes-external-secrets_deployment.yaml
@@ -1,0 +1,41 @@
+---
+# Source: kubernetes-external-secrets/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-external-secrets
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubernetes-external-secrets
+    spec:
+      serviceAccountName: kubernetes-external-secrets-sa-private
+      containers:
+        - name: kubernetes-external-secrets
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:8.5.1"
+          ports:
+          - name: prometheus
+            containerPort: 3001
+          imagePullPolicy: IfNotPresent
+          resources:
+            {}
+          env:
+          - name: "LOG_LEVEL"
+            value: "info"
+          - name: "METRICS_PORT"
+            value: "3001"
+          - name: "POLLER_INTERVAL_MILLISECONDS"
+            value: "10000"
+          - name: "WATCH_TIMEOUT"
+            value: "60000"
+          # Params for env vars populated from k8s secrets
+      securityContext:
+        runAsNonRoot: true

--- a/prow/cluster/private/kubernetes-external-secrets_rbac.yaml
+++ b/prow/cluster/private/kubernetes-external-secrets_rbac.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: kubernetes-external-secrets-sa-private@istio-testing.iam.gserviceaccount.com
+  namespace: default
+  name: "kubernetes-external-secrets-sa-private"
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-external-secrets
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "get"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["externalsecrets.kubernetes-client.io"]
+    verbs: ["get", "update"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets/status"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create"]
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-external-secrets
+subjects:
+  - name: kubernetes-external-secrets-sa-private
+    namespace: "default"
+    kind: ServiceAccount
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets-auth
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- name: kubernetes-external-secrets-sa-private
+  namespace: "default"
+  kind: ServiceAccount

--- a/prow/cluster/private/kubernetes-external-secrets_service.yaml
+++ b/prow/cluster/private/kubernetes-external-secrets_service.yaml
@@ -1,0 +1,17 @@
+---
+# Source: kubernetes-external-secrets/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-external-secrets
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+spec:
+  selector:
+    app.kubernetes.io/name: kubernetes-external-secrets
+  ports:
+    - protocol: TCP
+      port: 3001
+      name: prometheus
+      targetPort: prometheus

--- a/prow/cluster/private/kubernetes_external_secrets.yaml
+++ b/prow/cluster/private/kubernetes_external_secrets.yaml
@@ -1,5 +1,5 @@
 ---
-# NOTE: When adding a new ExternalSecret here (or in arm/), make sure the
+# NOTE: When adding a new ExternalSecret here, make sure the
 # `kubernetes_external_secrets_account` SA in
 # infra/gcp/istio-prow-private/iam.tf is granted secretAccessor on the new
 # GSM secret (add it to the `secrets` list). Without that IAM grant the

--- a/prow/cluster/private/kubernetes_external_secrets.yaml
+++ b/prow/cluster/private/kubernetes_external_secrets.yaml
@@ -1,0 +1,17 @@
+---
+# NOTE: When adding a new ExternalSecret here (or in arm/), make sure the
+# `kubernetes_external_secrets_account` SA in
+# infra/gcp/istio-prow-private/iam.tf is granted secretAccessor on the new
+# GSM secret (add it to the `secrets` list). Without that IAM grant the
+# operator cannot fetch the secret and the K8s Secret will not be created.
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cf-r2-istio-prow-private-credentials
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_istio-prow-private_credentials # Secret name in GSM
+    name: service-account.json

--- a/prow/cluster/private/prowjob_service_accounts.yaml
+++ b/prow/cluster/private/prowjob_service_accounts.yaml
@@ -1,3 +1,7 @@
+# The `cf-r2-istio-prow-private-credentials` secret listed under the
+# ServiceAccount allows plank to mount R2 credentials into sidecar/initupload
+# for jobs that use s3:// artifact storage. The secret itself is synced by
+# external-secrets from GSM `cf_r2_istio-prow-private_credentials`.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,3 +12,5 @@ metadata:
   namespace: test-pods
   # Default service account that only has permissions to access the GCS buckets for private build.
   name: prowjob-private
+secrets:
+- name: cf-r2-istio-prow-private-credentials

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16,8 +16,9 @@ plank:
         entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260423-a2314bdb2"
         sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260423-a2314bdb2"
       gcs_configuration:
-        bucket: "istio-prow"
+        bucket: "s3://istio-prow"
         path_strategy: "explicit"
+      s3_credentials_secret: "cf-r2-istio-prow-credentials"
       blobless_fetch: true
       ssh_host_fingerprints:
         - "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk="
@@ -43,13 +44,12 @@ plank:
     config:
       default_service_account_name: "prowjob-default-sa" # Use workload identity
       gcs_credentials_secret: ""                         # rather than service account key secret
-  # Add this back when we figure out how to get R2 credentials in worker clusters.
-  - repo: istio/test-infra
+  # istio/istio still uploads artifacts to GCS; everything else uses R2 by default.
+  - repo: istio/istio
     config:
       gcs_configuration:
-        bucket: "s3://istio-prow"
+        bucket: "istio-prow"
         path_strategy: "explicit"
-      s3_credentials_secret: "cf-r2-istio-prow-credentials"
 
 sinker:
   resync_period: 1m


### PR DESCRIPTION
I already added

   - cf_r2_istio-build-private_credentials
   - cf_r2_istio-prerelease_credentials
   - cf_r2_istio-prerelease-private_credentials
   - cf_r2_istio-prow-private_credentials
   - cf_r2_istio-testgrid_credentials

to gcp.

This PR adds secret rotation for all these credentials. It also configures permissions for the private clusters to use prow-private as its storage backend (but doesn't actually use it).