### PR TITLE
update release-1.31 build tools image

### DIFF
--- a/prow/aws/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.31.gen.yaml
@@ -27,7 +27,7 @@ postsubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv4,IPv6
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv6
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -257,7 +257,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -369,7 +369,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -427,7 +427,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -481,7 +481,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -524,7 +524,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -577,7 +577,7 @@ presubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv4,IPv6
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -640,7 +640,7 @@ presubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv6
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -702,7 +702,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -762,7 +762,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -822,7 +822,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -882,7 +882,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -942,7 +942,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1004,7 +1004,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1062,7 +1062,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1108,7 +1108,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.31.gen.yaml
@@ -29,7 +29,7 @@ postsubmits:
           value: "0"
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           requests:
@@ -96,7 +96,7 @@ postsubmits:
           value: istio-build-private
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           requests:
@@ -227,7 +227,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           requests:
@@ -351,7 +351,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -412,7 +412,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/api/istio.api.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/api/istio.api.release-1.31.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -170,7 +170,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -214,7 +214,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -263,7 +263,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/client-go/istio.client-go.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/client-go/istio.client-go.release-1.31.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -107,7 +107,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -259,7 +259,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -303,7 +303,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/common-files/istio.common-files.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/common-files/istio.common-files.release-1.31.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -253,7 +253,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/enhancements/istio.enhancements.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/enhancements/istio.enhancements.release-1.31.gen.yaml
@@ -32,7 +32,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/istio.io/istio.istio.io.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/istio.io/istio.istio.io.release-1.31.gen.yaml
@@ -27,7 +27,7 @@ postsubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -257,7 +257,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -369,7 +369,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -427,7 +427,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -481,7 +481,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -524,7 +524,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -575,7 +575,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -636,7 +636,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -696,7 +696,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -754,7 +754,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -812,7 +812,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -870,7 +870,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -928,7 +928,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -988,7 +988,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1044,7 +1044,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1088,7 +1088,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1144,7 +1144,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/proxy/istio.proxy.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/proxy/istio.proxy.release-1.31.gen.yaml
@@ -40,7 +40,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "64"
-      image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+      image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
       name: ""
       resources:
         limits:
@@ -95,7 +95,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           requests:
@@ -152,7 +152,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -219,7 +219,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -271,7 +271,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           requests:
@@ -322,7 +322,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -371,7 +371,7 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           requests:
@@ -422,7 +422,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -471,7 +471,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.31.gen.yaml
@@ -37,7 +37,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -171,7 +171,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ postsubmits:
           value: /var/run/rustc-cache
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -370,7 +370,7 @@ presubmits:
           value: /var/run/rustc-cache
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/aws/config/jobs/api-1.31.yaml
+++ b/prow/aws/config/jobs/api-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: build
   node_selector:
     testing: test-pool
@@ -214,7 +214,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: gencheck
   node_selector:
     testing: test-pool
@@ -426,7 +426,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: update-api-dep-client-go
   node_selector:
     testing: test-pool
@@ -636,7 +636,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: release-notes

--- a/prow/aws/config/jobs/client-go-1.31.yaml
+++ b/prow/aws/config/jobs/client-go-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: build
   node_selector:
     testing: test-pool
@@ -214,7 +214,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: lint
   node_selector:
     testing: test-pool
@@ -417,7 +417,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: gencheck
   node_selector:
     testing: test-pool
@@ -631,7 +631,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: update-client-go-dep
   node_selector:
     testing: test-pool

--- a/prow/aws/config/jobs/common-files-1.31.yaml
+++ b/prow/aws/config/jobs/common-files-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: lint
   node_selector:
     testing: test-pool
@@ -224,7 +224,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: update-common
   node_selector:
     testing: test-pool
@@ -442,7 +442,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: update-common-istio.io
   node_selector:
     testing: test-pool
@@ -664,7 +664,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: update-build-tools-image
   node_selector:
     testing: test-pool

