### PR TITLE
Pin build and publish release jobs to non-spot e2 node pool

### DIFF
--- a/prow/gcp/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.31.gen.yaml
@@ -60,6 +60,7 @@ postsubmits:
           readOnly: true
           subPath: .netrc
       nodeSelector:
+        cloud.google.com/gke-nodepool: istio-test-pool-e2
         kubernetes.io/arch: amd64
         testing: test-pool
       serviceAccountName: prowjob-private

--- a/prow/gcp/cluster/jobs/istio/release-builder/istio.release-builder.release-1.31.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/release-builder/istio.release-builder.release-1.31.gen.yaml
@@ -97,6 +97,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-nodepool: istio-test-pool-e2
         kubernetes.io/arch: amd64
         testing: test-pool
       serviceAccountName: prowjob-release
@@ -287,6 +288,7 @@ postsubmits:
         - mountPath: /var/lib/docker
           name: docker-root
       nodeSelector:
+        cloud.google.com/gke-nodepool: istio-test-pool-e2
         kubernetes.io/arch: amd64
         testing: test-pool
       serviceAccountName: prowjob-release

--- a/prow/gcp/config/jobs/release-builder-1.31.yaml
+++ b/prow/gcp/config/jobs/release-builder-1.31.yaml
@@ -1328,6 +1328,7 @@ jobs:
   name: build-release
   node_selector:
     testing: test-pool
+    cloud.google.com/gke-nodepool: istio-test-pool-e2
   regex: ^release/trigger-build$
   requirement_presets:
     build-base:
@@ -1552,6 +1553,7 @@ jobs:
   name: publish-release
   node_selector:
     testing: test-pool
+    cloud.google.com/gke-nodepool: istio-test-pool-e2
   regex: ^release/trigger-publish$
   requirement_presets:
     build-base:

--- a/prow/gcp/config/jobs_test.go
+++ b/prow/gcp/config/jobs_test.go
@@ -216,6 +216,11 @@ func TestJobs(t *testing.T) {
 				})
 			}
 		}
+		validSelectors = append(validSelectors, map[string]string{
+			"kubernetes.io/arch":              "amd64",
+			"testing":                         "test-pool",
+			"cloud.google.com/gke-nodepool":   "istio-test-pool-e2",
+		})
 		ns := j.Base.Spec.NodeSelector
 		for _, s := range validSelectors {
 			if maps.Equal(s, ns) {

--- a/prow/gcp/config/jobs_test.go
+++ b/prow/gcp/config/jobs_test.go
@@ -217,9 +217,9 @@ func TestJobs(t *testing.T) {
 			}
 		}
 		validSelectors = append(validSelectors, map[string]string{
-			"kubernetes.io/arch":              "amd64",
-			"testing":                         "test-pool",
-			"cloud.google.com/gke-nodepool":   "istio-test-pool-e2",
+			"kubernetes.io/arch":            "amd64",
+			"testing":                       "test-pool",
+			"cloud.google.com/gke-nodepool": "istio-test-pool-e2",
 		})
 		ns := j.Base.Spec.NodeSelector
 		for _, s := range validSelectors {


### PR DESCRIPTION
The build-release and publish-release postsubmit jobs for release-builder on release-1.31 were susceptible to GCP spot instance preemption. Multiple node pools carry the `testing: test-pool` label, and most of them (c3, n4, c4d) use spot instances. When a job landed on a spot node, GCP could reclaim the VM at any time, sending SIGTERM to the pod - observed during a publish-release run that was terminated after only ~28 minutes while cosign-signing images.

Pin both jobs to the `istio-test-pool-e2` node pool, which is the only pool with `testing: test-pool` that does not use spot instances, by adding `cloud.google.com/gke-nodepool: istio-test-pool-e2` to their node selectors.