### PR TITLE
trust dependabot app in trigger plugin

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -8,6 +8,8 @@ triggers:
   - istio-ecosystem
   - istio-private
   trusted_org: istio
+  trusted_apps:
+  - dependabot
 
 config_updater:
   maps:


### PR DESCRIPTION
dependabot PRs currently sit with "needs-ok-to-test" since the app is not an org member. same setup kubernetes uses.