### PR TITLE
AWS Infrastructure

### DIFF
--- a/infra/aws/istio/cluster_autoscaler.tf
+++ b/infra/aws/istio/cluster_autoscaler.tf
@@ -1,13 +1,3 @@
-# Cluster Autoscaler. One deployment per cluster; each one scales only the
-# managed node groups of its own cluster via ASG auto-discovery. EKS managed
-# node groups automatically tag their Auto Scaling Groups with
-# k8s.io/cluster-autoscaler/enabled and k8s.io/cluster-autoscaler/<cluster>, so
-# no extra tagging is required for discovery.
-#
-# Each controller's IAM role is delivered via EKS Pod Identity: the association
-# binds the role to the kube-system/cluster-autoscaler service account, scoped
-# to that cluster's ASGs only.
-
 locals {
   cluster_autoscaler_chart_version = "9.58.0"
   cluster_autoscaler_image_tag     = "v1.35.0"

--- a/infra/aws/istio/cluster_autoscaler.tf
+++ b/infra/aws/istio/cluster_autoscaler.tf
@@ -1,0 +1,143 @@
+# Cluster Autoscaler. One deployment per cluster; each one scales only the
+# managed node groups of its own cluster via ASG auto-discovery. EKS managed
+# node groups automatically tag their Auto Scaling Groups with
+# k8s.io/cluster-autoscaler/enabled and k8s.io/cluster-autoscaler/<cluster>, so
+# no extra tagging is required for discovery.
+#
+# Each controller's IAM role is delivered via EKS Pod Identity: the association
+# binds the role to the kube-system/cluster-autoscaler service account, scoped
+# to that cluster's ASGs only.
+
+locals {
+  cluster_autoscaler_chart_version = "9.58.0"
+  cluster_autoscaler_image_tag     = "v1.35.0"
+}
+
+module "cluster_autoscaler_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "~> 2.0"
+
+  for_each = local.clusters
+
+  name = "cluster-autoscaler-${each.key}"
+
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_names = [module.eks[each.key].cluster_name]
+
+  associations = {
+    this = {
+      cluster_name    = module.eks[each.key].cluster_name
+      namespace       = "kube-system"
+      service_account = "cluster-autoscaler"
+    }
+  }
+}
+
+resource "helm_release" "cluster_autoscaler_prow" {
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = local.cluster_autoscaler_chart_version
+  namespace  = "kube-system"
+
+  set {
+    name  = "autoDiscovery.clusterName"
+    value = module.eks["prow"].cluster_name
+  }
+
+  set {
+    name  = "awsRegion"
+    value = local.region
+  }
+
+  set {
+    name  = "image.tag"
+    value = local.cluster_autoscaler_image_tag
+  }
+
+  set {
+    name  = "rbac.serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "rbac.serviceAccount.name"
+    value = "cluster-autoscaler"
+  }
+
+  depends_on = [module.cluster_autoscaler_identity]
+}
+
+resource "helm_release" "cluster_autoscaler_prow_build" {
+  provider = helm.prow_build
+
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = local.cluster_autoscaler_chart_version
+  namespace  = "kube-system"
+
+  set {
+    name  = "autoDiscovery.clusterName"
+    value = module.eks["prow-build"].cluster_name
+  }
+
+  set {
+    name  = "awsRegion"
+    value = local.region
+  }
+
+  set {
+    name  = "image.tag"
+    value = local.cluster_autoscaler_image_tag
+  }
+
+  set {
+    name  = "rbac.serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "rbac.serviceAccount.name"
+    value = "cluster-autoscaler"
+  }
+
+  depends_on = [module.cluster_autoscaler_identity]
+}
+
+resource "helm_release" "cluster_autoscaler_prow_private" {
+  provider = helm.prow_private
+
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = local.cluster_autoscaler_chart_version
+  namespace  = "kube-system"
+
+  set {
+    name  = "autoDiscovery.clusterName"
+    value = module.eks["prow-private"].cluster_name
+  }
+
+  set {
+    name  = "awsRegion"
+    value = local.region
+  }
+
+  set {
+    name  = "image.tag"
+    value = local.cluster_autoscaler_image_tag
+  }
+
+  set {
+    name  = "rbac.serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "rbac.serviceAccount.name"
+    value = "cluster-autoscaler"
+  }
+
+  depends_on = [module.cluster_autoscaler_identity]
+}

--- a/infra/aws/istio/eks.tf
+++ b/infra/aws/istio/eks.tf
@@ -78,7 +78,6 @@ locals {
       }
     }
 
