### PR TITLE
Revert "Automator: update build-tools:master"

### DIFF
--- a/prow/aws/cluster/cloudflare_rotator_cronjob.yaml
+++ b/prow/aws/cluster/cloudflare_rotator_cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             kubernetes.io/arch: amd64
           containers:
             - name: rotator
-              image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+              image: gcr.io/istio-testing/build-tools:master-1aae82591b3f663bba15d501ae7ce9c2d329aa70
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/rotate.sh"]
               env:

--- a/prow/aws/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/api/istio-private.api.master.gen.yaml
@@ -23,7 +23,7 @@ postsubmits:
           value: "3"
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -68,7 +68,7 @@ postsubmits:
           value: "3"
         - name: ISTIO_ENVOY_BASE_URL
           value: https://storage.googleapis.com/istio-build-private/proxy
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ presubmits:
           value: istio-build-private/dev
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -165,7 +165,7 @@ presubmits:
           value: istio-build-private/dev
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/istio.io/istio-private.istio.io.master.gen.yaml
@@ -27,7 +27,7 @@ postsubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv4,IPv6
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -87,7 +87,7 @@ postsubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv6
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -145,7 +145,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -201,7 +201,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -257,7 +257,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -313,7 +313,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -369,7 +369,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -427,7 +427,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -481,7 +481,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -524,7 +524,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -577,7 +577,7 @@ presubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv4,IPv6
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -640,7 +640,7 @@ presubmits:
           value: "8"
         - name: IP_FAMILIES
           value: IPv6
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -702,7 +702,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -762,7 +762,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -822,7 +822,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -882,7 +882,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -942,7 +942,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1004,7 +1004,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1062,7 +1062,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1108,7 +1108,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/proxy/istio-private.proxy.master.gen.yaml
@@ -29,7 +29,7 @@ postsubmits:
           value: "0"
         - name: GCS_BUILD_BUCKET
           value: istio-build-private
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -96,7 +96,7 @@ postsubmits:
           value: istio-build-private
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -164,7 +164,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -227,7 +227,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -288,7 +288,7 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -351,7 +351,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -412,7 +412,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/api/istio.api.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/api/istio.api.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -124,7 +124,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -170,7 +170,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -214,7 +214,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -263,7 +263,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/bots/istio.bots.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -69,7 +69,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -110,7 +110,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -153,7 +153,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -196,7 +196,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -241,7 +241,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -285,7 +285,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -329,7 +329,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -373,7 +373,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/client-go/istio.client-go.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -64,7 +64,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -107,7 +107,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -169,7 +169,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -259,7 +259,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -303,7 +303,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/common-files/istio.common-files.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -85,7 +85,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -268,7 +268,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -314,7 +314,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/community/istio.community.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/community/istio.community.master.gen.yaml
@@ -20,7 +20,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -67,7 +67,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -109,7 +109,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -153,7 +153,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -197,7 +197,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/enhancements/istio.enhancements.master.gen.yaml
@@ -32,7 +32,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/istio.io/istio.istio.io.master.gen.yaml
@@ -37,7 +37,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "8"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -99,7 +99,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "8"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -151,7 +151,7 @@ postsubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -211,7 +211,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -269,7 +269,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -325,7 +325,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -381,7 +381,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -437,7 +437,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -493,7 +493,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -551,7 +551,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -605,7 +605,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -648,7 +648,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -699,7 +699,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -760,7 +760,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -820,7 +820,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -878,7 +878,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -936,7 +936,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -994,7 +994,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1052,7 +1052,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1112,7 +1112,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1168,7 +1168,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1212,7 +1212,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1268,7 +1268,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/proxy/istio.proxy.master.gen.yaml
@@ -39,7 +39,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "64"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -103,7 +103,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "64"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -158,7 +158,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -215,7 +215,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -282,7 +282,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -334,7 +334,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -385,7 +385,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -434,7 +434,7 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -485,7 +485,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -534,7 +534,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/proxy/istio.proxyexperimental.gen.yaml
@@ -30,7 +30,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -87,7 +87,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -143,7 +143,7 @@ presubmits:
           value: "1"
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -194,7 +194,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -243,7 +243,7 @@ presubmits:
         - name: BAZEL_BUILD_RBE_INSTANCE
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           requests:
@@ -294,7 +294,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -343,7 +343,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "64"
-        image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/test-infra/istio.test-infra.master.gen.yaml
@@ -40,7 +40,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "3"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -104,7 +104,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "3"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -150,7 +150,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -193,7 +193,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -242,7 +242,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -289,7 +289,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -336,7 +336,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -377,7 +377,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -422,7 +422,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -466,7 +466,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -510,7 +510,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
+++ b/prow/aws/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml
@@ -67,7 +67,7 @@ postsubmits:
         - deploy-gcsweb
         - deploy-build
         - deploy-private
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         resources:
           limits:
             cpu: "3"

