### PR TITLE
Change ambient mix-network multicluster kind config to default

### DIFF
--- a/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -352,7 +352,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --kind-config
-        - prow/config/ambient-sc.yaml
+        - prow/config/default.yaml
         - --topology
         - AMBIENT_MULTICLUSTER
         - --topology-config
@@ -4514,7 +4514,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --kind-config
-        - prow/config/ambient-sc.yaml
+        - prow/config/default.yaml
         - --topology
         - AMBIENT_MULTICLUSTER
         - --topology-config

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -692,7 +692,7 @@ postsubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --kind-config
-        - prow/config/ambient-sc.yaml
+        - prow/config/default.yaml
         - --topology
         - AMBIENT_MULTICLUSTER
         - --topology-config
@@ -3830,7 +3830,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --kind-config
-        - prow/config/ambient-sc.yaml
+        - prow/config/default.yaml
         - --topology
         - AMBIENT_MULTICLUSTER
         - --topology-config

--- a/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/gcp/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -597,7 +597,7 @@ presubmits:
         - entrypoint
         - prow/integ-suite-kind.sh
         - --kind-config
-        - prow/config/ambient-sc.yaml
+        - prow/config/default.yaml
         - --topology
         - AMBIENT_MULTICLUSTER
         - --topology-config

--- a/prow/gcp/config/jobs/istio.yaml
+++ b/prow/gcp/config/jobs/istio.yaml
@@ -338,7 +338,7 @@ jobs:
     - entrypoint
     - prow/integ-suite-kind.sh
     - --kind-config
-    - prow/config/ambient-sc.yaml
+    - prow/config/default.yaml
     - --topology
     - AMBIENT_MULTICLUSTER
     - --topology-config


### PR DESCRIPTION
I introduced this test initiall with ambient-sc config (and I suspect that sc actually stands for single cluster now) because ambient muilti-cluster tests before used it.

That however creates an issue, because ambient-sc kind config creates clusters with multiple nodes. In single-network environment, we assume that pods within the same network are directly reachable.

The way cluster provisioniner achieves it is it configures iptables to provide direct connectivity between kind nodes. The issue however is that it only does that for controlplane nodes. All other nodes are not directly reachable.

As a result, mix-network tests have been failing when two pods not running on the controlplane node from the same network tried to communicate with each other because there is no direct network connectivity between them.

Part of #61067.
Related to #61066.