### PR TITLE
Temporary introduce ambient multicluster integration test suite with mixed network setup

### DIFF
--- a/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -343,6 +343,92 @@ postsubmits:
     - ^master$
     cluster: private
     decorate: true
+    name: integ-ambient-mc-mixed-network_istio_postsubmit_pri
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - --topology
+        - AMBIENT_MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/ambient-multicluster-large.json
+        - test.integration.ambient.kube
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.multinetwork
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: s3://istio-build-private/proxy
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+  - annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
     name: integ-ambient-mc_istio_postsubmit_pri
     path_alias: istio.io/istio
     spec:
@@ -4324,6 +4410,97 @@ presubmits:
             path: .netrc
           secretName: netrc-secret
     trigger: ((?m)^/test( | .* )integ-ambient-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ambient-ipv6_istio,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    branches:
+    - ^master$
+    cluster: private
+    decorate: true
+    name: integ-ambient-mc-mixed-network_istio_pri
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test integ-ambient-mc-mixed-network
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - --topology
+        - AMBIENT_MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/ambient-multicluster-large.json
+        - test.integration.ambient.kube
+        env:
+        - name: BAZEL_BUILD_RBE_INSTANCE
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.multinetwork
+        - name: DEPENDENCIES
+          valueFrom:
+            configMapKeyRef:
+              key: dependencies
+              name: master-istio-deps
+        - name: ISTIO_ENVOY_BASE_URL
+          value: s3://istio-build-private/proxy
+        - name: GCP_SECRETS
+          value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+        - mountPath: /home/.netrc
+          name: netrc
+          readOnly: true
+          subPath: .netrc
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+      - name: netrc
+        secret:
+          items:
+          - key: secret
+            mode: 384
+            path: .netrc
+          secretName: netrc-secret
+    trigger: ((?m)^/test( | .* )integ-ambient-mc-mixed-network,?($|\s.*))|((?m)^/test(
+      | .* )integ-ambient-mc-mixed-network_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-create-test-group: "false"

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -683,6 +683,72 @@ postsubmits:
     branches:
     - ^master$
     decorate: true
+    name: integ-ambient-mc-mixed-network_istio_postsubmit
+    path_alias: istio.io/istio
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - --topology
+        - AMBIENT_MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/ambient-multicluster-large.json
+        - test.integration.ambient.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.multinetwork
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+  - annotations:
+      testgrid-alert-email: istio-oncall@googlegroups.com
+      testgrid-dashboards: istio_istio_postsubmit
+      testgrid-num-failures-to-alert: "1"
+    branches:
+    - ^master$
+    decorate: true
     name: integ-ambient-mc_istio_postsubmit
     path_alias: istio.io/istio
     spec:
@@ -3681,6 +3747,75 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ambient-ipv6_istio,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^master$
+    decorate: true
+    name: integ-ambient-mc-mixed-network_istio
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test integ-ambient-mc-mixed-network
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - --topology
+        - AMBIENT_MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/ambient-multicluster-large.json
+        - test.integration.ambient.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.multinetwork
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ambient-mc-mixed-network,?($|\s.*))|((?m)^/test(
+      | .* )integ-ambient-mc-mixed-network_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -580,6 +580,75 @@ presubmits:
       - emptyDir: {}
         name: docker-root
     trigger: ((?m)^/test( | .* )integ-ambient-ipv6,?($|\s.*))|((?m)^/test( | .* )integ-ambient-ipv6_istio,?($|\s.*))
+  - always_run: false
+    annotations:
+      testgrid-dashboards: istio_istio
+    branches:
+    - ^experimental-.*
+    decorate: true
+    name: integ-ambient-mc-mixed-network_istio_exp
+    optional: true
+    path_alias: istio.io/istio
+    rerun_command: /test integ-ambient-mc-mixed-network
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - entrypoint
+        - prow/integ-suite-kind.sh
+        - --kind-config
+        - prow/config/ambient-sc.yaml
+        - --topology
+        - AMBIENT_MULTICLUSTER
+        - --topology-config
+        - prow/config/topology/ambient-multicluster-large.json
+        - test.integration.ambient.kube
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: INTEGRATION_TEST_FLAGS
+          value: --istio.test.ambient --istio.test.ambient.multinetwork
+        - name: GOMAXPROCS
+          value: "5"
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 24Gi
+          requests:
+            cpu: "5"
+            memory: 3Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /home/prow/go/pkg
+          name: build-cache
+          subPath: gomod
+        - mountPath: /gocache
+          name: build-cache
+          subPath: gocache
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /var/lib/docker
+          name: docker-root
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        testing: test-pool
+      volumes:
+      - hostPath:
+          path: /var/tmp/prow/cache
+          type: DirectoryOrCreate
+        name: build-cache
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - emptyDir: {}
+        name: docker-root
+    trigger: ((?m)^/test( | .* )integ-ambient-mc-mixed-network,?($|\s.*))|((?m)^/test(
+      | .* )integ-ambient-mc-mixed-network_istio,?($|\s.*))
   - always_run: true
     annotations:
       testgrid-dashboards: istio_istio

--- a/prow/gcp/config/jobs/istio.yaml
+++ b/prow/gcp/config/jobs/istio.yaml
@@ -313,6 +313,28 @@ jobs:
     - --topology-config
     - prow/config/topology/ambient-multicluster.json
     - test.integration.ambient.kube
+    
+  # TODO(#61067): once we can confirm that these tests aren't flakier than regular
+  # ambient-mc test suite, we can merge the two suites into one.
+  - name: integ-ambient-mc-mixed-network
+    # NOTE: to check flakiness of the suite it's enough to run it in postsubmit only;
+    # we can aggregate and analyze the results of the postsubmit runs without
+    # bothering anybody with failed presubmit runs.
+    modifiers: [presubmit_optional, presubmit_skipped]
+    requirements: [kind]
+    env:
+    - name: INTEGRATION_TEST_FLAGS
+      value: --istio.test.ambient --istio.test.ambient.multinetwork
+    command:
+    - entrypoint
+    - prow/integ-suite-kind.sh
+    - --kind-config
+    - prow/config/ambient-sc.yaml
+    - --topology
+    - AMBIENT_MULTICLUSTER
+    - --topology-config
+    - prow/config/topology/ambient-multicluster-large.json
+    - test.integration.ambient.kube
 
   - name: integ-ambient-dual
     requirements: [kind]


### PR DESCRIPTION
The mixed network setup includes 3 clusters, two on network-1 and one on network-2. In this setup we will be able to test both single- and multi- network dataplane paths.

Eventually, I want to have just a single test suite that covers boths, but the immediate goal is to just confirm that adding single-network multicluster to the mix does not make tests significantly flakier. For that reason I only configure that test suite to run in postsubmit.

Once this test suite is stable enough, I will just delete it and change the topology configuration used by the integ-ambient-mc suite.

Part of #61067.
Related to #61066.