--- a/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/ztunnel/istio.ztunnel.master.gen.yaml
@@ -37,7 +37,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -101,7 +101,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -171,7 +171,7 @@ postsubmits:
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -237,7 +237,7 @@ postsubmits:
           value: /var/run/rustc-cache
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -304,7 +304,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -370,7 +370,7 @@ presubmits:
           value: /var/run/rustc-cache
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/aws/config/jobs/api.yaml
+++ b/prow/aws/config/jobs/api.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: api
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: build

--- a/prow/aws/config/jobs/bots.yaml
+++ b/prow/aws/config/jobs/bots.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: bots
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: build

--- a/prow/aws/config/jobs/client-go.yaml
+++ b/prow/aws/config/jobs/client-go.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: client-go
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: build

--- a/prow/aws/config/jobs/common-files.yaml
+++ b/prow/aws/config/jobs/common-files.yaml
@@ -1,7 +1,7 @@
 org: istio
 support_release_branching: true
 repo: common-files
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: lint

--- a/prow/aws/config/jobs/community.yaml
+++ b/prow/aws/config/jobs/community.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: community
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: lint

--- a/prow/aws/config/jobs/enhancements.yaml
+++ b/prow/aws/config/jobs/enhancements.yaml
@@ -2,7 +2,7 @@ org: istio
 repo: enhancements
 branches: [master]
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 jobs:
 - name: validate-features
   types: [presubmit]

--- a/prow/aws/config/jobs/istio.io.yaml
+++ b/prow/aws/config/jobs/istio.io.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio.io
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: lint

--- a/prow/aws/config/jobs/proxy.yaml
+++ b/prow/aws/config/jobs/proxy.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: proxy
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools-proxy:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools-proxy:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 node_selector:
   testing: build-pool
 
@@ -124,7 +124,7 @@ jobs:
   - --cmd=bin/update_proxy.sh $AUTOMATOR_SHA
   requirements: [github-istio-testing]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+  image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
   env:
     - name: AUTOMATOR_ORG
       value: istio
@@ -145,7 +145,7 @@ jobs:
   - --cmd=UPDATE_BRANCH=main scripts/update_envoy.sh
   requirements: [github-istio-testing]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+  image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
   env:
     - name: AUTOMATOR_ORG
       value: istio
@@ -167,7 +167,7 @@ jobs:
   disable_release_branching: true
   requirements: [github-istio-testing]
   repos: [istio/test-infra@master]
-  image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+  image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
   env:
     - name: AUTOMATOR_ORG
       value: istio

--- a/prow/aws/config/jobs/test-infra.yaml
+++ b/prow/aws/config/jobs/test-infra.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: test-infra
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: lint

--- a/prow/aws/config/jobs/ztunnel.yaml
+++ b/prow/aws/config/jobs/ztunnel.yaml
@@ -1,6 +1,6 @@
 org: istio
 repo: ztunnel
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 support_release_branching: true
 
 jobs:

--- a/prow/gcp/cluster/cloudflare_rotator_cronjob.yaml
+++ b/prow/gcp/cluster/cloudflare_rotator_cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             kubernetes.io/arch: amd64
           containers:
             - name: rotator
-              image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+              image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/rotate.sh"]
               env:

