### PR TITLE
Fully use R2 for prow

### DIFF
--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -146,7 +146,6 @@ locals {
     "cf_r2_istio-prerelease_credentials",
     "cf_r2_istio-prerelease-private_credentials",
     "cf_r2_istio-prow_credentials",
-    "cf_r2_istio-prow_ro_credentials",
     "cf_r2_istio-prow-private_credentials",
     "cf_r2_istio-testgrid_credentials",
   ])

--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -146,6 +146,7 @@ locals {
     "cf_r2_istio-prerelease_credentials",
     "cf_r2_istio-prerelease-private_credentials",
     "cf_r2_istio-prow_credentials",
+    "cf_r2_istio-prow_ro_credentials",
     "cf_r2_istio-prow-private_credentials",
     "cf_r2_istio-testgrid_credentials",
   ])

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -8,19 +8,18 @@ data:
     #!/usr/bin/env bash
     # Inputs (env): CF_ACCOUNT_ID, GCP_PROJECT
     set -euo pipefail
-    # Each entry is "<secret_suffix>:<bucket>:<permission>". The GSM secret name is
-    # "cf_r2_${bucket}${secret_suffix}_credentials". Permission is the value passed
-    # to Cloudflare's temp-access-credentials API (e.g. object-read-write,
-    # object-read-only).
-    rotations=(
-      ":istio-build:object-read-write"
-      ":istio-build-private:object-read-write"
-      ":istio-prerelease:object-read-write"
-      ":istio-prerelease-private:object-read-write"
-      ":istio-prow:object-read-write"
-      "_ro:istio-prow:object-read-only"
-      ":istio-prow-private:object-read-write"
-      ":istio-testgrid:object-read-write"
+    set +x
+    # Note that we don't rotate "cf_r2_public_buckets_ro_credentials"
+    # because temp credentials can only be scoped to one bucket.
+    # That's probably fine since its read-only to already-public information.
+    buckets=(
+      "istio-build"
+      "istio-build-private"
+      "istio-prerelease"
+      "istio-prerelease-private"
+      "istio-prow"
+      "istio-prow-private"
+      "istio-testgrid"
     )
     echo "Setting up gcloud"
     gcloud config set project "${GCP_PROJECT}"
@@ -42,17 +41,14 @@ data:
     }
     echo "Fetching admin token value"
     admin_token=$(gcloud secrets versions access latest --secret=cf_r2_admin_token | tr -d '\n\r')
-    for entry in "${rotations[@]}"; do
-      IFS=':' read -r suffix bucket permission <<< "${entry}"
-      secret="cf_r2_${bucket}${suffix}_credentials"
-      echo "Fetching parent access key id from ${secret}"
-      key_id=$(gcloud secrets versions access latest --secret="${secret}" | jq -r '.access_key' | tr -d '\n\r')
-      echo "Rotating credentials for ${secret} (bucket=${bucket}, permission=${permission})"
+    for bucket in "${buckets[@]}"; do
+      echo "Fetching parent access key id for bucket ${bucket}"
+      key_id=$(gcloud secrets versions access latest --secret="cf_r2_${bucket}_credentials" | jq -r '.access_key' | tr -d '\n\r')
+      echo "Rotating credentials for bucket ${bucket}"
       body=$(jq -n \
         --arg bucket "${bucket}" \
         --arg parent "${key_id}" \
-        --arg permission "${permission}" \
-        '{bucket: $bucket, parentAccessKeyId: $parent, permission: $permission, ttlSeconds: 86400}')
+        '{bucket: $bucket, parentAccessKeyId: $parent, permission: "object-read-write", ttlSeconds: 86400}')
       response=$( \
         curl -XPOST \
         --retry 3 \
@@ -86,5 +82,5 @@ data:
         --arg st "${session_token}" \
         --arg ep "https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com" \
         '{access_key: $ak, secret_key: $sk, session_token: $st, endpoint: $ep, s3_force_path_style: true, region: "auto"}')
-      upload_and_prune "${secret}" "${credentials_json}"
+      upload_and_prune "cf_r2_${bucket}_credentials" "${credentials_json}"
     done

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -8,14 +8,19 @@ data:
     #!/usr/bin/env bash
     # Inputs (env): CF_ACCOUNT_ID, GCP_PROJECT
     set -euo pipefail
