### PR TITLE
Correct HELM_HUB to fix ztunnel OCI tag collision

### DIFF
--- a/prow/aws/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/istio/istio-private.istio.master.gen.yaml
@@ -3600,7 +3600,7 @@ postsubmits:
         - name: GCS_BUCKET
           value: istio-build-private/dev
         - name: HELM_HUB
-          value: ghcr.io/istio/testing
+          value: ghcr.io/istio/testing/charts
         - name: R2_BUCKET
           value: istio-build-private/dev
         - name: DEPENDENCIES

--- a/prow/aws/cluster/jobs/istio-private/istio/istio-private.istio.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio-private/istio/istio-private.istio.release-1.31.gen.yaml
@@ -3262,7 +3262,7 @@ postsubmits:
         - name: GCS_BUCKET
           value: istio-build-private/dev
         - name: HELM_HUB
-          value: ghcr.io/istio/testing
+          value: ghcr.io/istio/testing/charts
         - name: R2_BUCKET
           value: istio-build-private/dev
         - name: DEPENDENCIES

--- a/prow/aws/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/istio/istio.istio.master.gen.yaml
@@ -3153,7 +3153,7 @@ postsubmits:
         - name: DOCKER_PUSH_HUB
           value: ghcr.io/istio/testing
         - name: HELM_HUB
-          value: ghcr.io/istio/testing
+          value: ghcr.io/istio/testing/charts
         - name: DOCKER_CONFIG
           value: /var/run/ci/docker
         - name: GCP_SECRETS

--- a/prow/aws/cluster/jobs/istio/istio/istio.istio.release-1.31.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/istio/istio.istio.release-1.31.gen.yaml
@@ -2764,7 +2764,7 @@ postsubmits:
         - name: DOCKER_PUSH_HUB
           value: ghcr.io/istio/testing
         - name: HELM_HUB
-          value: ghcr.io/istio/testing
+          value: ghcr.io/istio/testing/charts
         - name: DOCKER_CONFIG
           value: /var/run/ci/docker
         - name: GCP_SECRETS

--- a/prow/aws/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
+++ b/prow/aws/cluster/jobs/istio/istio/istio.istioexperimental.gen.yaml
@@ -23,7 +23,7 @@ postsubmits:
         - name: DOCKER_PUSH_HUB
           value: ghcr.io/istio/testing
         - name: HELM_HUB
-          value: ghcr.io/istio/testing
+          value: ghcr.io/istio/testing/charts
         - name: DOCKER_CONFIG
           value: /var/run/ci/docker
         - name: GCP_SECRETS

--- a/prow/aws/config/jobs/istio-1.31.yaml
+++ b/prow/aws/config/jobs/istio-1.31.yaml
@@ -480,7 +480,7 @@ jobs:
   - name: DOCKER_PUSH_HUB
     value: ghcr.io/istio/testing
   - name: HELM_HUB
-    value: ghcr.io/istio/testing
+    value: ghcr.io/istio/testing/charts
   image: registry.istio.io/testing/build-tools:release-1.31-7f929a842d4a0cb482c9d18a9a369b177d51a555
   name: release
   node_selector:

--- a/prow/aws/config/jobs/istio.yaml
+++ b/prow/aws/config/jobs/istio.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: DOCKER_PUSH_HUB
         value: ghcr.io/istio/testing
       - name: HELM_HUB
-        value: ghcr.io/istio/testing
+        value: ghcr.io/istio/testing/charts
 
   - name: benchmark
     types: [presubmit]


### PR DESCRIPTION
Chart and image both push to ghcr.io/istio/testing/ztunnel:<tag>, so whichever runs last wins the tag. Point Helm chart publishing at a /charts subpath instead. Seems to have been a typo in istio/test-infra#6008.