### PR TITLE
Pass UPDATE_BRANCH to make update-common in automator jobs

### DIFF
--- a/prow/aws/config/jobs/common-files-1.31.yaml
+++ b/prow/aws/config/jobs/common-files-1.31.yaml
@@ -218,7 +218,7 @@ jobs:
   - --strict
   - --modifier=commonfiles
   - --token-env
-  - --cmd=make update-common && make gen
+  - --cmd=make update-common UPDATE_BRANCH=${AUTOMATOR_SRC_BRANCH} && make gen
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
@@ -436,7 +436,7 @@ jobs:
   - --strict
   - --modifier=commonfiles
   - --token-env
-  - --cmd=make update-common && make gen
+  - --cmd=make update-common UPDATE_BRANCH=${AUTOMATOR_SRC_BRANCH} && make gen
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"

--- a/prow/aws/config/jobs/common-files.yaml
+++ b/prow/aws/config/jobs/common-files.yaml
@@ -19,7 +19,7 @@ jobs:
     - --strict
     - --modifier=commonfiles
     - --token-env
-    - --cmd=make update-common && make gen
+    - --cmd=make update-common UPDATE_BRANCH=${AUTOMATOR_SRC_BRANCH} && make gen
     requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
@@ -39,7 +39,7 @@ jobs:
     - --strict
     - --modifier=commonfiles
     - --token-env
-    - --cmd=make update-common && make gen
+    - --cmd=make update-common UPDATE_BRANCH=${AUTOMATOR_SRC_BRANCH} && make gen
     requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:
@@ -58,7 +58,7 @@ jobs:
     - --strict
     - --modifier=commonfiles
     - --token-env
-    - --cmd=make update-common && make gen
+    - --cmd=make update-common UPDATE_BRANCH=${AUTOMATOR_SRC_BRANCH} && make gen
     requirements: [github-istio-testing]
     repos: [istio/test-infra@master]
     env:


### PR DESCRIPTION
When the automator propagates common-files changes to downstream repos, `make update-common` uses UPDATE_BRANCH from the downstream repo's existing Makefile.common.mk. After a release branch cut, downstream repos still have `UPDATE_BRANCH ?= "master"`, so any propagation that runs before step 5 (istio/common-files#1294) clones common-files@master instead of the release branch, overwriting release-specific IMAGE_VERSION with the master one.

This was observed during the 1.31 release: the automator image update (istio/common-files#1291) merged on the release branch before step 5, triggering propagation to downstream repos whose Makefile still defaulted to master. This caused repos like istio/istio to receive PRs reverting IMAGE_VERSION from release-1.31 back to master (e.g. istio/istio@abc7551). For 1.30 this issue didn't occur, because the first automated PR (istio/common-files#1273) to release-1.30 branch was closed.

Fix by passing `UPDATE_BRANCH=${AUTOMATOR_SRC_BRANCH}` as a make command-line override, so the correct common-files branch is always cloned regardless of the downstream repo's current Makefile default.