### PR TITLE
upgrade oauth2 proxy to 7.15.2

### DIFF
--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -74,7 +74,7 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       - name: oauth2-proxy
-        image: quay.io/pusher/oauth2_proxy:v5.0.0
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.2
         ports:
         - containerPort: 4180
           protocol: TCP
@@ -83,10 +83,11 @@ spec:
         - --github-org=istio-private
         - --http-address=0.0.0.0:4180
         - --upstream=http://localhost:8080
-        - --cookie-domain=prow-private.istio.io
+        - --cookie-domains=prow-private.istio.io
         - --cookie-name=prow-private-istio-io-oauth2-proxy
         - --cookie-samesite=none
         - --email-domain=*
+        - --reverse-proxy=true
         livenessProbe:
           httpGet:
             path: /ping


### PR DESCRIPTION
I tried my best to read the changelogs, but someone please check it. Its definitely an improvement since right now, it just straight fails to pull:

```
  Type     Reason     Age                   From               Message
  ----     ------     ----                  ----               -------
  Normal   Scheduled  19m                   default-scheduler  Successfully assigned default/deck-private-dc958977f-8rppx to gke-prow-prod-node-pool-f54e56be-htus
  Normal   Pulled     19m                   kubelet            Container image "us-docker.pkg.dev/k8s-infra-prow/images/deck:v20260423-a2314bdb2" already present on machine
  Normal   Created    19m                   kubelet            Created container: deck-private
  Normal   Started    19m                   kubelet            Started container deck-private
  Normal   Pulling    16m (x5 over 19m)     kubelet            Pulling image "quay.io/pusher/oauth2_proxy:v5.0.0"
  Warning  Failed     16m (x5 over 19m)     kubelet            Failed to pull image "quay.io/pusher/oauth2_proxy:v5.0.0": failed to pull and unpack image "quay.io/pusher/oauth2_proxy:v5.0.0": failed to get converter for "quay.io/pusher/oauth2_proxy:v5.0.0": Pulling Schema 1 images have been deprecated and disabled by default since containerd v2.0. As a workaround you may set an environment variable `CONTAINERD_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=1`, but this will be completely removed in containerd v2.1.
  Warning  Failed     16m (x5 over 19m)     kubelet            Error: ErrImagePull
  Normal   BackOff    4m22s (x67 over 19m)  kubelet            Back-off pulling image "quay.io/pusher/oauth2_proxy:v5.0.0"
  Warning  Failed     4m22s (x67 over 19m)  kubelet            Error: ImagePullBackOff
```