--- a/prow/gcp/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-ecosystem/sail-operator/istio-ecosystem.sail-operator.main.gen.yaml
@@ -22,7 +22,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -86,7 +86,7 @@ presubmits:
           value: dual
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -146,7 +146,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -207,7 +207,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -265,7 +265,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -322,7 +322,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -370,7 +370,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -419,7 +419,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -468,7 +468,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -517,7 +517,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -576,7 +576,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -627,7 +627,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -33,7 +33,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -117,7 +117,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -203,7 +203,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -289,7 +289,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -375,7 +375,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -461,7 +461,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -543,7 +543,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -626,7 +626,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -708,7 +708,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -790,7 +790,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -868,7 +868,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -957,7 +957,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1037,7 +1037,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1119,7 +1119,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1201,7 +1201,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1279,7 +1279,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1361,7 +1361,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1447,7 +1447,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1531,7 +1531,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1615,7 +1615,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1699,7 +1699,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1785,7 +1785,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1871,7 +1871,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1957,7 +1957,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2043,7 +2043,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2129,7 +2129,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2215,7 +2215,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2301,7 +2301,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2387,7 +2387,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2473,7 +2473,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2553,7 +2553,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2635,7 +2635,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2719,7 +2719,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2803,7 +2803,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2883,7 +2883,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2961,7 +2961,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3045,7 +3045,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3125,7 +3125,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3203,7 +3203,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3283,7 +3283,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3367,7 +3367,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3447,7 +3447,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3525,7 +3525,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3606,7 +3606,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3679,7 +3679,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3752,7 +3752,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3821,7 +3821,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3887,7 +3887,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: master-istio-deps
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3964,7 +3964,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4041,7 +4041,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: master-istio-deps
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4107,7 +4107,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: master-istio-deps
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4180,7 +4180,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4268,7 +4268,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4358,7 +4358,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4447,7 +4447,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4537,7 +4537,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4627,7 +4627,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4713,7 +4713,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4801,7 +4801,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4887,7 +4887,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4973,7 +4973,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5054,7 +5054,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5142,7 +5142,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5225,7 +5225,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5310,7 +5310,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5396,7 +5396,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5478,7 +5478,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5563,7 +5563,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5647,7 +5647,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5734,7 +5734,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5822,7 +5822,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5910,7 +5910,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5994,7 +5994,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6076,7 +6076,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6163,7 +6163,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6247,7 +6247,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6329,7 +6329,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6412,7 +6412,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6500,7 +6500,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6584,7 +6584,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6665,7 +6665,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6739,7 +6739,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: master-istio-deps
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6805,7 +6805,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: master-istio-deps
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6872,7 +6872,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -6947,7 +6947,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -7023,7 +7023,7 @@ presubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -7089,7 +7089,7 @@ presubmits:
             configMapKeyRef:
               key: dependencies
               name: master-istio-deps
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/release-builder/istio-private.release-builder.master.gen.yaml
@@ -39,7 +39,7 @@ postsubmits:
           value: s3://istio-build-private/proxy
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prerelease-private_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"},{"secret":"cf_r2_istio-build-private_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -97,7 +97,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -151,7 +151,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -205,7 +205,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -273,7 +273,7 @@ presubmits:
           value: istio-prerelease-private/prerelease
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prerelease-private_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -319,7 +319,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -376,7 +376,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -433,7 +433,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -23,7 +23,7 @@ periodics:
         value: "0"
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -73,7 +73,7 @@ periodics:
         value: "0"
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -148,7 +148,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -214,7 +214,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -279,7 +279,7 @@ periodics:
         value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "5"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -330,7 +330,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prow_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -389,7 +389,7 @@ postsubmits:
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -443,7 +443,7 @@ postsubmits:
           value: --istio.test.agentgateway
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -507,7 +507,7 @@ postsubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -573,7 +573,7 @@ postsubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -639,7 +639,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -705,7 +705,7 @@ postsubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -771,7 +771,7 @@ postsubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -833,7 +833,7 @@ postsubmits:
           value: '--istio.test.ambient --istio.test.nativeNftables '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -896,7 +896,7 @@ postsubmits:
             --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -958,7 +958,7 @@ postsubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1020,7 +1020,7 @@ postsubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1079,7 +1079,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1148,7 +1148,7 @@ postsubmits:
           value: -flaky
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1208,7 +1208,7 @@ postsubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1270,7 +1270,7 @@ postsubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1332,7 +1332,7 @@ postsubmits:
           value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1390,7 +1390,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1452,7 +1452,7 @@ postsubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1518,7 +1518,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1582,7 +1582,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1646,7 +1646,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1710,7 +1710,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1776,7 +1776,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1842,7 +1842,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1908,7 +1908,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1974,7 +1974,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2040,7 +2040,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2106,7 +2106,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2172,7 +2172,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2238,7 +2238,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2304,7 +2304,7 @@ postsubmits:
           value: ' --istio.test.retries=1 '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2364,7 +2364,7 @@ postsubmits:
           value: grpctesting/istio_echo_cpp
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2426,7 +2426,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2490,7 +2490,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2554,7 +2554,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2614,7 +2614,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2672,7 +2672,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2736,7 +2736,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2796,7 +2796,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2854,7 +2854,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2914,7 +2914,7 @@ postsubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2978,7 +2978,7 @@ postsubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3038,7 +3038,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3096,7 +3096,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3153,7 +3153,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3207,7 +3207,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3260,7 +3260,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3307,7 +3307,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3355,7 +3355,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3416,7 +3416,7 @@ presubmits:
           value: "true"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3475,7 +3475,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3523,7 +3523,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3574,7 +3574,7 @@ presubmits:
           value: --istio.test.agentgateway
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3640,7 +3640,7 @@ presubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3708,7 +3708,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3775,7 +3775,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3843,7 +3843,7 @@ presubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3911,7 +3911,7 @@ presubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -3975,7 +3975,7 @@ presubmits:
           value: '--istio.test.ambient --istio.test.nativeNftables '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4041,7 +4041,7 @@ presubmits:
             --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4105,7 +4105,7 @@ presubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4169,7 +4169,7 @@ presubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4229,7 +4229,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4295,7 +4295,7 @@ presubmits:
           value: ' --istio.test.istio.enableCNI=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4356,7 +4356,7 @@ presubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4419,7 +4419,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4483,7 +4483,7 @@ presubmits:
           value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4543,7 +4543,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4606,7 +4606,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4668,7 +4668,7 @@ presubmits:
           value: --istio.test.istio.enableCNI=true --istio.test.nativeNftables=true
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4733,7 +4733,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4799,7 +4799,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4865,7 +4865,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4927,7 +4927,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -4987,7 +4987,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5052,7 +5052,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5114,7 +5114,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5174,7 +5174,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5235,7 +5235,7 @@ presubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5301,7 +5301,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5363,7 +5363,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5422,7 +5422,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5478,7 +5478,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5526,7 +5526,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5577,7 +5577,7 @@ presubmits:
           value: '[{"secret":"github-read_github_read","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5623,7 +5623,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5677,7 +5677,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5731,7 +5731,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -5779,7 +5779,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -22,7 +22,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-build_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -74,7 +74,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -122,7 +122,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -183,7 +183,7 @@ presubmits:
           value: "true"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -242,7 +242,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -290,7 +290,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -341,7 +341,7 @@ presubmits:
           value: --istio.test.agentgateway
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -407,7 +407,7 @@ presubmits:
           value: calico
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -475,7 +475,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -542,7 +542,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -610,7 +610,7 @@ presubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -678,7 +678,7 @@ presubmits:
           value: --istio.test.ambient --istio.test.ambient.multinetwork
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -742,7 +742,7 @@ presubmits:
           value: '--istio.test.ambient --istio.test.nativeNftables '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -808,7 +808,7 @@ presubmits:
             --istio.test.ambient '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -872,7 +872,7 @@ presubmits:
           value: --istio.test.ambient
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -936,7 +936,7 @@ presubmits:
           value: ' --istio.test.istio.operatorOptions=values.pilot.env.UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -996,7 +996,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1062,7 +1062,7 @@ presubmits:
           value: ' --istio.test.istio.enableCNI=true '
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1123,7 +1123,7 @@ presubmits:
           value: distroless
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1186,7 +1186,7 @@ presubmits:
           value: IPv4,IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1250,7 +1250,7 @@ presubmits:
           value: -run="TestGatewayConformance|TestGateway$$|TestHTTPRouteAndGRPCRouteCoexistence|TestInferencePoolMultipleTargetPorts|TestPilotResourceFilter"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1310,7 +1310,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1373,7 +1373,7 @@ presubmits:
           value: IPv6
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1435,7 +1435,7 @@ presubmits:
           value: --istio.test.istio.enableCNI=true --istio.test.nativeNftables=true
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1500,7 +1500,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1566,7 +1566,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1632,7 +1632,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1694,7 +1694,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1754,7 +1754,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1819,7 +1819,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1881,7 +1881,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -1941,7 +1941,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2002,7 +2002,7 @@ presubmits:
           value: --istio.test.peer_metadata_discovery
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2068,7 +2068,7 @@ presubmits:
           value: --istio.test.skipVM
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2130,7 +2130,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2189,7 +2189,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2245,7 +2245,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2293,7 +2293,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2338,7 +2338,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2392,7 +2392,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2446,7 +2446,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -2494,7 +2494,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "5"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/release-builder/istio.release-builder.master.gen.yaml
@@ -29,7 +29,7 @@ periodics:
         value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
       - name: GOMAXPROCS
         value: "8"
