### PR TITLE
give default prow job access istio-prow

### DIFF
--- a/infra/gcp/istio-testing/iam.tf
+++ b/infra/gcp/istio-testing/iam.tf
@@ -65,6 +65,14 @@ resource "google_service_account" "testgrid_updater" {
   project      = "istio-testing"
 }
 
+# Allow the default prowjob SA to read the cf_r2_istio-prow_credentials secret
+resource "google_secret_manager_secret_iam_member" "prowjob_default_cf_r2_istio_prow" {
+  project   = "istio-testing"
+  secret_id = "cf_r2_istio-prow_credentials"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.istio_prow_test_job_default.email}"
+}
+
 
 ## Prow Infra Service Accounts ##
 # Used for WI for external secrets deployment

--- a/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3179,8 +3179,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: DOCKER_HUB
           value: us-docker.pkg.dev/istio-prow-private/istio-prow-private
         - name: GCS_BUCKET

--- a/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -25,8 +25,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         image: gcr.io/istio-testing/build-tools-proxy:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -90,8 +88,6 @@ postsubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -2988,8 +2988,6 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -263,6 +263,8 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:
@@ -2830,8 +2832,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -2988,6 +2988,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -74,8 +74,6 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -20,8 +20,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -76,6 +74,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
         name: ""
         resources:

--- a/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -154,8 +154,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools-proxy:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -208,8 +206,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -26,8 +26,6 @@ postsubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         image: gcr.io/istio-testing/build-tools-proxy:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -80,8 +78,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -299,8 +299,6 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -98,8 +98,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -168,8 +166,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -280,6 +276,21 @@ presubmits:
     path_alias: istio.io/ztunnel
     rerun_command: /test bench
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: cloud.google.com/machine-family
+                operator: In
+                values:
+                - c3
+                - c3d
+                - n4
+                - c4d
+                - c4a
+                - c4
+            weight: 1
       automountServiceAccountToken: false
       containers:
       - command:
@@ -288,6 +299,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -305,6 +318,9 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
+        - mountPath: /home/.cargo
+          name: build-cache
+          subPath: cargo
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -280,21 +280,6 @@ presubmits:
     path_alias: istio.io/ztunnel
     rerun_command: /test bench
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: cloud.google.com/machine-family
-                operator: In
-                values:
-                - c3
-                - c3d
-                - n4
-                - c4d
-                - c4a
-                - c4
-            weight: 1
       automountServiceAccountToken: false
       containers:
       - command:
@@ -303,8 +288,6 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: GCP_SECRETS
-          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4
@@ -322,9 +305,6 @@ presubmits:
         - mountPath: /home/prow/go/pkg
           name: build-cache
           subPath: gomod
-        - mountPath: /home/.cargo
-          name: build-cache
-          subPath: cargo
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: test-pool

--- a/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -98,8 +98,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
@@ -170,8 +168,6 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        - name: CF_ACCOUNT_ID
-          value: 1eb8152ceed73d3ee6f66c3557819d4c
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
@@ -307,6 +303,8 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
         image: gcr.io/istio-testing/build-tools:master-63fd6eec6f3df5a3ed4e190e60153ef3425f66b4

--- a/prow/config/jobs/.base.yaml
+++ b/prow/config/jobs/.base.yaml
@@ -133,11 +133,13 @@ requirement_presets:
         project: istio-prow-build
         env: GH_TOKEN
   cf-r2-istio-build-auth:
-    env:
-      - name: CF_ACCOUNT_ID
-        value: "1eb8152ceed73d3ee6f66c3557819d4c"
     secrets:
       - secret: cf_r2_istio-build_credentials
+        project: istio-testing
+        env: CF_CREDENTIALS
+  cf-r2-istio-prow-auth:
+    secrets:
+      - secret: cf_r2_istio-prow_credentials
         project: istio-testing
         env: CF_CREDENTIALS
   # build-base has access to push to dockerhub and to push as istio-testing github. Only for use with base image building

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -26,11 +26,13 @@ jobs:
     modifiers: [presubmit_optional, presubmit_skipped]
     command: [entrypoint, make, benchtest]
     resources: dedicated
+    requirements: [cf-r2-istio-prow-auth]
 
   - name: benchmark-report
     types: [postsubmit]
     command: [entrypoint, make, benchtest, report-benchtest]
     resources: dedicated
+    requirements: [cf-r2-istio-prow-auth]
 
   - name: integ-cni
     types: [presubmit]

--- a/prow/config/jobs/istio.yaml
+++ b/prow/config/jobs/istio.yaml
@@ -26,7 +26,6 @@ jobs:
     modifiers: [presubmit_optional, presubmit_skipped]
     command: [entrypoint, make, benchtest]
     resources: dedicated
-    requirements: [cf-r2-istio-prow-auth]
 
   - name: benchmark-report
     types: [postsubmit]

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -12,7 +12,7 @@ jobs:
     command: [entrypoint, ./scripts/benchtest.sh]
     modifiers: [presubmit_optional, presubmit_skipped]
     types: [presubmit]
-    requirements: [cratescache]
+    requirements: [cratescache, cf-r2-istio-prow-auth]
 
   - name: coverage
     command: [entrypoint, make, coverage]

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -12,7 +12,7 @@ jobs:
     command: [entrypoint, ./scripts/benchtest.sh]
     modifiers: [presubmit_optional, presubmit_skipped]
     types: [presubmit]
-    requirements: [cratescache, cf-r2-istio-prow-auth]
+    requirements: [cratescache]
 
   - name: coverage
     command: [entrypoint, make, coverage]

--- a/prow/config/jobs/ztunnel.yaml
+++ b/prow/config/jobs/ztunnel.yaml
@@ -24,7 +24,7 @@ jobs:
     service_account_name: prowjob-testing-write
     types: [postsubmit]
     command: [entrypoint, make, release]
-    requirements: [cratescache, cf-r2-istio-build-auth]
+    requirements: [cratescache]
 
 resources_presets:
   # Rust jobs are CPU intensive. Bump up defaults (from 1/3) to 3/8 to speed up jobs.

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -298,6 +298,10 @@ func TestJobs(t *testing.T) {
 			return fmt.Errorf("jobs with secrets %v cannot be presubmits", secrets.UnsortedList())
 		}
 
+		if secrets.Len() == 1 && secrets.Has("istio-testing/cf_r2_istio-prow_credentials") {
+			// All pods already have access to this secret, as its needed to upload prowjob results to R2.
+			return nil
+		}
 		secretSA := SecretServiceAccounts.Has(j.ServiceAccount())
 		if !secretSA {
 			return fmt.Errorf("service account %v does not have Secrets access", j.ServiceAccount())


### PR DESCRIPTION
Didn't realize that our perf tests explicitly uploaded to prow. The jobs don't declare a KSA, which means that they use whatever the node pool has access to (?), which is the istio-prow-build SA:

https://github.com/istio/test-infra/blob/master/infra/gcp/istio-prow-build/cluster-prow.tf#L152-L176

One thing that's kinda annoying is that we expose the istio-prow cluster in two different ways. Once via a k8s secret/external secrets operator, and once via calling the gcloud api.