### PR TITLE
Set Some nodeselectors Arch

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -4,6 +4,8 @@ presubmits:
   decorate: true
   run_if_changed: '^(\.prow|prow/gcp/(config|plugins|cluster/jobs/.*))\.yaml$'
   spec:
+    nodeSelector:
+      kubernetes.io/arch: amd64
     containers:
     - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260714-0633879af
       command:

--- a/prow/aws/cluster/build/bazel_remote.yaml
+++ b/prow/aws/cluster/build/bazel_remote.yaml
@@ -41,6 +41,8 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
+      nodeSelector:
+        kubernetes.io/arch: amd64
       securityContext:
         fsGroup: 65532
         runAsGroup: 65532


### PR DESCRIPTION
So our bazel remote cache container doesn't get scheduled onto an ARM node.