--- a/prow/aws/config/jobs/enhancements-1.31.yaml
+++ b/prow/aws/config/jobs/enhancements-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - ../test-infra/scripts/validate_schema.sh
@@ -12,7 +12,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: validate-features

--- a/prow/aws/config/jobs/istio.io-1.31.yaml
+++ b/prow/aws/config/jobs/istio.io-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: lint
   node_selector:
     testing: test-pool
@@ -228,7 +228,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: gencheck
   node_selector:
     testing: test-pool
@@ -446,7 +446,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.profile-default
   node_selector:
     testing: test-pool
@@ -667,7 +667,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.profile-demo
   node_selector:
     testing: test-pool
@@ -887,7 +887,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.profile-none
   node_selector:
     testing: test-pool
@@ -1108,7 +1108,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.profile-minimal
   node_selector:
     testing: test-pool
@@ -1328,7 +1328,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.profile-ambient
   node_selector:
     testing: test-pool
@@ -1550,7 +1550,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.multicluster
   node_selector:
     testing: test-pool
@@ -1774,7 +1774,7 @@ jobs:
     value: "true"
   - name: IP_FAMILIES
     value: IPv4,IPv6
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.dualstack
   node_selector:
     testing: test-pool
@@ -1998,7 +1998,7 @@ jobs:
     value: "true"
   - name: IP_FAMILIES
     value: IPv6
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: doc.test.ipv6.profile-default
   node_selector:
     testing: test-pool
@@ -2223,7 +2223,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: update-ref-docs-dry-run

--- a/prow/aws/config/jobs/proxy-1.31.yaml
+++ b/prow/aws/config/jobs/proxy-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - ./prow/proxy-presubmit.sh
@@ -14,7 +14,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test
   node_selector:
     testing: build-pool
@@ -228,7 +228,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test-asan
   node_selector:
     testing: build-pool
@@ -446,7 +446,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test-arm
   node_selector:
     testing: test-pool
@@ -661,7 +661,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release-test
   node_selector:
     testing: build-pool
@@ -881,7 +881,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release-test
   node_selector:
     testing: test-pool
@@ -1097,7 +1097,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:
     testing: build-pool
@@ -1320,7 +1320,7 @@ jobs:
     value: ""
   - name: BAZEL_BUILD_RBE_CACHE
     value: http://bazel-remote.bazel-remote.svc.cluster.local:8080
-  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools-proxy:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:
     testing: test-pool
@@ -1544,7 +1544,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: update-istio
   node_selector:
     testing: build-pool
@@ -1766,7 +1766,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   interval: 24h
   name: update-proxy
   node_selector:

--- a/prow/aws/config/jobs/ztunnel-1.31.yaml
+++ b/prow/aws/config/jobs/ztunnel-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - entrypoint
@@ -13,7 +13,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test
   node_selector:
     testing: test-pool
@@ -218,7 +218,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -428,7 +428,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: coverage
   node_selector:
     testing: test-pool
@@ -638,7 +638,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:
     testing: test-pool

