### PR TITLE
Use long lived tokens for some of prow. Fix health

### DIFF
--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -139,13 +139,13 @@ resource "google_project_iam_member" "owners" {
 }
 
 // We need to read from these secrets to get the key id, which lets us get new ephemeral credentials and refresh the secrets.
+// TODO Also rotate cf_r2_istio-prow_credentials when the rest of prow supports short-lived creds
 locals {
   cloudflare_rotator_r2_secrets = toset([
     "cf_r2_istio-build_credentials",
     "cf_r2_istio-build-private_credentials",
     "cf_r2_istio-prerelease_credentials",
     "cf_r2_istio-prerelease-private_credentials",
-    "cf_r2_istio-prow_credentials",
     "cf_r2_istio-prow-private_credentials",
     "cf_r2_istio-testgrid_credentials",
   ])

--- a/prow/cluster/cloudflare_rotator_configmap.yaml
+++ b/prow/cluster/cloudflare_rotator_configmap.yaml
@@ -9,15 +9,20 @@ data:
     # Inputs (env): CF_ACCOUNT_ID, GCP_PROJECT
     set -euo pipefail
     set +x
-    # Note that we don't rotate "cf_r2_public_buckets_ro_credentials"
-    # because temp credentials can only be scoped to one bucket.
-    # That's probably fine since its read-only to already-public information.
+    # We don't rotate two secrets, both for least-privilege reasons but coming
+    # from opposite directions:
+    #   - cf_r2_public_buckets_ro_credentials: temp credentials can only be
+    #     scoped to one bucket, but we need one credential covering several
+    #     public buckets for gcsweb / Deck Spyglass. Long-lived but RO and
+    #     read-only on already-public data, so the blast radius is small.
+    #   - cf_r2_istio-prow_credentials: Prow, as of right now, does not
+    #     support `session_token` in AWS creds, which are necessary for short-lived
+    #     creds.
     buckets=(
       "istio-build"
       "istio-build-private"
       "istio-prerelease"
       "istio-prerelease-private"
-      "istio-prow"
       "istio-prow-private"
       "istio-testgrid"
     )

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -44,7 +44,8 @@ spec:
         - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
         - --cookie-secret=/etc/cookie/secret
-        - --s3-credentials-file=/etc/cf-r2-istio-prow-credentials/service-account.json
+        # Deck only reads from blob storage (Spyglass, job/PR history).
+        - --s3-credentials-file=/etc/cf-r2-public-buckets-ro-credentials/service-account.json
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
@@ -68,8 +69,8 @@ spec:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
           readOnly: true
-        - mountPath: /etc/cf-r2-istio-prow-credentials
-          name: cf-r2-istio-prow-credentials
+        - mountPath: /etc/cf-r2-public-buckets-ro-credentials
+          name: cf-r2-public-buckets-ro-credentials
           readOnly: true
         livenessProbe:
           httpGet:
@@ -104,6 +105,6 @@ spec:
         configMap:
           defaultMode: 420
           name: kubeconfig
-      - name: cf-r2-istio-prow-credentials
+      - name: cf-r2-public-buckets-ro-credentials
         secret:
-          secretName: cf-r2-istio-prow-credentials
+          secretName: cf-r2-public-buckets-ro-credentials

--- a/prow/cluster/gcsweb/gcsweb_backendconfig.yaml
+++ b/prow/cluster/gcsweb/gcsweb_backendconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: gcsweb
+  namespace: gcs
+spec:
+  # Just explicitly set the LB healthcheck path to not have to deal with
+  # back inferences (e.g. defaults to /)
+  healthCheck:
+    type: HTTP
+    requestPath: /robots.txt

--- a/prow/cluster/gcsweb/gcsweb_deployment.yaml
+++ b/prow/cluster/gcsweb/gcsweb_deployment.yaml
@@ -53,11 +53,11 @@ spec:
             memory: 128Mi
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /robots.txt
             port: 8080
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /robots.txt
             port: 8080
           initialDelaySeconds: 3
           timeoutSeconds: 2

--- a/prow/cluster/gcsweb/gcsweb_service.yaml
+++ b/prow/cluster/gcsweb/gcsweb_service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: gcsweb
   namespace: gcs
+  annotations:
+    cloud.google.com/backend-config: '{"default": "gcsweb"}'
 spec:
   type: NodePort
   selector:

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -71,12 +71,24 @@ spec:
   - key: cf_r2_istio-prow_credentials # Secret name in GSM
     name: service-account.json
 ---
-# Read-only R2 credentials scoped to the public buckets
+# Read-only R2 credentials scoped to the public buckets.
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: cf-r2-public-buckets-ro-credentials
   namespace: gcs
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_public_buckets_ro_credentials # Secret name in GSM
+    name: service-account.json
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cf-r2-public-buckets-ro-credentials
+  namespace: default
 spec:
   backendType: gcpSecretsManager
   projectId: istio-testing


### PR DESCRIPTION
So we had to update our gcsweb version, which no longer had a healthz endpoint.
The GCP load balancer healthchecker was a bit disappointing started defaulting to `/` and failing because it returned a 404
I just decided to hardcode it to /robots.txt to not have to deal with it guessing.

Also, lots of our images still havne't picked up the changes that allow using temp s3 tokens... So for now (and for ONLY PROW) we use a long-lived token.

