### PR TITLE
Aws bazel build cache

### DIFF
--- a/infra/aws/istio/iam.tf
+++ b/infra/aws/istio/iam.tf
@@ -2,11 +2,12 @@
 # Identity. Each role mirrors a GCP service account / Workload Identity binding.
 
 locals {
-  # Object-storage buckets that workloads can be granted access to. `s3_read` /
-  # `s3_read_write` on a workload role reference these keys.
+  # Object-storage buckets that workloads can be granted access to. `s3_read`,
+  # `s3_read` and `s3_read_write` on a workload role reference these keys.
   s3_buckets = {
-    "istio-prow"         = aws_s3_bucket.istio_prow.arn
-    "istio-prow-private" = aws_s3_bucket.istio_prow_private.arn
+    "istio-prow"             = aws_s3_bucket.istio_prow.arn
+    "istio-prow-bazel-cache" = aws_s3_bucket.istio_prow_bazel_cache.arn
+    "istio-prow-private"     = aws_s3_bucket.istio_prow_private.arn
   }
 
   # WI mappings and permissions
@@ -44,6 +45,10 @@ locals {
       read          = ["github_istio-testing_pusher"]
       s3_read_write = ["istio-prow"]
       associations  = { prow-build = { namespace = "test-pods", service_account = "prowjob-build-tools" } }
+    }
+    "prowjob-bazel-cache" = {
+      s3_read_write = ["istio-prow-bazel-cache"]
+      associations  = { prow-build = { namespace = "bazel-remote", service_account = "prowjob-bazel-cache" } }
     }
     # Runs on both the build cluster and the trusted control-plane cluster.
     "prowjob-testing-write" = {

--- a/infra/aws/istio/iam.tf
+++ b/infra/aws/istio/iam.tf
@@ -2,8 +2,8 @@
 # Identity. Each role mirrors a GCP service account / Workload Identity binding.
 
 locals {
-  # Object-storage buckets that workloads can be granted access to. `s3_read`,
-  # `s3_read` and `s3_read_write` on a workload role reference these keys.
+  # Object-storage buckets that workloads can be granted access to. `s3_read` /
+  # `s3_read_write` on a workload role reference these keys.
   s3_buckets = {
     "istio-prow"             = aws_s3_bucket.istio_prow.arn
     "istio-prow-bazel-cache" = aws_s3_bucket.istio_prow_bazel_cache.arn

--- a/infra/aws/istio/s3.tf
+++ b/infra/aws/istio/s3.tf
@@ -56,3 +56,41 @@ resource "aws_s3_bucket_public_access_block" "istio_prow_private" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Private, durable backend for the Bazel remote cache. The cache service keeps
+# a bounded local working set; S3 lifecycle expiry bounds durable retention.
+resource "aws_s3_bucket" "istio_prow_bazel_cache" {
+  bucket = "istio-prow-bazel-cache"
+}
+
+resource "aws_s3_bucket_public_access_block" "istio_prow_bazel_cache" {
+  bucket = aws_s3_bucket.istio_prow_bazel_cache.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "istio_prow_bazel_cache" {
+  bucket = aws_s3_bucket.istio_prow_bazel_cache.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "istio_prow_bazel_cache" {
+  bucket = aws_s3_bucket.istio_prow_bazel_cache.id
+
+  rule {
+    id     = "expire-cache-entries"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+  }
+}

--- a/prow/aws/cluster/build/bazel_remote.yaml
+++ b/prow/aws/cluster/build/bazel_remote.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bazel-remote
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prowjob-bazel-cache
+  namespace: bazel-remote
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazel-remote
+  namespace: bazel-remote
+  labels:
+    app: bazel-remote
+spec:
+  selector:
+    app: bazel-remote
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bazel-remote
+  namespace: bazel-remote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bazel-remote
+  template:
+    metadata:
+      labels:
+        app: bazel-remote
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        testing: build-pool
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+      serviceAccountName: prowjob-bazel-cache
+      containers:
+      - name: bazel-remote
+        image: buchgr/bazel-remote-cache:v2.6.2
+        args:
+        - --dir=/data
+        - --http_address=0.0.0.0:8080
+        - --grpc_address=0.0.0.0:9092
+        - --max_size=16
+        - --s3.auth_method=iam_role
+        - --s3.bucket=istio-prow-bazel-cache
+        - --s3.endpoint=s3.us-west-2.amazonaws.com
+        - --s3.prefix=proxy
+        - --s3.region=us-west-2
+        ports:
+        - name: grpc
+          containerPort: 9092
+          protocol: TCP
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          grpc:
+            service: /grpc.health.v1.Health/Check
+            port: grpc
+          failureThreshold: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 10
+        livenessProbe:
+          grpc:
+            service: /grpc.health.v1.Health/Check
+            port: grpc
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "2"
+            ephemeral-storage: 32Gi
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            ephemeral-storage: 32Gi
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: cache
+          mountPath: /data
+      volumes:
+      - name: cache
+        emptyDir:
+          sizeLimit: 32Gi

--- a/prow/aws/cluster/build/bazel_remote.yaml
+++ b/prow/aws/cluster/build/bazel_remote.yaml
@@ -40,8 +40,7 @@ spec:
         app: bazel-remote
     spec:
       automountServiceAccountToken: false
-      nodeSelector:
-        testing: build-pool
+      enableServiceLinks: false
       securityContext:
         fsGroup: 65532
         runAsGroup: 65532
@@ -50,7 +49,7 @@ spec:
       serviceAccountName: prowjob-bazel-cache
       containers:
       - name: bazel-remote
-        image: buchgr/bazel-remote-cache:v2.6.2
+        image: gcr.io/istio-testing/bazel-remote-cache:v2.6.2
         args:
         - --dir=/data
         - --http_address=0.0.0.0:8080
@@ -71,7 +70,7 @@ spec:
         readinessProbe:
           grpc:
             service: /grpc.health.v1.Health/Check
-            port: grpc
+            port: 9092
           failureThreshold: 3
           periodSeconds: 3
           successThreshold: 1
@@ -79,7 +78,7 @@ spec:
         livenessProbe:
           grpc:
             service: /grpc.health.v1.Health/Check
-            port: grpc
+            port: 9092
           failureThreshold: 3
           initialDelaySeconds: 3
           periodSeconds: 1

--- a/prow/aws/cluster/build/prowjob_service_accounts.yaml
+++ b/prow/aws/cluster/build/prowjob_service_accounts.yaml
@@ -33,17 +33,6 @@ metadata:
   annotations:
     kubernetes.io/enforce-mountable-secrets: "true"
   namespace: test-pods
-  # Service account that has permissions for RBE access. For use by istio/proxy, currently.
-  name: prowjob-rbe
-secrets:
-- name: cf-r2-istio-prow-credentials
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    kubernetes.io/enforce-mountable-secrets: "true"
-  namespace: test-pods
   # Service account that has permissions for GitHub read-only (public) access. For use by release-notes jobs, currently.
   name: prowjob-github-read
 secrets:

--- a/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -20,6 +20,8 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
@@ -85,6 +87,8 @@ postsubmits:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -153,6 +157,8 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
@@ -214,6 +220,8 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-release.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -275,6 +283,8 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -334,6 +344,8 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-asan.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -393,6 +405,8 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.31.gen.yaml
@@ -20,6 +20,8 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
@@ -85,6 +87,8 @@ postsubmits:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -153,6 +157,8 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
@@ -214,6 +220,8 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-release.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -275,6 +283,8 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -334,6 +344,8 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-asan.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
@@ -393,6 +405,8 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"

--- a/prow/aws/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -135,7 +135,6 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -150,6 +149,9 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
         - name: BUILD_WITH_CONTAINER
@@ -204,6 +206,9 @@ postsubmits:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GCP_SECRETS
@@ -308,7 +313,6 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -323,6 +327,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
         - name: BUILD_WITH_CONTAINER
@@ -342,7 +349,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -371,6 +378,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-release.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -393,7 +403,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -405,7 +415,6 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^master$
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -420,6 +429,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
@@ -437,7 +449,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -466,6 +478,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-asan.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -488,7 +503,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -512,6 +527,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -534,7 +552,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/aws/cluster/jobs/istio/proxy/istio.proxy.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/proxy/istio.proxy.release-1.31.gen.yaml
@@ -72,7 +72,6 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^release-1.31$
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -87,6 +86,9 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
         - name: BUILD_WITH_CONTAINER
@@ -141,6 +143,9 @@ postsubmits:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GCP_SECRETS
@@ -245,7 +250,6 @@ presubmits:
       testgrid-dashboards: istio_release-1.31_proxy
     branches:
     - ^release-1.31$
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -260,6 +264,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
         - name: BUILD_WITH_CONTAINER
@@ -279,7 +286,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -308,6 +315,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-release.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -330,7 +340,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -342,7 +352,6 @@ presubmits:
       testgrid-dashboards: istio_release-1.31_proxy
     branches:
     - ^release-1.31$
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -357,6 +366,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
@@ -374,7 +386,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -403,6 +415,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-asan.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -425,7 +440,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -449,6 +464,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -471,7 +489,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/aws/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -7,7 +7,6 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^experimental-.*
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -22,6 +21,9 @@ postsubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
         - name: BUILD_WITH_CONTAINER
@@ -76,6 +78,9 @@ postsubmits:
         - entrypoint
         - ./prow/proxy-postsubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GCP_SECRETS
@@ -117,7 +122,6 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^experimental-.*
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -132,6 +136,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_ENVOY_BINARY_ONLY
           value: "1"
         - name: BUILD_WITH_CONTAINER
@@ -151,7 +158,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -180,6 +187,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-release.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -202,7 +212,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -214,7 +224,6 @@ presubmits:
       testgrid-dashboards: istio_proxy
     branches:
     - ^experimental-.*
-    cluster: prow-arm
     decorate: true
     decoration_config:
       timeout: 6h0m0s
@@ -229,6 +238,9 @@ presubmits:
         env:
         - name: ARCH_SUFFIX
           value: arm64
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
@@ -246,7 +258,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: arm64
         testing: test-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       tolerations:
       - effect: NoSchedule
         key: kubernetes.io/arch
@@ -275,6 +287,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit-asan.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -297,7 +312,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache
@@ -321,6 +336,9 @@ presubmits:
       - command:
         - ./prow/proxy-presubmit.sh
         env:
+        - name: BAZEL_BUILD_RBE_CACHE
+          value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+        - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
         - name: GOMAXPROCS
@@ -343,7 +361,7 @@ presubmits:
       nodeSelector:
         kubernetes.io/arch: amd64
         testing: build-pool
-      serviceAccountName: prowjob-rbe
+      serviceAccountName: prowjob-default-sa
       volumes:
       - hostPath:
           path: /var/tmp/prow/cache

--- a/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -69,7 +69,6 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^master$
-    cluster: prow-arm
     decorate: true
     name: release-arm64_ztunnel_postsubmit
     path_alias: istio.io/ztunnel

--- a/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.31.gen.yaml
@@ -69,7 +69,6 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     branches:
     - ^release-1.31$
-    cluster: prow-arm
     decorate: true
     name: release-arm64_ztunnel_release-1.31_postsubmit
     path_alias: istio.io/ztunnel

--- a/prow/aws/config/jobs/.base.yaml
+++ b/prow/aws/config/jobs/.base.yaml
@@ -8,9 +8,6 @@ node_selector:
 
 auto_max_procs: true
 
-cluster_overrides:
-  arm64: prow-arm
-
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"

--- a/prow/aws/config/jobs/proxy-1.31.yaml
+++ b/prow/aws/config/jobs/proxy-1.31.yaml
@@ -224,15 +224,11 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-<<<<<<< HEAD
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
-=======
   - name: BAZEL_BUILD_RBE_INSTANCE
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
->>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test-asan
   node_selector:
     testing: build-pool
@@ -446,15 +442,11 @@ jobs:
     value: "0"
   - name: ARCH_SUFFIX
     value: $(params.arch)
-<<<<<<< HEAD
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
-=======
   - name: BAZEL_BUILD_RBE_INSTANCE
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
->>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test-arm
   node_selector:
     testing: test-pool
@@ -665,15 +657,11 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-<<<<<<< HEAD
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
-=======
   - name: BAZEL_BUILD_RBE_INSTANCE
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
->>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release-test
   node_selector:
     testing: build-pool
@@ -889,15 +877,11 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-<<<<<<< HEAD
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
-=======
   - name: BAZEL_BUILD_RBE_INSTANCE
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
->>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release-test
   node_selector:
     testing: test-pool
@@ -1109,15 +1093,11 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-<<<<<<< HEAD
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
-=======
   - name: BAZEL_BUILD_RBE_INSTANCE
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
->>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:
     testing: build-pool
@@ -1336,15 +1316,11 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-<<<<<<< HEAD
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
-=======
   - name: BAZEL_BUILD_RBE_INSTANCE
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
->>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:
     testing: test-pool

--- a/prow/aws/config/jobs/proxy-1.31.yaml
+++ b/prow/aws/config/jobs/proxy-1.31.yaml
@@ -10,6 +10,10 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test
   node_selector:
@@ -211,7 +215,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   timeout: 4h0m0s
   types:
   - presubmit
@@ -220,7 +224,15 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
+<<<<<<< HEAD
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
+=======
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+>>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
   name: test-asan
   node_selector:
     testing: build-pool
@@ -421,7 +433,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   timeout: 4h0m0s
   types:
   - presubmit
@@ -434,7 +446,15 @@ jobs:
     value: "0"
   - name: ARCH_SUFFIX
     value: $(params.arch)
+<<<<<<< HEAD
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
+=======
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+>>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
   name: test-arm
   node_selector:
     testing: test-pool
@@ -636,7 +656,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   timeout: 6h0m0s
   types:
   - presubmit
@@ -645,7 +665,15 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
+<<<<<<< HEAD
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
+=======
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+>>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
   name: release-test
   node_selector:
     testing: build-pool
@@ -846,7 +874,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   timeout: 6h0m0s
   types:
   - presubmit
@@ -861,7 +889,15 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
+<<<<<<< HEAD
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
+=======
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+>>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
   name: release-test
   node_selector:
     testing: test-pool
@@ -1063,7 +1099,7 @@ jobs:
       requests:
         cpu: "30"
         memory: 100G
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   timeout: 6h0m0s
   types:
   - presubmit
@@ -1073,7 +1109,15 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
+<<<<<<< HEAD
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
+=======
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+>>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
   name: release
   node_selector:
     testing: build-pool
@@ -1292,7 +1336,15 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
+<<<<<<< HEAD
   image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
+=======
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+>>>>>>> cbe062f1d (Don't use arm cluster and create build-cache)
   name: release
   node_selector:
     testing: test-pool

--- a/prow/aws/config/jobs/proxy.yaml
+++ b/prow/aws/config/jobs/proxy.yaml
@@ -7,23 +7,37 @@ node_selector:
 
 jobs:
 - name: test
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 4h
+  env:
+    - name: BAZEL_BUILD_RBE_INSTANCE
+      value: ""
+    - name: BAZEL_BUILD_RBE_CACHE
+      value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
 
 - name: test-asan
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-asan.sh]
   timeout: 4h
+  env:
+    - name: BAZEL_BUILD_RBE_INSTANCE
+      value: ""
+    - name: BAZEL_BUILD_RBE_CACHE
+      value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
 
 - name: test-arm
   architectures: [arm64]
   env:
   - name: ARCH_SUFFIX
     value: $(params.arch)
-  service_account_name: prowjob-rbe
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  service_account_name: prowjob-default-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit.sh]
   timeout: 6h
@@ -33,10 +47,15 @@ jobs:
     testing: test-pool
 
 - name: release-test
-  service_account_name: prowjob-rbe
+  service_account_name: prowjob-default-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
   timeout: 6h
+  env:
+    - name: BAZEL_BUILD_RBE_INSTANCE
+      value: ""
+    - name: BAZEL_BUILD_RBE_CACHE
+      value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
 
 - name: release-test
   architectures: [arm64]
@@ -45,7 +64,11 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
-  service_account_name: prowjob-rbe
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
+  service_account_name: prowjob-default-sa
   types: [presubmit]
   command: [./prow/proxy-presubmit-release.sh]
   timeout: 6h
@@ -60,6 +83,11 @@ jobs:
   command: [entrypoint, ./prow/proxy-postsubmit.sh]
   requirements: [docker, cf-r2-istio-build-auth]
   timeout: 6h
+  env:
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
 - name: release
   architectures: [arm64]
   env:
@@ -67,6 +95,10 @@ jobs:
     value: $(params.arch)
   - name: BUILD_ENVOY_BINARY_ONLY
     value: "1"
+  - name: BAZEL_BUILD_RBE_INSTANCE
+    value: ""
+  - name: BAZEL_BUILD_RBE_CACHE
+    value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
   service_account_name: prowjob-testing-write
   types: [postsubmit]
   command: [entrypoint, ./prow/proxy-postsubmit.sh]


### PR DESCRIPTION
This creates a new bucket/deployment/service where we will hold build artifacts for bazel builds so they dont take 2 hours for every CI run.