### PR TITLE
Add presubmit job for pilot integ tests with nativeNftables

### DIFF
--- a/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -5356,6 +5356,91 @@ presubmits:
     - ^master$
     cluster: private
     decorate: true
+    name: integ-pilot-cni-nftables_istio_pri
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-cni-nftables
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.pilot.kube
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istio.enableCNI=true --istio.test.nativeNftables=true
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: s3://istio-build-private/proxy
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+    trigger: ((?m)^/test( | .* )integ-pilot-cni-nftables,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-cni-nftables_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: integ-pilot-filebasedkubeconfig_istio_pri
     optional: true
     path_alias: istio.io/istio

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -4449,6 +4449,69 @@ presubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-pilot-cni-nftables_istio
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-cni-nftables
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.pilot.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istio.enableCNI=true --istio.test.nativeNftables=true
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-cni-nftables,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-cni-nftables_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
     name: integ-pilot-filebasedkubeconfig_istio
     optional: true
     path_alias: istio.io/istio

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -1348,6 +1348,69 @@ presubmits:
     branches:
     - ^experimental-.*
     decorate: true
+    name: integ-pilot-cni-nftables_istio_exp
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test integ-pilot-cni-nftables
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - test.integration.pilot.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.istio.enableCNI=true --istio.test.nativeNftables=true
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )integ-pilot-cni-nftables,?($|\s.*))|((?m)^/test( |
+      .* )integ-pilot-cni-nftables_istio,?($|\s.*))
+  - always_run: true
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^experimental-.*
+    decorate: true
     name: integ-pilot-filebasedkubeconfig_istio_exp
     optional: true
     path_alias: istio.io/istio

--- a/prow/gcp/config/jobs/istio.yaml
+++ b/prow/gcp/config/jobs/istio.yaml
@@ -139,6 +139,15 @@ jobs:
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
     requirements: [kind]
 
+  - name: integ-pilot-cni-nftables
+    types: [presubmit]
+    modifiers: [presubmit_optional]
+    command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]
+    requirements: [kind]
+    env:
+      - name: INTEGRATION_TEST_FLAGS
+        value: "--istio.test.istio.enableCNI=true --istio.test.nativeNftables=true"
+
   - name: integ-pilot-cpp
     types: [postsubmit]
     command: [entrypoint, prow/integ-suite-kind.sh, test.integration.pilot.kube]


### PR DESCRIPTION
This PR adds a new optional presubmit job to validate all Istio pilot integration tests with the nativeNftables backend and CNI enabled. The existing pilot integration tests mainly validate the default iptables backend, leaving a significant gap in coverage for the nftables backend.

This complements the existing integ-pilot job, which uses the default iptables backend, and helps catch regressions in the nftables traffic redirection path early in the development cycle.

The job is marked as presubmit_optional to give it soak time before promoting it to a required check.

Corresponding PR in the Istio repo: https://github.com/istio/istio/pull/61216