-      image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+      image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
       name: ""
       resources:
         limits:
@@ -80,7 +80,7 @@ postsubmits:
           value: "0"
         - name: GCP_SECRETS
           value: '[{"secret":"cf_r2_istio-prerelease_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -126,7 +126,7 @@ postsubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -172,7 +172,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -215,7 +215,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -268,7 +268,7 @@ postsubmits:
           value: /var/run/ci/github/token
         - name: GCP_SECRETS
           value: '[{"secret":"release_docker_istio","project":"istio-prow-build","file":"/var/run/ci/docker/config.json"},{"secret":"release_github_istio-release","project":"istio-prow-build","file":"/var/run/ci/github/token"},{"secret":"release_grafana_istio","project":"istio-prow-build","file":"/var/run/ci/grafana/token"},{"secret":"cf_r2_istio-prerelease_credentials","project":"istio-testing","env":"CF_PRERELEASE_CREDENTIALS"},{"secret":"cf_r2_istio-release_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -315,7 +315,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -364,7 +364,7 @@ presubmits:
           value: '[{"secret":"cf_r2_public_buckets_ro_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -407,7 +407,7 @@ presubmits:
         env:
         - name: BUILD_WITH_CONTAINER
           value: "0"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -454,7 +454,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -498,7 +498,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -546,7 +546,7 @@ presubmits:
           value: '[{"secret":"cf_r2_public_buckets_ro_credentials","project":"istio-testing","env":"CF_CREDENTIALS"}]'
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -590,7 +590,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/tools/istio.tools.master.gen.yaml
@@ -21,7 +21,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -68,7 +68,7 @@ postsubmits:
         - name: MANIFEST_ARCH
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -144,7 +144,7 @@ postsubmits:
           value: '[{"secret":"github_istio-testing_pusher","project":"istio-prow-build","env":"GH_TOKEN"}]'
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -192,7 +192,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -235,7 +235,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -278,7 +278,7 @@ postsubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -323,7 +323,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -370,7 +370,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -426,7 +426,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "8"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -474,7 +474,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -518,7 +518,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:
@@ -562,7 +562,7 @@ presubmits:
           value: "0"
         - name: GOMAXPROCS
           value: "3"