--- a/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.release-1.31.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -203,7 +203,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -289,7 +289,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -375,7 +375,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -457,7 +457,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -540,7 +540,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -622,7 +622,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -704,7 +704,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -782,7 +782,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -871,7 +871,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -951,7 +951,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1033,7 +1033,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1115,7 +1115,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1193,7 +1193,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1275,7 +1275,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1361,7 +1361,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1445,7 +1445,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1529,7 +1529,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1613,7 +1613,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1699,7 +1699,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1785,7 +1785,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1871,7 +1871,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1957,7 +1957,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2043,7 +2043,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2129,7 +2129,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2215,7 +2215,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2301,7 +2301,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2381,7 +2381,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2463,7 +2463,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2547,7 +2547,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2631,7 +2631,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2711,7 +2711,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2789,7 +2789,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2873,7 +2873,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2953,7 +2953,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3031,7 +3031,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3111,7 +3111,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3195,7 +3195,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3275,7 +3275,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3353,7 +3353,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3434,7 +3434,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3507,7 +3507,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3580,7 +3580,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3649,7 +3649,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3715,7 +3715,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: release-1.31-istio-deps
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3792,7 +3792,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3869,7 +3869,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: release-1.31-istio-deps
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3935,7 +3935,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: release-1.31-istio-deps
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4008,7 +4008,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4096,7 +4096,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4186,7 +4186,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4275,7 +4275,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4364,7 +4364,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4450,7 +4450,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4538,7 +4538,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4624,7 +4624,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4710,7 +4710,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4791,7 +4791,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4879,7 +4879,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4962,7 +4962,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5047,7 +5047,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5133,7 +5133,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5215,7 +5215,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5300,7 +5300,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5386,7 +5386,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5474,7 +5474,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5562,7 +5562,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5646,7 +5646,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5728,7 +5728,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5815,7 +5815,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5899,7 +5899,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5981,7 +5981,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6064,7 +6064,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6152,7 +6152,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6236,7 +6236,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6317,7 +6317,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6391,7 +6391,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: release-1.31-istio-deps
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6457,7 +6457,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: release-1.31-istio-deps
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6524,7 +6524,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6599,7 +6599,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6675,7 +6675,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -6741,7 +6741,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: release-1.31-istio-deps
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.31.gen.yaml
@@ -39,7 +39,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prerelease-private_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"},{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -153,7 +153,7 @@ postsubmits:
           value: "3"
         - name: VERSION
           value: "1.31"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -275,7 +275,7 @@ presubmits:
           value: istio-prerelease-private/prerelease
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prerelease-private_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -321,7 +321,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -380,7 +380,7 @@ presubmits:
           value: "3"
         - name: VERSION
           value: "1.31"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istio.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istio.release-1.31.gen.yaml
@@ -23,7 +23,7 @@ periodics:
         value: "0"
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+      image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
       name: ""
       resources:
         limits:
@@ -73,7 +73,7 @@ periodics:
         value: "0"
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+      image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
       name: ""
       resources:
         limits:
@@ -148,7 +148,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+      image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
       name: ""
       resources:
         limits:
@@ -199,7 +199,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -258,7 +258,7 @@ postsubmits:
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -312,7 +312,7 @@ postsubmits:
           value: --istio.test.agentgateway
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ postsubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -442,7 +442,7 @@ postsubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -508,7 +508,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -574,7 +574,7 @@ postsubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -636,7 +636,7 @@ postsubmits:
           value: '--istio.test.ambient --istio.test.nativeNftables '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -699,7 +699,7 @@ postsubmits:
             --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -761,7 +761,7 @@ postsubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -823,7 +823,7 @@ postsubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -882,7 +882,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -951,7 +951,7 @@ postsubmits:
           value: -flaky
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1011,7 +1011,7 @@ postsubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1073,7 +1073,7 @@ postsubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1135,7 +1135,7 @@ postsubmits:
           value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1193,7 +1193,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1255,7 +1255,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1321,7 +1321,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1385,7 +1385,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1449,7 +1449,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1513,7 +1513,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1579,7 +1579,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1645,7 +1645,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1711,7 +1711,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1777,7 +1777,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1843,7 +1843,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1909,7 +1909,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -1975,7 +1975,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2041,7 +2041,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2101,7 +2101,7 @@ postsubmits:
           value: grpctesting/istio_echo_cpp
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2163,7 +2163,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2227,7 +2227,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2291,7 +2291,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2351,7 +2351,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2409,7 +2409,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2473,7 +2473,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2533,7 +2533,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2591,7 +2591,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2651,7 +2651,7 @@ postsubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2715,7 +2715,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2775,7 +2775,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2833,7 +2833,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2890,7 +2890,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2944,7 +2944,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -2997,7 +2997,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3044,7 +3044,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3092,7 +3092,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3153,7 +3153,7 @@ presubmits:
           value: "true"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3212,7 +3212,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3260,7 +3260,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3311,7 +3311,7 @@ presubmits:
           value: --istio.test.agentgateway
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3377,7 +3377,7 @@ presubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3445,7 +3445,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3512,7 +3512,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3579,7 +3579,7 @@ presubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3643,7 +3643,7 @@ presubmits:
           value: '--istio.test.ambient --istio.test.nativeNftables '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3709,7 +3709,7 @@ presubmits:
             --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3773,7 +3773,7 @@ presubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3837,7 +3837,7 @@ presubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3897,7 +3897,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -3963,7 +3963,7 @@ presubmits:
           value: ' --istio.test.istio.enableCNI=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4024,7 +4024,7 @@ presubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4087,7 +4087,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4151,7 +4151,7 @@ presubmits:
           value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4211,7 +4211,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4274,7 +4274,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4338,7 +4338,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4404,7 +4404,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4470,7 +4470,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4532,7 +4532,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4592,7 +4592,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4657,7 +4657,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4719,7 +4719,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4779,7 +4779,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4840,7 +4840,7 @@ presubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4906,7 +4906,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -4968,7 +4968,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5027,7 +5027,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5083,7 +5083,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5131,7 +5131,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5182,7 +5182,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5228,7 +5228,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5282,7 +5282,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5336,7 +5336,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -5384,7 +5384,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/release-builder/istio.release-builder.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/release-builder/istio.release-builder.release-1.31.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "8"