-    # Private / PSWG build cluster (GKE `prow` in istio-prow-private).
     prow-private = {
       node_groups = {
         # Test pool (e2-standard-16).

--- a/infra/aws/istio/eks.tf
+++ b/infra/aws/istio/eks.tf
@@ -1,0 +1,160 @@
+locals {
+  cluster_version = "1.36"
+
+  clusters = {
+    prow = {
+      node_groups = {
+        default = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["t3.medium"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 3
+          disk_size      = 20
+          labels         = { prod = "prow" }
+        }
+      }
+    }
+
+    # Core build cluster (for both amd and arm)
+    prow-build = {
+      node_groups = {
+        # Large build pool
+        build = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["m6i.4xlarge"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "build-pool" }
+        }
+        # Primary test pool
+        test-e2 = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["m6i.4xlarge"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "test-pool" }
+        }
+        # Newer Intel spot test pool
+        test-n4 = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["m6i.4xlarge"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "test-pool" }
+        }
+        # AMD
+        test-c4d = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["m6i.4xlarge"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "test-pool" }
+        }
+        # Graviton spot pool
+        arm = {
+          ami_type       = "AL2023_ARM_64_STANDARD"
+          instance_types = ["m7g.4xlarge"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "test-pool" }
+        }
+      }
+    }
+
+    # Private / PSWG build cluster (GKE `prow` in istio-prow-private).
+    prow-private = {
+      node_groups = {
+        # Test pool (e2-standard-16).
+        test = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["t3.small"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 1
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "test-pool" }
+        }
+        # High-memory build pool
+        build = {
+          ami_type       = "AL2023_x86_64_STANDARD"
+          instance_types = ["t3.small"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 0
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "build-pool" }
+        }
+        # Graviton spot pool
+        arm = {
+          ami_type       = "AL2023_ARM_64_STANDARD"
+          instance_types = ["t4g.small"]
+          capacity_type  = "ON_DEMAND"
+          min_size       = 0
+          max_size       = 5
+          desired_size   = 1
+          disk_size      = 20
+          labels         = { testing = "test-pool" }
+        }
+      }
+    }
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.0"
+
+  for_each = local.clusters
+
+  name               = each.key
+  kubernetes_version = local.cluster_version
+
+  vpc_id     = module.vpc[each.key].vpc_id
+  subnet_ids = module.vpc[each.key].private_subnets
+
+  # Auth via EKS access entries (API). This is the boundary mechanism that
+  # replaces GCP project isolation: each principal is granted RBAC only on the
+  # clusters it may use. The Terraform principal gets admin to bootstrap.
+  authentication_mode                      = "API"
+  enable_cluster_creator_admin_permissions = true
+
+  # Skeleton: public endpoint so the API is reachable while building out.
+  # Lock this down (private endpoint + CIDR allow-list) before production.
+  endpoint_public_access = true
+
+  addons = {
+    coredns = {}
+    # CNI and kube-proxy must be installed before the node groups so nodes can
+    # get pod networking and reach Ready; otherwise node group creation deadlocks
+    # waiting on nodes that can never join.
+    kube-proxy = {
+      before_compute = true
+    }
+    vpc-cni = {
+      before_compute = true
+    }
+    # Required for the workload IAM roles in iam.tf (EKS Pod Identity).
+    eks-pod-identity-agent = {}
+  }
+
+  eks_managed_node_groups = each.value.node_groups
+}

--- a/infra/aws/istio/eks.tf
+++ b/infra/aws/istio/eks.tf
@@ -42,7 +42,6 @@ locals {
           disk_size      = 20
           labels         = { testing = "test-pool" }
         }