-    buckets=(
-      "istio-build"
-      "istio-build-private"
-      "istio-prerelease"
-      "istio-prerelease-private"
-      "istio-prow"
-      "istio-prow-private"
-      "istio-testgrid"
+    # Each entry is "<secret_suffix>:<bucket>:<permission>". The GSM secret name is
+    # "cf_r2_${bucket}${secret_suffix}_credentials". Permission is the value passed
+    # to Cloudflare's temp-access-credentials API (e.g. object-read-write,
+    # object-read-only).
+    rotations=(
+      ":istio-build:object-read-write"
+      ":istio-build-private:object-read-write"
+      ":istio-prerelease:object-read-write"
+      ":istio-prerelease-private:object-read-write"
+      ":istio-prow:object-read-write"
+      "_ro:istio-prow:object-read-only"
+      ":istio-prow-private:object-read-write"
+      ":istio-testgrid:object-read-write"
     )
     echo "Setting up gcloud"
     gcloud config set project "${GCP_PROJECT}"
@@ -37,14 +42,17 @@ data:
     }
     echo "Fetching admin token value"
     admin_token=$(gcloud secrets versions access latest --secret=cf_r2_admin_token | tr -d '\n\r')
-    for bucket in "${buckets[@]}"; do
-      echo "Fetching parent access key id for bucket ${bucket}"
-      key_id=$(gcloud secrets versions access latest --secret="cf_r2_${bucket}_credentials" | jq -r '.access_key' | tr -d '\n\r')
-      echo "Rotating credentials for bucket ${bucket}"
+    for entry in "${rotations[@]}"; do
+      IFS=':' read -r suffix bucket permission <<< "${entry}"
+      secret="cf_r2_${bucket}${suffix}_credentials"
+      echo "Fetching parent access key id from ${secret}"
+      key_id=$(gcloud secrets versions access latest --secret="${secret}" | jq -r '.access_key' | tr -d '\n\r')
+      echo "Rotating credentials for ${secret} (bucket=${bucket}, permission=${permission})"
       body=$(jq -n \
         --arg bucket "${bucket}" \
         --arg parent "${key_id}" \
-        '{bucket: $bucket, parentAccessKeyId: $parent, permission: "object-read-write", ttlSeconds: 86400}')
+        --arg permission "${permission}" \
+        '{bucket: $bucket, parentAccessKeyId: $parent, permission: $permission, ttlSeconds: 86400}')
       response=$( \
         curl -XPOST \
         --retry 3 \
@@ -78,5 +86,5 @@ data:
         --arg st "${session_token}" \
         --arg ep "https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com" \
         '{access_key: $ak, secret_key: $sk, session_token: $st, endpoint: $ep, s3_force_path_style: true, region: "auto"}')
-      upload_and_prune "cf_r2_${bucket}_credentials" "${credentials_json}"
+      upload_and_prune "${secret}" "${credentials_json}"
     done

--- a/prow/cluster/gcsweb/gcsweb_deployment.yaml
+++ b/prow/cluster/gcsweb/gcsweb_deployment.yaml
@@ -34,13 +34,15 @@ spec:
         # (kubernetes/test-infra#31241). Use the staging image until a newer tag
         # is published to registry.k8s.io.
         image: gcr.io/k8s-staging-test-infra/gcsweb:v20260325-0ac3b4d79f
+        # Upstream gcsweb refuses to serve buckets from different storage
+        # providers (gs:// + s3://) in the same process, so all -b entries
+        # must be R2.
         args:
         - -b=s3://istio-prow
-        - -b=istio-build
-        - -b=istio-artifacts
-        - -b=istio-release
-        - -b=istio-prerelease
-        - -b=istio-release-pipeline-data
+        - -b=s3://istio-build
+        - -b=s3://istio-release
+        - -b=s3://istio-prerelease
+        - -b=s3://istio-testgrid
         - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - -p=8080
         ports:
@@ -70,4 +72,4 @@ spec:
           name: nginx
       - name: s3-credentials
         secret:
-          secretName: cf-r2-istio-prow-ro-credentials
+          secretName: cf-r2-public-buckets-ro-credentials

--- a/prow/cluster/gcsweb/gcsweb_deployment.yaml
+++ b/prow/cluster/gcsweb/gcsweb_deployment.yaml
@@ -30,14 +30,18 @@ spec:
         - name: nginx
           mountPath: /etc/nginx/conf.d
       - name: gcsweb
