### PR TITLE
Add TestPilotResourceFilter to integ-gateway-api-only job

### DIFF
--- a/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -1105,7 +1105,7 @@ postsubmits:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt
         - name: T
-          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
+          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: DEPENDENCIES
           valueFrom:
             configMapKeyRef:
@@ -5123,7 +5123,7 @@ presubmits:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt
         - name: T
-          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
+          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: DEPENDENCIES
           valueFrom:
             configMapKeyRef:

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -1263,7 +1263,7 @@ postsubmits:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt
         - name: T
-          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
+          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: GOMAXPROCS
           value: "5"
         image: gcr.io/istio-testing/build-tools:master-6db0b4c7fbe345bd531a07fbcff13877dc9cd801
@@ -4279,7 +4279,7 @@ presubmits:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt
         - name: T
-          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
+          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: GOMAXPROCS
           value: "5"
         image: gcr.io/istio-testing/build-tools:master-6db0b4c7fbe345bd531a07fbcff13877dc9cd801

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -1178,7 +1178,7 @@ presubmits:
         - name: INTEGRATION_TEST_FLAGS
           value: --istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt
         - name: T
-          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
+          value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: GOMAXPROCS
           value: "5"
         image: gcr.io/istio-testing/build-tools:master-6db0b4c7fbe345bd531a07fbcff13877dc9cd801

--- a/prow/gcp/config/jobs/istio.yaml
+++ b/prow/gcp/config/jobs/istio.yaml
@@ -338,7 +338,7 @@ jobs:
     - name: INTEGRATION_TEST_FLAGS
       value: "--istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt"
     - name: T
-      value: '-run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"'
+      value: '-run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"'
     command:
     - entrypoint
     - prow/integ-suite-kind.sh


### PR DESCRIPTION
## Summary
- Adds `TestPilotResourceFilter` to the `-run` regex of the `integ-gateway-api-only` prow job.
- `TestPilotResourceFilter` (in `tests/integration/pilot/resourcefilter`) is the most on-point test for gateway-API-only mode: its `TestMain` installs istiod with `PILOT_IGNORE_RESOURCES="*.istio.io"` and `PILOT_INCLUDE_RESOURCES="wasmplugins.extensions.istio.io"`, then verifies that Gateway API + WasmPlugin resources are reconciled while other Istio CRDs (EnvoyFilter, BackendTLSPolicy) are ignored — exactly the resource-filtering behavior this job exercises.
- The test is already GatewayClass-aware (reads `i.GatewayClassName`), so it works under the job's `--istio.test.kube.gatewayClassName=istio-alt`. The job's `--istio.test.gatewayAPIOnly` flag sets the same `PILOT_IGNORE_RESOURCES=*.istio.io` the suite already sets itself, so it's an idempotent no-op overlay — no conflict.

## Test plan
- [ ] Regenerated job configs via prowgen/prowtrans; only the `-run` regex changed across the canonical, experimental, and istio-private gen outputs.
- [ ] `/test integ-gateway-api-only` on an istio/istio PR after merge to confirm the added test runs green.