-      image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+      image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
       name: ""
       resources:
         limits:
@@ -80,7 +80,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prerelease_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -217,7 +217,7 @@ postsubmits:
           value: "1.31"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -270,7 +270,7 @@ postsubmits:
           value: /var/run/ci/github/token
         - name: GCP_SECRETS
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"},{"secret":"cf_r2_istio-prerelease_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"},{"secret":"cf_r2_istio-release_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -317,7 +317,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -366,7 +366,7 @@ presubmits:
           value: '[{"secret":"cf_r2_public_buckets_ro_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -409,7 +409,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -456,7 +456,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -502,7 +502,7 @@ presubmits:
           value: "1.31"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -550,7 +550,7 @@ presubmits:
           value: '[{"secret":"cf_r2_public_buckets_ro_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -594,7 +594,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/tools/istio.tools.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/tools/istio.tools.release-1.31.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -68,7 +68,7 @@ postsubmits:
         - name: MANIFEST_ARCH
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -144,7 +144,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -192,7 +192,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -235,7 +235,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -370,7 +370,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -426,7 +426,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:
@@ -562,7 +562,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+        image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
         name: ""
         resources:
           limits:

--- a/prow/gcp/config/jobs/istio-1.31.yaml
+++ b/prow/gcp/config/jobs/istio-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - architectures:
   - amd64
@@ -19,7 +19,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: unit-tests
   node_selector:
     testing: test-pool
@@ -243,7 +243,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release-test
   node_selector:
     testing: test-pool
@@ -470,7 +470,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:
     testing: test-pool
@@ -700,7 +700,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -931,7 +931,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: benchmark-report
   node_selector:
     testing: test-pool
@@ -1161,7 +1161,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -1388,7 +1388,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-telemetry
   node_selector:
     testing: test-pool
@@ -1615,7 +1615,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.peer_metadata_discovery
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-telemetry-discovery
   node_selector:
     testing: test-pool
@@ -1842,7 +1842,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-telemetry-mc
   node_selector:
     testing: test-pool
@@ -2074,7 +2074,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-telemetry-istiodremote
   node_selector:
     testing: test-pool
@@ -2306,7 +2306,7 @@ jobs:
     value: --istio.test.ambient
   - name: KUBERNETES_CNI
     value: calico
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -2536,7 +2536,7 @@ jobs:
     value: "0"
   - name: VARIANT
     value: distroless
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-distroless
   node_selector:
     testing: test-pool
@@ -2763,7 +2763,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -2999,7 +2999,7 @@ jobs:
     value: "true"
   - name: IP_FAMILIES
     value: IPv6
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-ipv6
   node_selector:
     testing: test-pool
