### PR TITLE
Give deck-private the necessary permissions to read prow bucket

### DIFF
--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -37,6 +37,9 @@ spec:
         - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
         - --cookie-secret=/etc/cookie/secret
+        # Deck only reads from blob storage (Spyglass, job/PR history). Private
+        # jobs upload to s3://istio-prow-private.
+        - --s3-credentials-file=/etc/cf-r2-istio-prow-private-credentials/service-account.json
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
@@ -59,6 +62,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/cf-r2-istio-prow-private-credentials
+          name: cf-r2-istio-prow-private-credentials
           readOnly: true
         livenessProbe:
           httpGet:
@@ -136,3 +142,6 @@ spec:
         configMap:
           defaultMode: 420
           name: kubeconfig
+      - name: cf-r2-istio-prow-private-credentials
+        secret:
+          secretName: cf-r2-istio-prow-private-credentials

--- a/prow/cluster/kubernetes_external_secrets.yaml
+++ b/prow/cluster/kubernetes_external_secrets.yaml
@@ -71,6 +71,20 @@ spec:
   - key: cf_r2_istio-prow_credentials # Secret name in GSM
     name: service-account.json
 ---
+# Mounted by deck-private so Spyglass can read the private artifact bucket
+# (s3://istio-prow-private).
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cf-r2-istio-prow-private-credentials
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: istio-testing
+  data:
+  - key: cf_r2_istio-prow-private_credentials # Secret name in GSM
+    name: service-account.json
+---
 # Read-only R2 credentials scoped to the public buckets.
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret


### PR DESCRIPTION
Passes s3 credentials file to deck private (which is behind oauth proxy) for it to get and display prow state
