### PR TITLE
arm prow pool: drop spot to fix preemption-driven test flakes

### DIFF
--- a/infra/gcp/istio-prow-build/cluster-prow-arm.tf
+++ b/infra/gcp/istio-prow-build/cluster-prow-arm.tf
@@ -125,8 +125,6 @@ module "prow_arm_test_spot_preview" {
 
   arm          = true
   machine_type = "c4a-standard-16"
-  # Spot instances are used as quota is capped for ARM nodes, and its cheaper.
-  spot = true
 
   service_account = "istio-prow-jobs@istio-prow-build.iam.gserviceaccount.com"
 


### PR DESCRIPTION
The c4a arm test pool is spot-only, while the amd64 cluster has a non-spot backbone. Across recent master PRs, arm jobs failed ~21% of attempts vs ~1.5% on amd64, with ~37% of arm failures being mid-run SIGTERM (Entrypoint received interrupt, no preceding error, completion_time null) consistent with spot preemption. Removing spot=true so arm jobs land on on-demand c4a-standard-16 instances. Pool name kept as c4a-16-spot for now to avoid destroy+recreate; rename can follow once stable. Confirm c4a-standard-16 quota in us-central1-f is sufficient before merging.