### PR TITLE
Make IPv6 docs test job mandatory

### DIFF
--- a/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -620,7 +620,6 @@ presubmits:
     cluster: private
     decorate: true
     name: doc.test.ipv6.profile-default_istio.io_pri
-    optional: true
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.ipv6.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -741,7 +741,6 @@ presubmits:
     - ^master$
     decorate: true
     name: doc.test.ipv6.profile-default_istio.io
-    optional: true
     path_alias: istio.io/istio.io
     rerun_command: /test doc.test.ipv6.profile-default
     run_if_changed: ^(go.mod$|tests/|pkg/test/|prow/|content/en/boilerplates/snips/|content/en/docs/.*(test\.sh|/snips\.sh)$)

--- a/prow/config/jobs/istio.io.yaml
+++ b/prow/config/jobs/istio.io.yaml
@@ -60,7 +60,6 @@ jobs:
   - name: doc.test.ipv6.profile-default
     command: [entrypoint, prow/integ-suite-kind.sh, doc.test.profile-default]
     requirements: [kind]
-    modifiers: [presubmit_optional]
     env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"


### PR DESCRIPTION
Move the `doc.test.ipv6.profile-default` job from optional to mandatory in CI/CD pipeline. All tests are passing and the job is stable.

Related to: https://github.com/istio/istio/issues/60425