### PR TITLE
Update Dockerfiles to Go 1.24 to match the Go version from go.mod

### DIFF
--- a/tools/prowgen/Dockerfile
+++ b/tools/prowgen/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 as build-env
+FROM golang:1.24 AS build-env
 
 WORKDIR /go/src/istio
 

--- a/tools/prowtrans/Dockerfile
+++ b/tools/prowtrans/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 as build-env
+FROM golang:1.24 AS build-env
 
 WORKDIR /go/src/istio
 


### PR DESCRIPTION
Due to this version mismatch [push-prowgen](https://prow.istio.io/view/s3/istio-prow/logs/push-prowgen_test-infra_postsubmit/2081738606245842944) job has failed.