### PR TITLE
prow: add optional IPv6 docs CI job for istio.io

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -87,7 +87,7 @@ postsubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv6
-        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        image: gcr.io/istio-testing/build-tools:master-1aae82591b3f663bba15d501ae7ce9c2d329aa70
         name: ""
         resources:
           limits:
@@ -105,9 +105,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -122,10 +119,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -648,7 +641,7 @@ presubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv6
-        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        image: gcr.io/istio-testing/build-tools:master-1aae82591b3f663bba15d501ae7ce9c2d329aa70
         name: ""
         resources:
           limits:
@@ -666,9 +659,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -683,10 +673,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.ipv6.profile-default,?($|\s.*))|((?m)^/test(

--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -67,6 +67,73 @@ postsubmits:
     - ^master$
     cluster: private
     decorate: true
+    name: doc.test.ipv6.profile-default_istio.io_postsubmit_pri
+    path_alias: istio.io/istio.io
+    run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile-default
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: GOMAXPROCS
+          value: "8"
+        - name: IP_FAMILIES
+          value: IPv6
+        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: doc.test.multicluster_istio.io_postsubmit_pri
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -552,6 +619,78 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.dualstack,?($|\s.*))|((?m)^/test( | .* )doc.test.dualstack_istio.io,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
+    name: doc.test.ipv6.profile-default_istio.io_pri
+    optional: true
+    path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.ipv6.profile-default
+    run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile-default
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: GOMAXPROCS
+          value: "8"
+        - name: IP_FAMILIES
+          value: IPv6
+        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.ipv6.profile-default,?($|\s.*))|((?m)^/test(
+      | .* )doc.test.ipv6.profile-default_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -211,7 +211,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        image: gcr.io/istio-testing/build-tools:master-1aae82591b3f663bba15d501ae7ce9c2d329aa70
         name: ""
         resources:
           limits:
@@ -229,9 +229,6 @@ postsubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -246,10 +243,6 @@ postsubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
   - annotations:
@@ -768,7 +761,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        image: gcr.io/istio-testing/build-tools:master-1aae82591b3f663bba15d501ae7ce9c2d329aa70
         name: ""
         resources:
           limits:
@@ -786,9 +779,6 @@ presubmits:
         - mountPath: /lib/modules
           name: modules
           readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-          readOnly: true
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
@@ -803,10 +793,6 @@ presubmits:
           path: /lib/modules
           type: Directory
         name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.ipv6.profile-default,?($|\s.*))|((?m)^/test(

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -192,6 +192,73 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: doc.test.ipv6.profile-default_istio.io_postsubmit
+    path_alias: istio.io/istio.io
+    run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile-default
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILIES
+          value: IPv6
+        - name: GOMAXPROCS
+          value: "8"
+        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio.io_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: doc.test.multicluster_istio.io_postsubmit
     path_alias: istio.io/istio.io
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
@@ -674,6 +741,76 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )doc.test.dualstack,?($|\s.*))|((?m)^/test( | .* )doc.test.dualstack_istio.io,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio.io
+    branches:
+    - ^master$
+    decorate: true
+    name: doc.test.ipv6.profile-default_istio.io
+    optional: true
+    path_alias: istio.io/istio.io
+    rerun_command: /test doc.test.ipv6.profile-default
+    run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - doc.test.profile-default
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILIES
+          value: IPv6
+        - name: GOMAXPROCS
+          value: "8"
+        image: gcr.io/istio-testing/build-tools:master-6de2ce5813071b34e0ca033dbac7f79ffc1644be
+        name: ""
+        resources:
+          limits:
+            cpu: "8"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )doc.test.ipv6.profile-default,?($|\s.*))|((?m)^/test(
+      | .* )doc.test.ipv6.profile-default_istio.io,?($|\s.*))
   - always_run: false
     annotations:
       testgrid-dashboards: istio_istio.io

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -60,7 +60,7 @@ jobs:
   - name: doc.test.ipv6.profile-default
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-default]
     requirements: [kind]
-    modifiers: [presubmit_optional, presubmit_skipped]
+    modifiers: [presubmit_optional]
     env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -57,6 +57,17 @@ jobs:
         value: "IPv4,IPv6"
     regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
 
+  - name: doc.test.ipv6.profile-default
+    command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-default]
+    requirements: [kind]
+    modifiers: [presubmit_optional, presubmit_skipped]
+    env:
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+        value: "true"
+      - name: IP_FAMILIES
+        value: "IPv6"
+    regex: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)
+
   - name: update-ref-docs-dry-run
     types: [presubmit]
     command:


### PR DESCRIPTION
Adds a new optional presubmit job `doc.test.ipv6.profile-default` that runs the standard `doc.test.profile-default` test suite against an IPv6-only kind cluster (`IP_FAMILIES=IPv6`).

The job is marked `presubmit_optional` + `presubmit_skipped` so it does not block PRs while we validate coverage. It can be triggered manually with:

  /test doc.test.ipv6.profile-default

Part of the IPv6 promote-to-Beta effort tracked in istio/istio#60425.