-        # Newer Intel spot test pool
         test-n4 = {
           ami_type       = "AL2023_x86_64_STANDARD"
           instance_types = ["m6i.4xlarge"]
@@ -64,7 +63,6 @@ locals {
           disk_size      = 20
           labels         = { testing = "test-pool" }
         }
-        # Graviton spot pool
         arm = {
           ami_type       = "AL2023_ARM_64_STANDARD"
           instance_types = ["m7g.4xlarge"]
@@ -102,7 +100,6 @@ locals {
           disk_size      = 20
           labels         = { testing = "build-pool" }
         }
-        # Graviton spot pool
         arm = {
           ami_type       = "AL2023_ARM_64_STANDARD"
           instance_types = ["t4g.small"]

--- a/infra/aws/istio/external_secrets.tf
+++ b/infra/aws/istio/external_secrets.tf
@@ -1,0 +1,113 @@
+# External Secrets Operator (ESO). ESO syncs AWS Secrets Manager secrets into
+# native Kubernetes Secrets, driven by ExternalSecret resources in cluster/eks/.
+# It runs on every cluster that consumes secrets.
+#
+# Auth uses EKS Pod Identity: the controller's service account
+# (external-secrets/external-secrets) is bound to a per-cluster IAM role scoped
+# to exactly the secrets that cluster reads. A ClusterSecretStore with no auth
+# block (see cluster/eks/.../external_secrets_store.yaml) therefore resolves
+# against the controller pod's identity.
+
+locals {
+  # Secrets each cluster's ESO controller is allowed to read. Keys reference
+  # aws_secretsmanager_secret.secrets (secrets.tf).
+  eso_read_secrets = {
+    prow = [
+      "github_istio-testing_pusher",
+      "cf_r2_istio-prow_credentials",
+      "cf_r2_public_buckets_ro_credentials",
+      "oauth_token",
+      "hmac_token",
+      "cookie",
+      "github-oauth-config",
+      "github-oauth-config-private",
+      "slack_token",
+      "deck-oauth-proxy",
+      "istio-testing_robot-ssh-key",
+      "gcsweb_s3_credentials",
+    ]
+    prow-build = [
+      "cf_r2_istio-prow_credentials",
+    ]
+    prow-private = [
+      "cf_r2_istio-prow-private_credentials",
+    ]
+  }
+}
+
+module "external_secrets_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "~> 2.0"
+
+  for_each = local.eso_read_secrets
+
+  name = "external-secrets-${each.key}"
+
+  attach_custom_policy = true
+  policy_statements = [{
+    sid       = "ReadSecrets"
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    resources = [for s in each.value : aws_secretsmanager_secret.secrets[s].arn]
+  }]
+
+  associations = {
+    (each.key) = {
+      cluster_name    = module.eks[each.key].cluster_name
+      namespace       = "external-secrets"
+      service_account = "external-secrets"
+    }
+  }
+}
+
+resource "helm_release" "external_secrets_prow" {
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "2.6.0"
+  namespace        = "external-secrets"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  depends_on = [module.external_secrets_identity]
+}
+
+resource "helm_release" "external_secrets_prow_build" {
+  provider = helm.prow_build
+
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "2.6.0"
+  namespace        = "external-secrets"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  depends_on = [module.external_secrets_identity]
+}
+
+resource "helm_release" "external_secrets_prow_private" {
+  provider = helm.prow_private
+
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "2.6.0"
+  namespace        = "external-secrets"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  depends_on = [module.external_secrets_identity]
+}

--- a/infra/aws/istio/external_secrets.tf
+++ b/infra/aws/istio/external_secrets.tf
@@ -1,13 +1,3 @@
-# External Secrets Operator (ESO). ESO syncs AWS Secrets Manager secrets into
-# native Kubernetes Secrets, driven by ExternalSecret resources in cluster/eks/.
-# It runs on every cluster that consumes secrets.
-#
-# Auth uses EKS Pod Identity: the controller's service account
-# (external-secrets/external-secrets) is bound to a per-cluster IAM role scoped
-# to exactly the secrets that cluster reads. A ClusterSecretStore with no auth
-# block (see cluster/eks/.../external_secrets_store.yaml) therefore resolves
-# against the controller pod's identity.
-
 locals {
   # Secrets each cluster's ESO controller is allowed to read. Keys reference
   # aws_secretsmanager_secret.secrets (secrets.tf).

--- a/infra/aws/istio/iam.tf
+++ b/infra/aws/istio/iam.tf
@@ -1,0 +1,236 @@
+# iam.tf defines the IAM roles assumed by in-cluster workloads via EKS Pod
+# Identity. Each role mirrors a GCP service account / Workload Identity binding.
+#
+# Because object storage moved to Cloudflare R2 and registries to GHCR, most
+# workloads' cloud permissions reduce to "read (and sometimes write) specific
+# Secrets Manager secrets" (the R2 credentials / tokens). GCS/GCR/RBE grants
+# from the GCP config have no AWS equivalent and are intentionally dropped.
+#
+# The community eks-pod-identity module builds the role + Pod Identity trust
+# policy (pods.eks.amazonaws.com) and our scoped secrets policy. Pod Identity
+# *associations* (binding a role to a cluster + namespace + service account) are
+# wired in the identity-secrets phase; see the example at the bottom.
+
+locals {
+  # Object-storage buckets that workloads can be granted access to. `s3_read` /
+  # `s3_read_write` on a workload role reference these keys.
+  s3_buckets = {
+    "istio-prow"         = aws_s3_bucket.istio_prow.arn
+    "istio-prow-private" = aws_s3_bucket.istio_prow_private.arn
+  }
+
+  # Workloads that need an AWS IAM role. `read` / `write` reference secret keys
+  # in aws_secretsmanager_secret.secrets (see secrets.tf). `s3_read` /
+  # `s3_read_write` reference bucket keys in local.s3_buckets.
+  #
+  # Excluded by design:
+  #   - prowjob-rbe:             RBE is GCP-specific; no AWS equivalent.
+  #   - opentelemetry-collector: Cloud Trace -> X-Ray; different perm model.
+  #   - prow-deployer / prow-control-plane: cluster access is granted via EKS
+  #                              access entries, not IAM policies (EKS phase).
+  #   - istio-policy-bot / prowjob-bots-deployer: policy bot is a later phase.
+  workload_roles = {
+    # Highly privileged release job. Its cosign signing access (kms:Sign on the
+    # asymmetric key) is granted by the key's resource policy in kms.tf, not
+    # here, so no KMS statement is needed on this role.
+    "prowjob-release" = {
+      read = [
+        "release_docker_istio",
+        "release_github_istio-release",
+        "release_grafana_istio",
+        "github_istio-testing_pusher",
+        "cf_r2_istio-prerelease_credentials",
+        "cf_r2_istio-release_credentials",
+      ]
+      s3_read_write = ["istio-prow"]
+      associations = {
+        prow-build = { namespace = "test-pods", service_account = "prowjob-release" }
+      }
+    }
+
+    "prowjob-github-read" = {
+      read          = ["github-read_github_read"]
+      s3_read_write = ["istio-prow"]
+      associations  = { prow-build = { namespace = "test-pods", service_account = "prowjob-github-read" } }
+    }
+    "prowjob-github-istio-testing" = {
+      read          = ["github_istio-testing_pusher"]
+      s3_read_write = ["istio-prow"]
+      associations  = { prow-build = { namespace = "test-pods", service_account = "prowjob-github-istio-testing" } }
+    }
+    "prowjob-build-tools" = {
+      read          = ["github_istio-testing_pusher"]
+      s3_read_write = ["istio-prow"]
+      associations  = { prow-build = { namespace = "test-pods", service_account = "prowjob-build-tools" } }
+    }
+    # Runs on both the build cluster and the trusted control-plane cluster.
+    "prowjob-testing-write" = {
+      read          = ["cf_r2_istio-build_credentials"]
+      s3_read_write = ["istio-prow"]
+      associations = {
+        prow-build = { namespace = "test-pods", service_account = "prowjob-testing-write" }
+        prow       = { namespace = "test-pods", service_account = "prowjob-testing-write" }
+      }
+    }
+
+    # ESO (External Secrets Operator) controller identity is defined per cluster
+    # in external_secrets.tf, not here.
+
+    # Default Prow job service account.
+    "prowjob-default" = {
+      read = [
+        "cf_r2_istio-prow_credentials",
+        "cf_r2_public_buckets_ro_credentials",
+      ]
+      s3_read_write = ["istio-prow"]
+      associations  = { prow-build = { namespace = "test-pods", service_account = "prowjob-default-sa" } }
+    }
+
+    # Private Prow job service account. Uploads job artifacts to the private
+    # bucket via Pod Identity (pod-utils decoration).
+    "prowjob-private" = {
+      s3_read_write = ["istio-prow-private"]
+      associations  = { prow-private = { namespace = "test-pods", service_account = "prowjob-private" } }
+    }
+
+    # Prow control-plane components (trusted "prow" cluster, default namespace).
+    # These authenticate to S3 via Pod Identity rather than a credentials file.
+    "crier" = {
+      s3_read_write = ["istio-prow", "istio-prow-private"]
+      associations  = { prow = { namespace = "default", service_account = "crier" } }
+    }
+    "tide" = {
+      s3_read_write = ["istio-prow"]
+      associations  = { prow = { namespace = "default", service_account = "tide" } }
+    }
+    "deck" = {
+      s3_read      = ["istio-prow"]
+      associations = { prow = { namespace = "default", service_account = "deck" } }
+    }
+    "deck-private" = {
+      s3_read      = ["istio-prow-private"]
+      associations = { prow = { namespace = "default", service_account = "deck-private" } }
+    }
+
+    # Rotates ephemeral Cloudflare R2 credentials: reads the permanent admin
+    # token + all per-bucket creds, and writes new versions of the per-bucket
+    # creds. Runs as a CronJob in the trusted control-plane cluster.
+    "cloudflare-rotator" = {
+      read = [
+        "cf_r2_admin_token",
+        "cf_r2_istio-build_credentials",
+        "cf_r2_istio-build-private_credentials",
+        "cf_r2_istio-prerelease_credentials",
+        "cf_r2_istio-prerelease-private_credentials",
+        "cf_r2_istio-prow_credentials",
+        "cf_r2_istio-prow-private_credentials",
+        "cf_r2_istio-testgrid_credentials",
+      ]
+      write = [
+        "cf_r2_istio-build_credentials",
+        "cf_r2_istio-build-private_credentials",
+        "cf_r2_istio-prerelease_credentials",
+        "cf_r2_istio-prerelease-private_credentials",
+        "cf_r2_istio-prow_credentials",
+        "cf_r2_istio-prow-private_credentials",
+        "cf_r2_istio-testgrid_credentials",
+      ]
+      associations = { prow = { namespace = "cloudflare-secret-rotation", service_account = "cloudflare-rotator" } }
+    }
+  }
+}
+
+module "workload_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "~> 2.0"
+
+  for_each = local.workload_roles
+
+  name = each.key
+
+  attach_custom_policy = true
+  policy_statements = [
+    for s in [
+      length(try(each.value.read, [])) > 0 ? {
+        sid       = "ReadSecrets"
+        effect    = "Allow"
+        actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+        resources = [for x in each.value.read : aws_secretsmanager_secret.secrets[x].arn]
+      } : null,
+      length(try(each.value.write, [])) > 0 ? {
+        sid       = "WriteSecrets"
+        effect    = "Allow"
+        actions   = ["secretsmanager:PutSecretValue"]
+        resources = [for x in each.value.write : aws_secretsmanager_secret.secrets[x].arn]
+      } : null,
+      length(try(each.value.s3_read_write, [])) > 0 ? {
+        sid       = "S3ReadWriteObjects"
+        effect    = "Allow"
+        actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        resources = [for b in each.value.s3_read_write : "${local.s3_buckets[b]}/*"]
+      } : null,
+      length(try(each.value.s3_read_write, [])) > 0 ? {
+        sid       = "S3ReadWriteList"
+        effect    = "Allow"
+        actions   = ["s3:ListBucket"]
+        resources = [for b in each.value.s3_read_write : local.s3_buckets[b]]
+      } : null,
+      length(try(each.value.s3_read, [])) > 0 ? {
+        sid       = "S3ReadObjects"
+        effect    = "Allow"
+        actions   = ["s3:GetObject"]
+        resources = [for b in each.value.s3_read : "${local.s3_buckets[b]}/*"]
+      } : null,
+      length(try(each.value.s3_read, [])) > 0 ? {
+        sid       = "S3ReadList"
+        effect    = "Allow"
+        actions   = ["s3:ListBucket"]
+        resources = [for b in each.value.s3_read : local.s3_buckets[b]]
+      } : null,
+    ] : s if s != null
+  ]
+
+  # Pod Identity associations bind this role to a cluster + namespace + k8s
+  # service account. The map key references the EKS cluster (see eks.tf); the
+  # cluster_name comes from that module so associations wait for the cluster.
+  associations = {
+    for cluster, assoc in each.value.associations : cluster => {
+      cluster_name    = module.eks[cluster].cluster_name
+      namespace       = assoc.namespace
+      service_account = assoc.service_account
+    }
+  }
+}
+
+# gcsweb authenticates to S3 with a static access key rather than Pod Identity
+# because its embedded AWS SDK only accepts credentials from loopback metadata
+# endpoints. The key is delivered to the pod as the s3-credentials file (see
+# secrets.tf and external_secrets.yaml).
+resource "aws_iam_user" "gcsweb" {
+  name = "gcsweb"
+}
+
+data "aws_iam_policy_document" "gcsweb_s3_read" {
+  statement {
+    sid       = "S3ReadObjects"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.istio_prow.arn}/*"]
+  }
+  statement {
+    sid       = "S3ReadList"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.istio_prow.arn]
+  }
+}
+
+resource "aws_iam_user_policy" "gcsweb_s3_read" {
+  name   = "s3-read-istio-prow"
+  user   = aws_iam_user.gcsweb.name
+  policy = data.aws_iam_policy_document.gcsweb_s3_read.json
+}
+
+resource "aws_iam_access_key" "gcsweb" {
+  user = aws_iam_user.gcsweb.name
+}

--- a/infra/aws/istio/iam.tf
+++ b/infra/aws/istio/iam.tf
@@ -1,15 +1,5 @@
 # iam.tf defines the IAM roles assumed by in-cluster workloads via EKS Pod
 # Identity. Each role mirrors a GCP service account / Workload Identity binding.
-#
-# Because object storage moved to Cloudflare R2 and registries to GHCR, most
-# workloads' cloud permissions reduce to "read (and sometimes write) specific
-# Secrets Manager secrets" (the R2 credentials / tokens). GCS/GCR/RBE grants
-# from the GCP config have no AWS equivalent and are intentionally dropped.
-#
-# The community eks-pod-identity module builds the role + Pod Identity trust
-# policy (pods.eks.amazonaws.com) and our scoped secrets policy. Pod Identity
-# *associations* (binding a role to a cluster + namespace + service account) are
-# wired in the identity-secrets phase; see the example at the bottom.
 
 locals {
   # Object-storage buckets that workloads can be granted access to. `s3_read` /
@@ -19,16 +9,7 @@ locals {
     "istio-prow-private" = aws_s3_bucket.istio_prow_private.arn
   }
 
-  # Workloads that need an AWS IAM role. `read` / `write` reference secret keys
-  # in aws_secretsmanager_secret.secrets (see secrets.tf). `s3_read` /
-  # `s3_read_write` reference bucket keys in local.s3_buckets.
-  #
-  # Excluded by design:
-  #   - prowjob-rbe:             RBE is GCP-specific; no AWS equivalent.
-  #   - opentelemetry-collector: Cloud Trace -> X-Ray; different perm model.
-  #   - prow-deployer / prow-control-plane: cluster access is granted via EKS
-  #                              access entries, not IAM policies (EKS phase).
-  #   - istio-policy-bot / prowjob-bots-deployer: policy bot is a later phase.
+  # WI mappings and permissions
   workload_roles = {
     # Highly privileged release job. Its cosign signing access (kms:Sign on the
     # asymmetric key) is granted by the key's resource policy in kms.tf, not
@@ -87,14 +68,13 @@ locals {
     }
 
     # Private Prow job service account. Uploads job artifacts to the private
-    # bucket via Pod Identity (pod-utils decoration).
+    # bucket
     "prowjob-private" = {
       s3_read_write = ["istio-prow-private"]
       associations  = { prow-private = { namespace = "test-pods", service_account = "prowjob-private" } }
     }
 
     # Prow control-plane components (trusted "prow" cluster, default namespace).
-    # These authenticate to S3 via Pod Identity rather than a credentials file.
     "crier" = {
       s3_read_write = ["istio-prow", "istio-prow-private"]
       associations  = { prow = { namespace = "default", service_account = "crier" } }
@@ -190,9 +170,6 @@ module "workload_identity" {
     ] : s if s != null
   ]
 
-  # Pod Identity associations bind this role to a cluster + namespace + k8s
-  # service account. The map key references the EKS cluster (see eks.tf); the
-  # cluster_name comes from that module so associations wait for the cluster.
   associations = {
     for cluster, assoc in each.value.associations : cluster => {
       cluster_name    = module.eks[cluster].cluster_name

--- a/infra/aws/istio/kms.tf
+++ b/infra/aws/istio/kms.tf
@@ -1,13 +1,4 @@
-# Asymmetric signing key used by cosign to sign release artifacts. The release
-# Prow job references it through COSIGN_KEY=awskms:///alias/istio-cosign (see
-# prow/eks/config/jobs/.base.yaml).
-#
-# Access is scoped entirely through the key's resource policy: only the
-# prowjob-release workload role may sign with, or read the public half of, this
-# key. No other workload role is granted KMS permissions, so the effective
-# signer set is the release job alone. Granting via the key policy (rather than
-# the prowjob-release identity policy in iam.tf) keeps the dependency one-way:
-# the key policy reads the release role ARN, avoiding a cycle.
+# Asymmetric signing key used by cosign to sign release artifacts.
 
 data "aws_caller_identity" "current" {}
 

--- a/infra/aws/istio/kms.tf
+++ b/infra/aws/istio/kms.tf
@@ -1,0 +1,60 @@
+# Asymmetric signing key used by cosign to sign release artifacts. The release
+# Prow job references it through COSIGN_KEY=awskms:///alias/istio-cosign (see
+# prow/eks/config/jobs/.base.yaml).
+#
+# Access is scoped entirely through the key's resource policy: only the
+# prowjob-release workload role may sign with, or read the public half of, this
+# key. No other workload role is granted KMS permissions, so the effective
+# signer set is the release job alone. Granting via the key policy (rather than
+# the prowjob-release identity policy in iam.tf) keeps the dependency one-way:
+# the key policy reads the release role ARN, avoiding a cycle.
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "istio_cosign" {
+  description              = "Asymmetric signing key for cosign release signatures."
+  customer_master_key_spec = "ECC_NIST_P256"
+  key_usage                = "SIGN_VERIFY"
+  deletion_window_in_days  = 30
+
+  policy = data.aws_iam_policy_document.istio_cosign_key.json
+}
+
+resource "aws_kms_alias" "istio_cosign" {
+  name          = "alias/istio-cosign"
+  target_key_id = aws_kms_key.istio_cosign.key_id
+}
+
+data "aws_iam_policy_document" "istio_cosign_key" {
+  # Account root retains administrative control so the key stays manageable via
+  # IAM; this does not grant signing to any workload (no role has kms:Sign).
+  statement {
+    sid       = "EnableIAMAdmin"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  # Only the release job may sign with / read this key.
+  statement {
+    sid    = "ReleaseSign"
+    effect = "Allow"
+    actions = [
+      "kms:Sign",
+      "kms:Verify",
+      "kms:GetPublicKey",
+      "kms:DescribeKey",
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.workload_identity["prowjob-release"].iam_role_arn]
+    }
+  }
+}

--- a/infra/aws/istio/lb_controller.tf
+++ b/infra/aws/istio/lb_controller.tf
@@ -1,10 +1,6 @@
 # AWS Load Balancer Controller. It reconciles `ingressClassName: alb` Ingress
 # objects into ALBs (and Service type=LoadBalancer into NLBs). The chart runs on
 # the control-plane `prow` cluster, which serves the public ingress endpoints.
-#
-# The controller's IAM role is delivered via EKS Pod Identity: the association
-# binds the role to the kube-system/aws-load-balancer-controller service account,
-# so the chart's service account needs no role annotation.
 
 module "lb_controller_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"

--- a/infra/aws/istio/lb_controller.tf
+++ b/infra/aws/istio/lb_controller.tf
@@ -1,0 +1,59 @@
+# AWS Load Balancer Controller. It reconciles `ingressClassName: alb` Ingress
+# objects into ALBs (and Service type=LoadBalancer into NLBs). The chart runs on
+# the control-plane `prow` cluster, which serves the public ingress endpoints.
+#
+# The controller's IAM role is delivered via EKS Pod Identity: the association
+# binds the role to the kube-system/aws-load-balancer-controller service account,
+# so the chart's service account needs no role annotation.
+
+module "lb_controller_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "~> 2.0"
+
+  name = "aws-load-balancer-controller"
+
+  attach_aws_lb_controller_policy = true
+
+  associations = {
+    prow = {
+      cluster_name    = module.eks["prow"].cluster_name
+      namespace       = "kube-system"
+      service_account = "aws-load-balancer-controller"
+    }
+  }
+}
+
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "3.4.0"
+  namespace  = "kube-system"
+
+  set {
+    name  = "clusterName"
+    value = module.eks["prow"].cluster_name
+  }
+
+  set {
+    name  = "region"
+    value = local.region
+  }
+
+  set {
+    name  = "vpcId"
+    value = module.vpc["prow"].vpc_id
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  depends_on = [module.lb_controller_identity]
+}

--- a/infra/aws/istio/main.tf
+++ b/infra/aws/istio/main.tf
@@ -1,0 +1,3 @@
+locals {
+  region = "us-west-2"
+}

--- a/infra/aws/istio/providers.tf
+++ b/infra/aws/istio/providers.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "istio-terraform"
+    key          = "istio/terraform.tfstate"
+    region       = "us-west-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = local.region
+
+  default_tags {
+    tags = {
+      managed-by = "terraform"
+      owner      = "istio"
+    }
+  }
+}
+
+# Helm provider targets the control-plane (`prow`) cluster, where the ingress
+# objects (deck, hook, gcsweb) live. Auth uses `aws eks get-token` so no
+# long-lived credential is written to state.
+provider "helm" {
+  kubernetes {
+    host                   = module.eks["prow"].cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks["prow"].cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks["prow"].cluster_name, "--region", local.region]
+    }
+  }
+}
+
+provider "helm" {
+  alias = "prow_build"
+  kubernetes {
+    host                   = module.eks["prow-build"].cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks["prow-build"].cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks["prow-build"].cluster_name, "--region", local.region]
+    }
+  }
+}
+
+provider "helm" {
+  alias = "prow_private"
+  kubernetes {
+    host                   = module.eks["prow-private"].cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks["prow-private"].cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks["prow-private"].cluster_name, "--region", local.region]
+    }
+  }
+}

--- a/infra/aws/istio/prow_control_plane_access.tf
+++ b/infra/aws/istio/prow_control_plane_access.tf
@@ -1,0 +1,103 @@
+# Cross-cluster access for the Prow control plane.
+#
+# The control-plane components run on the `prow` cluster but talk to the build
+# clusters' API servers (via the aws-iam-authenticator exec plugin bundled in
+# the prow images; see prow/cluster/eks/build_kubeconfig.yaml) to schedule,
+# reap, and read job pods. Each component needs two things:
+#
+#   1. An IAM role with an EKS Pod Identity association on `prow`, so the pod
+#      carries an AWS identity that aws-iam-authenticator can present.
+#   2. An EKS access entry on every cluster it operates against, scoped to the
+#      `test-pods` namespace where job pods run.
+#
+# Writers (prow-controller-manager, sinker) create and delete pods -> Edit.
+# Readers (deck, deck-private, crier) only read pod logs/status -> View, reusing
+# the IAM roles they already have for S3 (see iam.tf).
+
+locals {
+  # Components that create and delete job pods on the build clusters. They get
+  # dedicated IAM roles with no AWS API permissions; the role exists solely as
+  # an identity for aws-iam-authenticator.
+  prow_writer_components = {
+    prow-controller-manager = { service_account = "prow-controller-manager" }
+    sinker                  = { service_account = "sinker" }
+  }
+
+  # Clusters whose API servers the control plane reaches as build clusters.
+  prow_build_clusters = ["prow", "prow-build", "prow-private"]
+
+  # Read-only components reuse their existing workload roles and only need to
+  # reach the clusters that actually run the pods they surface.
+  prow_reader_components = {
+    deck         = { clusters = ["prow-build", "prow"], role_arn = module.workload_identity["deck"].iam_role_arn }
+    deck-private = { clusters = ["prow-private"], role_arn = module.workload_identity["deck-private"].iam_role_arn }
+    crier        = { clusters = ["prow-build", "prow-private", "prow"], role_arn = module.workload_identity["crier"].iam_role_arn }
+  }
+
+  prow_writer_access = merge([
+    for name, cfg in local.prow_writer_components : {
+      for cluster in local.prow_build_clusters :
+      "${name}.${cluster}" => {
+        cluster   = cluster
+        principal = module.prow_control_plane_identity[name].iam_role_arn
+        policy    = "AmazonEKSEditPolicy"
+      }
+    }
+  ]...)
+
+  prow_reader_access = merge([
+    for name, cfg in local.prow_reader_components : {
+      for cluster in cfg.clusters :
+      "${name}.${cluster}" => {
+        cluster   = cluster
+        principal = cfg.role_arn
+        policy    = "AmazonEKSViewPolicy"
+      }
+    }
+  ]...)
+
+  prow_cluster_access = merge(local.prow_writer_access, local.prow_reader_access)
+}
+
+module "prow_control_plane_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "~> 2.0"
+
+  for_each = local.prow_writer_components
+
+  name = each.key
+
+  # No AWS API permissions: the role is only an identity for cross-cluster
+  # authentication, not for reaching any AWS service.
+  attach_custom_policy = false
+
+  associations = {
+    prow = {
+      cluster_name    = module.eks["prow"].cluster_name
+      namespace       = "default"
+      service_account = each.value.service_account
+    }
+  }
+}
+
+resource "aws_eks_access_entry" "prow_control_plane" {
+  for_each = local.prow_cluster_access
+
+  cluster_name  = module.eks[each.value.cluster].cluster_name
+  principal_arn = each.value.principal
+}
+
+resource "aws_eks_access_policy_association" "prow_control_plane" {
+  for_each = local.prow_cluster_access
+
+  cluster_name  = module.eks[each.value.cluster].cluster_name
+  principal_arn = each.value.principal
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/${each.value.policy}"
+
+  access_scope {
+    type       = "namespace"
+    namespaces = ["test-pods"]
+  }
+
+  depends_on = [aws_eks_access_entry.prow_control_plane]
+}

--- a/infra/aws/istio/prow_control_plane_access.tf
+++ b/infra/aws/istio/prow_control_plane_access.tf
@@ -5,14 +5,8 @@
 # the prow images; see prow/cluster/eks/build_kubeconfig.yaml) to schedule,
 # reap, and read job pods. Each component needs two things:
 #
-#   1. An IAM role with an EKS Pod Identity association on `prow`, so the pod
-#      carries an AWS identity that aws-iam-authenticator can present.
-#   2. An EKS access entry on every cluster it operates against, scoped to the
-#      `test-pods` namespace where job pods run.
-#
 # Writers (prow-controller-manager, sinker) create and delete pods -> Edit.
 # Readers (deck, deck-private, crier) only read pod logs/status -> View, reusing
-# the IAM roles they already have for S3 (see iam.tf).
 
 locals {
   # Components that create and delete job pods on the build clusters. They get

--- a/infra/aws/istio/s3.tf
+++ b/infra/aws/istio/s3.tf
@@ -1,0 +1,58 @@
+# S3 bucket for Prow test artifacts and results (the istio-prow bucket).
+#
+# This bucket is intentionally public-read: test logs and artifacts are served
+# to anonymous users (the same access model as the public GCS istio-prow
+# bucket). Only anonymous GET on objects is allowed; writes remain restricted
+# to authorized IAM principals.
+
+resource "aws_s3_bucket" "istio_prow" {
+  bucket = "istio-prow"
+}
+
+resource "aws_s3_bucket_public_access_block" "istio_prow" {
+  bucket = aws_s3_bucket.istio_prow.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = false
+  restrict_public_buckets = false
+}
+
+data "aws_iam_policy_document" "istio_prow_public_read" {
+  statement {
+    sid     = "PublicReadGetObject"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = ["${aws_s3_bucket.istio_prow.arn}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "istio_prow" {
+  bucket = aws_s3_bucket.istio_prow.id
+  policy = data.aws_iam_policy_document.istio_prow_public_read.json
+
+  depends_on = [aws_s3_bucket_public_access_block.istio_prow]
+}
+
+# Private equivalent of istio-prow for the private build cluster (mirrors the
+# private GCS istio-prow-private bucket). Access is restricted to authorized
+# IAM principals; no public access.
+
+resource "aws_s3_bucket" "istio_prow_private" {
+  bucket = "istio-prow-private"
+}
+
+resource "aws_s3_bucket_public_access_block" "istio_prow_private" {
+  bucket = aws_s3_bucket.istio_prow_private.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/infra/aws/istio/secrets.tf
+++ b/infra/aws/istio/secrets.tf
@@ -1,0 +1,86 @@
+locals {
+  # release_secrets contains secrets for the release prowjob.
+  all_secrets = {
+    # Access token for "istio" dockerhub account.
+    "release_docker_istio" = "DockerHub access token for the \"istio\" account"
+
+    # Fine grained PAT in the Istio org, "github/istio-release/release".
+    # Has write access to "Contents" and "Workflows". Expires 7/29/2026.
+    "release_github_istio-release" = "Fine-grained GitHub PAT for releases (Contents+Workflows write); expires 2026-07-29"
+
+    # Access token for Grafana for the "Istio" org. Named
+    # "release-pipeline-token" in Grafana, with role "Editor".
+    "release_grafana_istio" = "Grafana token for the Istio org (Editor role)"
+
+    # Fine grained PAT in the Istio org, "github/release-notes/public-read-only".
+    # Has public access only. Expires on 5/19/2027.
+    "github-read_github_read" = "Fine-grained GitHub PAT, public read-only; expires 2027-05-19"
+
+    # Classic PAT for user "istio-testing", token name
+    # "github/istio-testing/pusher". Has scopes `repo,read:user`. No expiration.
+    "github_istio-testing_pusher" = "Classic GitHub PAT for istio-testing (repo,read:user); no expiration"
+
+    # Permanent Cloudflare admin token; used to mint the ephemeral R2 creds.
+    "cf_r2_admin_token" = "Permanent Cloudflare admin token (mints ephemeral R2 credentials)"
+
+    # Generic read-only R2 credentials for the public buckets.
+    "cf_r2_public_buckets_ro_credentials" = "Read-only R2 credentials for public buckets"
+
+    # GitHub OAuth token for Prow jobs (JSON: {oauth}).
+    "oauth_token" = "GitHub OAuth token for Prow jobs"
+
+    # HMAC token used by hook to validate GitHub webhook payloads.
+    "hmac_token" = "HMAC token for validating GitHub webhooks"
+
+    # Cookie secret used by deck/deck-private to sign session cookies.
+    "cookie" = "Cookie secret for signing Prow deck session cookies"
+
+    # GitHub OAuth app config for the public deck login flow.
+    "github-oauth-config" = "GitHub OAuth app config for deck login"
+
+    # GitHub OAuth app config for the private deck login flow.
+    "github-oauth-config-private" = "GitHub OAuth app config for deck-private login"
+
+    # Slack token used by crier/hook for Slack notifications.
+    "slack_token" = "Slack token for Prow notifications"
+
+    # OAuth2-proxy client credentials guarding deck-private.
+    "deck-oauth-proxy" = "OAuth2-proxy client credentials for deck-private"
+
+    # SSH key material for the istio-testing robot (JSON: {id_rsa, id_rsa.pub, known_hosts}).
+    "istio-testing_robot-ssh-key" = "SSH key for the istio-testing robot"
+
+    # Bucket specific R2 credentials
+    "cf_r2_istio-release_credentials"            = "Ephemeral Cloudflare R2 credentials for the istio-release bucket"
+    "cf_r2_istio-build_credentials"              = "Ephemeral Cloudflare R2 credentials for the istio-build bucket"
+    "cf_r2_istio-build-private_credentials"      = "Ephemeral Cloudflare R2 credentials for the istio-build-private bucket"
+    "cf_r2_istio-prerelease_credentials"         = "Ephemeral Cloudflare R2 credentials for the istio-prerelease bucket"
+    "cf_r2_istio-prerelease-private_credentials" = "Ephemeral Cloudflare R2 credentials for the istio-prerelease-private bucket"
+    "cf_r2_istio-prow_credentials"               = "Ephemeral Cloudflare R2 credentials for the istio-prow bucket"
+    "cf_r2_istio-prow-private_credentials"       = "Ephemeral Cloudflare R2 credentials for the istio-prow-private bucket"
+    "cf_r2_istio-testgrid_credentials"           = "Ephemeral Cloudflare R2 credentials for the istio-testgrid bucket"
+
+    # Read-only S3 credentials for gcsweb (public buckets). The value is managed
+    # by Terraform (aws_secretsmanager_secret_version.gcsweb_s3_credentials).
+    "gcsweb_s3_credentials" = "Read-only S3 credentials for gcsweb (public buckets)"
+  }
+}
+
+resource "aws_secretsmanager_secret" "secrets" {
+  for_each    = local.all_secrets
+  name        = each.key
+  description = each.value
+}
+
+# Read-only S3 credentials for gcsweb, in the format expected by the prow
+# storage provider's s3-credentials file. The access key is minted in iam.tf
+# and synced into the cluster via external_secrets.yaml.
+resource "aws_secretsmanager_secret_version" "gcsweb_s3_credentials" {
+  secret_id = aws_secretsmanager_secret.secrets["gcsweb_s3_credentials"].id
+  secret_string = jsonencode({
+    region              = "us-west-2"
+    s3_force_path_style = false
+    access_key          = aws_iam_access_key.gcsweb.id
+    secret_key          = aws_iam_access_key.gcsweb.secret
+  })
+}

--- a/infra/aws/istio/vpc.tf
+++ b/infra/aws/istio/vpc.tf
@@ -1,13 +1,6 @@
-# vpc.tf provisions one VPC per cluster. In GCP each cluster lived in its own
-# project/network; in a single AWS account the VPC is the network isolation
-# boundary, so each cluster gets a dedicated, non-overlapping VPC.
-
 locals {
-  # Three AZs in the region (matches GCP us-west1 multi-zone layout).
   azs = ["us-west-2a", "us-west-2b", "us-west-2c"]
 
-  # Non-overlapping CIDRs so the networks can be peered/routed later without
-  # collisions (e.g. control plane -> build scheduling path).
   vpcs = {
     prow         = { cidr = "10.0.0.0/16" } # control plane / trusted
     prow-build   = { cidr = "10.1.0.0/16" } # core build (x86 + ARM)
@@ -28,7 +21,7 @@ module "vpc" {
   private_subnets = [for i in range(length(local.azs)) : cidrsubnet(each.value.cidr, 4, i)]
   public_subnets  = [for i in range(length(local.azs)) : cidrsubnet(each.value.cidr, 4, i + 8)]
 
-  # Skeleton: a single NAT gateway keeps cost down. Revisit for HA later.
+  # a single NAT gateway keeps cost down. Revisit for HA later.
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true

--- a/infra/aws/istio/vpc.tf
+++ b/infra/aws/istio/vpc.tf
@@ -1,0 +1,39 @@
+# vpc.tf provisions one VPC per cluster. In GCP each cluster lived in its own
+# project/network; in a single AWS account the VPC is the network isolation
+# boundary, so each cluster gets a dedicated, non-overlapping VPC.
+
+locals {
+  # Three AZs in the region (matches GCP us-west1 multi-zone layout).
+  azs = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  # Non-overlapping CIDRs so the networks can be peered/routed later without
+  # collisions (e.g. control plane -> build scheduling path).
+  vpcs = {
+    prow         = { cidr = "10.0.0.0/16" } # control plane / trusted
+    prow-build   = { cidr = "10.1.0.0/16" } # core build (x86 + ARM)
+    prow-private = { cidr = "10.2.0.0/16" } # private / PSWG build
+  }
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
+
+  for_each = local.vpcs
+
+  name = "${each.key}-vpc"
+  cidr = each.value.cidr
+  azs  = local.azs
+
+  private_subnets = [for i in range(length(local.azs)) : cidrsubnet(each.value.cidr, 4, i)]
+  public_subnets  = [for i in range(length(local.azs)) : cidrsubnet(each.value.cidr, 4, i + 8)]
+
+  # Skeleton: a single NAT gateway keeps cost down. Revisit for HA later.
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Subnet tags so EKS can discover where to place load balancers.
+  private_subnet_tags = { "kubernetes.io/role/internal-elb" = "1" }
+  public_subnet_tags  = { "kubernetes.io/role/elb" = "1" }
+}


### PR DESCRIPTION
The migration order will be:

* create the infrastructure (terrafrom resources)
* create prow resources
* move master jobs/new release jobs to aws
* move bots over (this will be super annoying)

This just does the raw infrastructure resources. A few maybe controversial points

* we are managing helm charts in helm
* we are using community-maintained `terraform-aws-modules`
* we are create a prow s3 bucket, but not using it (just in case we need it in the future)
* We are not (yet) creating a certificate 