@@ -3228,7 +3228,7 @@ jobs:
     value: "true"
   - name: IP_FAMILIES
     value: IPv4,IPv6
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-ds
   node_selector:
     testing: test-pool
@@ -3455,7 +3455,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-basic
   node_selector:
     testing: test-pool
@@ -3680,7 +3680,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-pilot
   node_selector:
     testing: test-pool
@@ -3907,7 +3907,7 @@ jobs:
     value: "0"
   - name: GRPC_ECHO_IMAGE
     value: grpctesting/istio_echo_cpp
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-pilot-cpp
   node_selector:
     testing: test-pool
@@ -4136,7 +4136,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-pilot-multicluster
   node_selector:
     testing: test-pool
@@ -4366,7 +4366,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: integ-pilot-filebasedkubeconfig
@@ -4600,7 +4600,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-pilot-istiodremote
   node_selector:
     testing: test-pool
@@ -4832,7 +4832,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-pilot-istiodremote-mc
   node_selector:
     testing: test-pool
@@ -5060,7 +5060,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.agentgateway
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: integ-agentgateway
@@ -5287,7 +5287,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-security
   node_selector:
     testing: test-pool
@@ -5513,7 +5513,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-security-fuzz
   node_selector:
     testing: test-pool
@@ -5742,7 +5742,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-security-multicluster
   node_selector:
     testing: test-pool
@@ -5974,7 +5974,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.skipVM
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-security-istiodremote
   node_selector:
     testing: test-pool
@@ -6204,7 +6204,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.ambient
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-ambient
   node_selector:
     testing: test-pool
@@ -6433,7 +6433,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: '--istio.test.ambient --istio.test.nativeNftables '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: integ-ambient-nftables
@@ -6665,7 +6665,7 @@ jobs:
   - name: INTEGRATION_TEST_FLAGS
     value: '--istio.test.kube.helm.values=cni.istioOwnedCNIConfig=true --istio.test.ambient.istioOwnedCNIConfig
       --istio.test.ambient '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: integ-ambient-owned-cni
@@ -6900,7 +6900,7 @@ jobs:
     value: "true"
   - name: IP_FAMILIES
     value: IPv6
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-ambient-ipv6
   node_selector:
     testing: test-pool
@@ -7133,7 +7133,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: --istio.test.ambient --istio.test.ambient.multinetwork
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-ambient-mc
   node_selector:
     testing: test-pool
@@ -7366,7 +7366,7 @@ jobs:
     value: "true"
   - name: IP_FAMILIES
     value: IPv4,IPv6
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-ambient-dual
   node_selector:
     testing: test-pool
@@ -7595,7 +7595,7 @@ jobs:
     value: --istio.test.gatewayAPIOnly --istio.test.kube.gatewayClassName=istio-alt
   - name: T
     value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: integ-gateway-api-only
@@ -7822,7 +7822,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-helm
   node_selector:
     testing: test-pool
@@ -8053,7 +8053,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-123
   node_selector:
     testing: test-pool
@@ -8285,7 +8285,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-124
   node_selector:
     testing: test-pool
@@ -8517,7 +8517,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-125
   node_selector:
     testing: test-pool
@@ -8749,7 +8749,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-126
   node_selector:
     testing: test-pool
@@ -8983,7 +8983,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-127
   node_selector:
     testing: test-pool
@@ -9217,7 +9217,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-128
   node_selector:
     testing: test-pool
@@ -9451,7 +9451,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-129
   node_selector:
     testing: test-pool
@@ -9685,7 +9685,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-130
   node_selector:
     testing: test-pool
@@ -9919,7 +9919,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-131
   node_selector:
     testing: test-pool
@@ -10153,7 +10153,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-132
   node_selector:
     testing: test-pool
@@ -10387,7 +10387,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-133
   node_selector:
     testing: test-pool
@@ -10621,7 +10621,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-k8s-134
   node_selector:
     testing: test-pool