-        image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+        image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
         name: ""
         resources:
           limits:

--- a/prow/gcp/config/jobs/istio.yaml
+++ b/prow/gcp/config/jobs/istio.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: istio
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 jobs:
   - name: unit-tests
     architectures: [amd64, arm64]

--- a/prow/gcp/config/jobs/release-builder.yaml
+++ b/prow/gcp/config/jobs/release-builder.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: release-builder
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: lint

--- a/prow/gcp/config/jobs/sail-operator.yaml
+++ b/prow/gcp/config/jobs/sail-operator.yaml
@@ -4,7 +4,7 @@ branches:
   - main
 
 support_release_branching: false
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 jobs:
   - name: unit-tests
     types: [presubmit]

--- a/prow/gcp/config/jobs/tools.yaml
+++ b/prow/gcp/config/jobs/tools.yaml
@@ -1,7 +1,7 @@
 org: istio
 repo: tools
 support_release_branching: true
-image: gcr.io/istio-testing/build-tools:master-10be95ae4c9f6fb218f4c0eef2ef76ab9c7d35bd
+image: gcr.io/istio-testing/build-tools:master-9a67f0594faf23c0974ab3db461b03f50f39ae33
 
 jobs:
   - name: build


### PR DESCRIPTION
Reverts istio/test-infra#6013 to unblock all the CI issues we are getting because the golangci-lint version is incompatible with 1.27.0 Go version