-        image: k8s.gcr.io/gcsweb:v1.1.0
+        # Upstream registry.k8s.io/gcsweb:v1.1.0 predates S3 support
+        # (kubernetes/test-infra#31241). Use the staging image until a newer tag
+        # is published to registry.k8s.io.
+        image: gcr.io/k8s-staging-test-infra/gcsweb:v20260325-0ac3b4d79f
         args:
-        - -b=istio-prow
+        - -b=s3://istio-prow
         - -b=istio-build
         - -b=istio-artifacts
         - -b=istio-release
         - -b=istio-prerelease
         - -b=istio-release-pipeline-data
+        - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - -p=8080
         ports:
         - containerPort: 8080
@@ -56,7 +60,14 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 2
           failureThreshold: 2
+        volumeMounts:
+        - name: s3-credentials
+          mountPath: /etc/s3-credentials
+          readOnly: true
       volumes:
       - name: nginx
         configMap:
           name: nginx
+      - name: s3-credentials
+        secret:
+          secretName: cf-r2-istio-prow-ro-credentials

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -95,7 +95,7 @@ periodics:
           - wget
         args:
           - --spider
-          - https://gcsweb.istio.io/gcs/istio-release/
+          - https://gcsweb.istio.io/s3/istio-release/
         resources:
           requests:
             memory: 256Mi

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -71,16 +71,16 @@ spec:
   - key: cf_r2_istio-prow_credentials # Secret name in GSM
     name: service-account.json
 ---
-# Read-only R2 credentials, mounted by gcsweb to browse the istio-prow bucket.
+# Read-only R2 credentials scoped to the public buckets
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: cf-r2-istio-prow-ro-credentials
+  name: cf-r2-public-buckets-ro-credentials
   namespace: gcs
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing
   data:
-  - key: cf_r2_istio-prow_ro_credentials # Secret name in GSM
+  - key: cf_r2_public_buckets_ro_credentials # Secret name in GSM
     name: service-account.json
 ---

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -71,3 +71,16 @@ spec:
   - key: cf_r2_istio-prow_credentials # Secret name in GSM
     name: service-account.json
 ---
+# Read-only R2 credentials, mounted by gcsweb to browse the istio-prow bucket.
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cf-r2-istio-prow-ro-credentials
+  namespace: gcs
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_istio-prow_ro_credentials # Secret name in GSM
+    name: service-account.json
+---

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -55,12 +55,7 @@ deck:
   google_analytics: G-7HJSJ6B5Q6
   spyglass:
     size_limit: 500000000 # 500MB
-    # Default to the s3/ scheme (gcsweb routes both /gcs/<bucket>/ and /s3/<bucket>/),
-    # since prow logs now live in s3://istio-prow. Override per-bucket below for
-    # any bucket that still uses GCS (e.g. the private prow bucket).
-    gcs_browser_prefixes_by_bucket:
-      "*": https://gcsweb.istio.io/s3/
-      istio-prow-private: https://gcsweb.istio.io/gcs/
+    gcs_browser_prefix: https://gcsweb.istio.io/s3/
     testgrid_config: gs://k8s-testgrid/config
     testgrid_root: https://testgrid.k8s.io/
     lenses:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -44,12 +44,6 @@ plank:
     config:
       default_service_account_name: "prowjob-default-sa" # Use workload identity
       gcs_credentials_secret: ""                         # rather than service account key secret
-  # istio/istio still uploads artifacts to GCS; everything else uses R2 by default.
-  - repo: istio/istio
-    config:
-      gcs_configuration:
-        bucket: "istio-prow"
-        path_strategy: "explicit"
 
 sinker:
   resync_period: 1m
@@ -61,7 +55,12 @@ deck:
   google_analytics: G-7HJSJ6B5Q6
   spyglass:
     size_limit: 500000000 # 500MB
-    gcs_browser_prefix: https://gcsweb.istio.io/gcs/
+    # Default to the s3/ scheme (gcsweb routes both /gcs/<bucket>/ and /s3/<bucket>/),
+    # since prow logs now live in s3://istio-prow. Override per-bucket below for
+    # any bucket that still uses GCS (e.g. the private prow bucket).
+    gcs_browser_prefixes_by_bucket:
+      "*": https://gcsweb.istio.io/s3/
+      istio-prow-private: https://gcsweb.istio.io/gcs/
     testgrid_config: gs://k8s-testgrid/config
     testgrid_root: https://testgrid.k8s.io/
     lenses:


### PR DESCRIPTION
We create a new RO credential for gcsweb. Unfortunately, we can do rotation, but its RO for public stuff so its fine.
Point gcsweb to s3 buckets.