@@ -10853,7 +10853,7 @@ jobs:
     value: -flaky
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.retries=1 --istio.test.istio.enableCNI=true '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: integ-cni
   node_selector:
     testing: test-pool
@@ -11083,7 +11083,7 @@ jobs:
     value: "0"
   - name: INTEGRATION_TEST_FLAGS
     value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -11311,7 +11311,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: lint
   node_selector:
     testing: test-pool
@@ -11538,7 +11538,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   - presubmit_skipped
@@ -11767,7 +11767,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: gencheck
   node_selector:
     testing: test-pool
@@ -11994,7 +11994,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release-notes
   node_selector:
     testing: test-pool
@@ -12224,7 +12224,7 @@ jobs:
     value: master
   - name: ALWAYS_GENERATE_BASE_IMAGE
     value: "true"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: build-base-images
   node_selector:
     testing: test-pool
@@ -12455,7 +12455,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: bookinfo-build
   node_selector:
     testing: test-pool
@@ -12684,7 +12684,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: macbuildcheck
   node_selector:
     testing: test-pool
@@ -12911,7 +12911,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: windowsbuildcheck
   node_selector:
     testing: test-pool
@@ -13145,7 +13145,7 @@ jobs:
     value: "0"
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   interval: 24h
   name: update-ztunnel
   node_selector:

--- a/prow/gcp/config/jobs/release-builder-1.31.yaml
+++ b/prow/gcp/config/jobs/release-builder-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - make
@@ -13,7 +13,7 @@ jobs:
     value: "0"
   - name: VERSION
     value: "1.31"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: lint
   node_selector:
     testing: test-pool
@@ -229,7 +229,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test
   node_selector:
     testing: test-pool
@@ -445,7 +445,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: gencheck
   node_selector:
     testing: test-pool
@@ -661,7 +661,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: dry-run
   node_selector:
     testing: test-pool
@@ -880,7 +880,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: build-warning
@@ -1102,7 +1102,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   modifiers:
   - presubmit_optional
   name: publish-warning
@@ -1324,7 +1324,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: build-release
   node_selector:
     testing: test-pool
@@ -1547,7 +1547,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   max_concurrency: 1
   name: publish-release
   node_selector:
@@ -1775,7 +1775,7 @@ jobs:
     value: "0"
   - name: VERSION
     value: master
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: build-base-images
   node_selector:
     testing: test-pool

--- a/prow/gcp/config/jobs/tools-1.31.yaml
+++ b/prow/gcp/config/jobs/tools-1.31.yaml
@@ -3,7 +3,7 @@ branches:
 env:
 - name: BUILD_WITH_CONTAINER
   value: "0"
-image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
 jobs:
 - command:
   - make
@@ -11,7 +11,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: build
   node_selector:
     testing: test-pool
@@ -221,7 +221,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: lint
   node_selector:
     testing: test-pool
@@ -431,7 +431,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: test
   node_selector:
     testing: test-pool
@@ -641,7 +641,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: gencheck
   node_selector:
     testing: test-pool
@@ -862,7 +862,7 @@ jobs:
     value: arm64 amd64
   - name: AUTOMATOR_ORG
     value: istio
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: containers
   node_selector:
     testing: test-pool
@@ -1086,7 +1086,7 @@ jobs:
   - name: BUILD_WITH_CONTAINER
     value: "0"
   - name: MANIFEST_ARCH
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: containers
   node_selector:
     testing: test-pool
@@ -1303,7 +1303,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: containers-test
   node_selector:
     testing: test-pool
@@ -1521,7 +1521,7 @@ jobs:
   env:
   - name: BUILD_WITH_CONTAINER
     value: "0"
-  image: gcr.io/istio-testing/build-tools:release-1.31-9dd215042ac24a150e432b1321a23be505f281a5
+  image: gcr.io/istio-testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: containers-test
   node_selector:
     testing: test-pool


### PR DESCRIPTION
@jewertow I think an automator PR changed all these to an older build of build tools. This reverts it to the new one so jobs can run on the aws cluster. I have already applied teh changes.